### PR TITLE
Fix for Issue #20 - Unsleeved horizontal A4 sheets overlap with expansion name

### DIFF
--- a/dominion_tabs.py
+++ b/dominion_tabs.py
@@ -709,7 +709,7 @@ class DominionTabs:
             minFontsize = 6
             fontname = 'MinionPro-Regular'
             font = pdfmetrics.getFont(fontname)
-            fontHeightRelative = (font.face.ascent + font.face.descent) / 1000
+            fontHeightRelative = (font.face.ascent + abs(font.face.descent) ) / 1000.0
 
             canFit = False
 
@@ -744,8 +744,10 @@ class DominionTabs:
                 if setTitle not in sets:
                     sets.append(setTitle)
 
+                # Centered on page
                 xPos = layout['width'] / 2
-                yPos = layout['minMarginHeight'] + availableMargin / 2
+                # Place at the very edge of the margin
+                yPos = layout['minMarginHeight']
 
                 if layout['rotation']:
                     self.canvas.rotate(layout['rotation'])


### PR DESCRIPTION
I made the smallest number of changes to make this work.
Basically, font.face.descent has a negative value.  So in order to get the full font height, the absolute value must be used.  That corrected getting the correct font size selected.

The second fix had the footer printed vertically in the middle of the space between the last card and the margin.  But all the calcuations on font size assumed the full space could be used.  So moved the printing of the footer to the very bottom at the margin.

That said, I'm not sure the function drawSetNames is really doing everything right.  
Not sure if the other layout is ever used.  And the use of layout[] outside the "for layout in layouts:" loop is odd.  I think this whole thing could use some clean up.