### PR TITLE
Adding three options to simplify tab output

### DIFF
--- a/dominion_tabs.py
+++ b/dominion_tabs.py
@@ -330,7 +330,7 @@ class DominionTabs:
 
         # draw banner
         img = card.getType().getNoCoinTabImageFile()
-        if img:
+        if not self.options.no_tab_artwork and img:
             self.canvas.drawImage(os.path.join(self.filedir, 'images', img), 1, 0,
                                   self.tabLabelWidth -
                                   2, self.tabLabelHeight - 1,
@@ -792,6 +792,8 @@ class DominionTabs:
                           default=False, help="exclude individual dividers for events")
         parser.add_option("--cardlist", type="string", dest="cardlist", default=None,
                           help="Path to file that enumerates each card to be printed on its own line.")
+        parser.add_option("--no-tab-artwork", action="store_true", dest="no_tab_artwork",
+                          help="don't show background artwork on tabs")
 
         options, args = parser.parse_args(argstring)
         if not options.cost:

--- a/dominion_tabs.py
+++ b/dominion_tabs.py
@@ -443,6 +443,9 @@ class DominionTabs:
         if drewTopIcon:
             usedHeight += 15
 
+        if self.options.no_card_rules:
+            return
+        
         # draw text
         if useExtra and card.extra:
             descriptions = (card.extra,)
@@ -794,6 +797,8 @@ class DominionTabs:
                           help="Path to file that enumerates each card to be printed on its own line.")
         parser.add_option("--no-tab-artwork", action="store_true", dest="no_tab_artwork",
                           help="don't show background artwork on tabs")
+        parser.add_option("--no-card-rules", action="store_true", dest="no_card_rules",
+                          help="don't print the card's rules on the tab body")
 
         options, args = parser.parse_args(argstring)
         if not options.cost:


### PR DESCRIPTION
Three new options:

 * --no-tab-artwork: omits background banner images on tabs
 * --no-card-rules: omits card rules from divider body
 * --use-text-set-icon: uses text instead of icons to identify/represent the set.