### PR TITLE
Add some grouping and cleanup options

### DIFF
--- a/card_db/en_us/card_groups.txt
+++ b/card_db/en_us/card_groups.txt
@@ -1,0 +1,6 @@
+Tournament, Bag of Gold, Diadem, Followers, Princess, Trusty Steed, Tournament and Prizes
+Shelters, Hovel, Overgrown Estate, Necropolis, Shelters
+Page, Treasure Hunter, Warrior, Hero, Champion, Page -> Champion
+Peasant, Soldier, Fugitive, Disciple, Teacher, Peasant -> Teacher
+Hermit, Madman, Hermit / Madman
+Urchin, Mercenary, Urchin / Mercenary

--- a/card_db/en_us/cards.yaml
+++ b/card_db/en_us/cards.yaml
@@ -739,7 +739,9 @@
 
     Each player may reveal a Province from his hand. If you do, discard it and gain
     a Prize (from the Prize pile) or a Duchy, putting it on top of your deck. If no-one
-    else does, +1 Card +1 Coin.'
+    else does, +1 Card +1 Coin.
+    
+    Prizes: Bag of Gold, Diadem, Followers, Princess, Trusty Steed'
   extra: First you get +1 Action. Then each player, including you, may reveal a Province
     card from his hand. Then, if you revealed a Province, discard that card, and you
     gain a Prize of your choice, or a Duchy, putting whatever card you took on top

--- a/card_db/en_us/dominion_cards.txt
+++ b/card_db/en_us/dominion_cards.txt
@@ -259,6 +259,8 @@ When another player plays an Attack card, you may set this aside from your hand.
 11	Remake	Cornucopia	Action	$4	Do this twice: Trash a card from your hand then gain a card costing exactly 1 more than the trashed card.
 12	Tournament	Cornucopia	Action	$4	+1 Action
 Each player may reveal a Province from his hand. If you do, discard it and gain a Prize (from the Prize pile) or a Duchy, putting it on top of your deck. If no-one else does, +1 Card +1 Coin.
+
+Prizes: Bag of Gold, Diadem, Followers, Princess, Trusty Steed
 13	Young Witch	Cornucopia	Action - Attack	$4	+2 Cards
 Discard 2 cards. Each other player may reveal a Bane card from his hand.
 If he doesn’t, he gains a Curse.

--- a/dominion_tabs.py
+++ b/dominion_tabs.py
@@ -50,6 +50,9 @@ class Card:
     def isEvent(self):
         return self.getType().getTypeNames() == ('Event',)
 
+    def isPrize(self):
+        return 'Prize' in self.getType().getTypeNames()
+
     def setImage(self):
         setImage = DominionTabs.getSetImage(self.cardset, self.name)
         if setImage is None and self.cardset not in ['base', 'extra'] and not self.isExpansion():
@@ -743,7 +746,7 @@ class DominionTabs:
             # remember whether we start with odd or even divider for tab
             # location
             pageStartOdd = self.odd
-            if not self.options.tabs_only and self.options.order != "global":
+            if not self.options.no_page_footer and (not self.options.tabs_only and self.options.order != "global"):
                 self.drawSetNames(pageCards)
             for i, card in enumerate(pageCards):
                 # print card
@@ -756,10 +759,10 @@ class DominionTabs:
             self.canvas.showPage()
             if pageNum + 1 == self.options.num_pages:
                 break
-            if self.options.tabs_only:
+            if self.options.tabs_only or self.options.no_card_backs:
                 # no set names or card backs for label-only sheets
                 continue
-            if self.options.order != "global":
+            if not self.options.no_page_footer and self.options.order != "global":
                 self.drawSetNames(pageCards)
             # start at same oddness
             self.odd = pageStartOdd
@@ -849,6 +852,8 @@ class DominionTabs:
                           help="include a few dividers with extra text")
         parser.add_option("--exclude_events", action="store_true",
                           default=False, help="exclude individual dividers for events")
+        parser.add_option("--exclude_prizes", action="store_true",
+                          default=False, help="exclude individual dividers for prizes (cornicopia)")
         parser.add_option("--cardlist", type="string", dest="cardlist", default=None,
                           help="Path to file that enumerates each card to be printed on its own line.")
         parser.add_option("--no-tab-artwork", action="store_true", dest="no_tab_artwork",
@@ -857,6 +862,10 @@ class DominionTabs:
                           help="don't print the card's rules on the tab body")
         parser.add_option("--use-text-set-icon", action="store_true", dest="use_text_set_icon",
                           help="use text/letters to represent a card's set instead of the set icon")
+        parser.add_option("--no-page-footer", action="store_true", dest="no_page_footer",
+                          help="don't print the set name at the bottom of the page.")
+        parser.add_option("--no-card-backs", action="store_true", dest="no_card_backs",
+                          help="don't print the back page of the card sheets.")
 
         options, args = parser.parse_args(argstring)
         if not options.cost:
@@ -1083,6 +1092,9 @@ class DominionTabs:
 
         if self.options.exclude_events:
             cards = [card for card in cards if not card.isEvent() or card.name == 'Events']
+
+        if self.options.exclude_prizes:
+            cards = [card for card in cards if not card.isPrize()]
 
         if self.cardlist:
             cards = [card for card in cards if card.name in self.cardlist]


### PR DESCRIPTION
Hi,

I've added some options to make it work a bit better to how i want my tabs setup (all configurable)
* remove the sets text at the bottom of the page
* remove the individual tabs for prizes, shelters, travellers, etc
* remove the back page