### PR TITLE
Initial support for Empires

### DIFF
--- a/card_db/en_us/card_groups.json
+++ b/card_db/en_us/card_groups.json
@@ -48,5 +48,40 @@
             "Mercenary"
         ],
         "new_name": "Urchin \/ Mercenary"
+    },
+    "Catapult \/ Rocks": {
+        "subcards": [
+            "Catapult",
+            "Rocks"
+        ],
+        "new_name": "Catapult \/ Rocks"
+    },
+    "Encampment \/ Plunder": {
+        "subcards": [
+            "Encampment",
+            "Plunder"
+        ],
+        "new_name": "Encampment \/ Plunder"
+    },
+    "Gladiator \/ Fortune": {
+        "subcards": [
+            "Gladiator",
+            "Fortune"
+        ],
+        "new_name": "Gladiator \/ Fortune"
+    },
+    "Patrician \/ Emporium": {
+        "subcards": [
+            "Patrician",
+            "Emporium"
+        ],
+        "new_name": "Patrician \/ Emporium"
+    },
+    "Bustling Village \/ Settlers": {
+        "subcards": [
+            "Bustling Village",
+            "Settlers"
+        ],
+        "new_name": "Bustling Village \/ Settlers"
     }
 }

--- a/card_db/en_us/cards.json
+++ b/card_db/en_us/cards.json
@@ -3530,5 +3530,422 @@
   "types": [
    "Event"
   ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "+1 Action\nSet aside the top 3 cards of your deck face down (you may look at them). Now and at the start of your next two turns, put one into your hand.",
+  "extra": "",
+  "name": "Archive",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Duration"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "+1 Card\n+3 Actions\nLook through your discard pile. You may reveal a Settlers from it and put it into your hand.",
+  "extra": "",
+  "name": "Bustling Village",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "2",
+  "description": "+1 Card\n+1 Action\nLook through your discard pile. You may reveal a Copper from it and put it into your hand.",
+  "extra": "",
+  "name": "Settlers",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "6 Coins\n+1 Buy\n______________________\nWhen you discard this from play, take 6 Debt, and then you may pay off Debt.",
+  "extra": "",
+  "name": "Capital",
+  "potcost": 0,
+  "types":[
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "",
+  "extra": "",
+  "name": "Castles",
+  "potcost": 0,
+  "types":[
+   "Victory",
+   "Castle"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "+1 Coin\nTrash a card from your hand. If it costs 3 Coins or more, each other player gains a Curse. If it's a Treasure, each other player discards down to 3 cards in hand.",
+  "extra": "",
+  "name": "Catapult",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Attack"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "+1 Action\nReveal the top card of your deck and put it into your hand. The player to your left reveals the top card of their deck. If your card costs more, +1 Coin and +1 Victory Token.",
+  "extra": "",
+  "name": "Chariot Race",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "When you play this, choose on: +1 Buy and +2 Coin; or the next time you buy a card this turn, you may also gain a differently named card with the same cost.",
+  "extra": "",
+  "name": "Charm",
+  "potcost": 0,
+  "types":[
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "-8",
+  "description": "+2 Actions\nReveal your hand. +1 Card per Action card revealed.",
+  "extra": "",
+  "name": "City Quarter",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "If it's your Action phase, you may play an Action from your hand twice. If it's your Buy phase, you may play a Treasure from your hand twice.",
+  "extra": "",
+  "name": "Crown",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "+1 Card\n+1 Action\n+1 Coin\n______________________\nWhen you gain this, if you have at least 5 Action cards in play, +2 Victory Tokens.",
+  "extra": "",
+  "name": "Emporium",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "2",
+  "description": "+2 Cards\n+2 Actions\nYou may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.",
+  "extra": "",
+  "name": "Encampment",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "Until your next turn, the first time each other play plays an Action card on their turn, they get +1 Card and +1 Action instead of following its instructions.\n\nAt the start of your next turn, +2 Cards.",
+  "extra": "",
+  "name": "Enchantress",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Attack",
+   "Duration"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "-4",
+  "description": "Gain a card costing up to 4 Coins. You may trash this. If you do, gain a card costing up to 4 Coins.",
+  "extra": "",
+  "name": "Engineer",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "+1 Buy\nIf there are 4 Victory Tokens or more on the Farmers' Market Supply pile, take them and trash this. Otherwise, add 1 Victory Token to the pile and then +1 Coin per 1 Victory Token on the pile.",
+  "extra": "",
+  "name": "Farmers' Market",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Gathering"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "8/-8",
+  "description": "",
+  "extra": "",
+  "name": "Fortune",
+  "potcost": 0,
+  "types":[
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "",
+  "extra": "",
+  "name": "Forum",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "3",
+  "description": "",
+  "extra": "",
+  "name": "Gladiator",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "",
+  "extra": "",
+  "name": "Groundskeeper",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "",
+  "extra": "",
+  "name": "Legionary",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Attack"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "-8",
+  "description": "",
+  "extra": "",
+  "name": "Royal Blacksmith",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "-8",
+  "description": "",
+  "extra": "",
+  "name": "Overlord",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "2",
+  "description": "",
+  "extra": "",
+  "name": "Patrician",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "",
+  "extra": "",
+  "name": "Plunder",
+  "potcost": 0,
+  "types":[
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "4",
+  "description": "",
+  "extra": "",
+  "name": "Rocks",
+  "potcost": 0,
+  "types":[
+   "Treasure"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "4",
+  "description": "",
+  "extra": "",
+  "name": "Sacrifice",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "2",
+  "description": "",
+  "extra": "",
+  "name": "Settlers",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "4",
+  "description": "",
+  "extra": "",
+  "name": "Temple",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Gathering"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "4",
+  "description": "",
+  "extra": "",
+  "name": "Villa",
+  "potcost": 0,
+  "types":[
+   "Action"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "5",
+  "description": "",
+  "extra": "",
+  "name": "Wild Hunt",
+  "potcost": 0,
+  "types":[
+   "Action",
+   "Gathering"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Events",
+  "potcost": 0,
+  "types":[
+   "Event"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Landmarks",
+  "potcost": 0,
+  "types":[
+   "Landmark"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Catapult \/ Rocks",
+  "potcost": 0,
+  "types":[
+   "Blank"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Encampment \/ Plunder",
+  "potcost": 0,
+  "types":[
+   "Blank"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Gladiator \/ Fortune",
+  "potcost": 0,
+  "types":[
+   "Blank"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Patrician \/ Emporium",
+  "potcost": 0,
+  "types":[
+   "Blank"
+  ]
+ },
+ {
+  "cardset": "empires",
+  "cost": "*",
+  "description": "",
+  "extra": "",
+  "name": "Bustling Village \/ Settlers",
+  "potcost": 0,
+  "types":[
+   "Blank"
+  ]
  }
 ]

--- a/domdiv/cards.py
+++ b/domdiv/cards.py
@@ -90,10 +90,10 @@ class Card(object):
 
     @classmethod
     def getSetText(cls, setName, cardName):
-        if setName in cls.setTextIcons:
-            return cls.setTextIcons[setName]
-        if cardName.lower() in cls.promoTextIcons:
-            return cls.promoTextIcons[cardName.lower()]
+        if setName in setTextIcons:
+            return setTextIcons[setName]
+        if cardName.lower() in promoTextIcons:
+            return promoTextIcons[cardName.lower()]
         return None
 
     def __init__(self, name, cardset, types, cost, description='', potcost=0, extra=''):
@@ -133,7 +133,7 @@ class Card(object):
         return setImage
 
     def setTextIcon(self):
-        setTextIcon = getSetText(self.cardset, self.name)
+        setTextIcon = Card.getSetText(self.cardset, self.name)
         if setTextIcon is None and self.cardset not in ['base', 'extra'] and not self.isExpansion():
             print 'warning, no set text for set "%s" card "%s"' % (self.cardset, self.name)
             setTextIcons[self.cardset] = 0

--- a/domdiv/cards.py
+++ b/domdiv/cards.py
@@ -18,7 +18,8 @@ setImages = {
     'dark ages extras': 'dark_ages_set.png',
     'guilds': 'guilds_set.png',
     'adventures': 'adventures_set.png',
-    'adventures extras': 'adventures_set.png'
+    'adventures extras': 'adventures_set.png',
+    'empires': "base_set.png"
 }
 promoImages = {
     'walled village': 'walled_village_set.png',
@@ -42,7 +43,8 @@ setTextIcons = {
     'dark ages extras': 'DA',
     'guilds': 'G',
     'adventures': 'Ad',
-    'adventures extras': 'Ad'
+    'adventures extras': 'Ad',
+    'empires': 'E'
 }
 
 promoTextIcons = {
@@ -193,11 +195,14 @@ cardTypes = [
     CardType(('Action', 'Prize'), 'action.png'),
     CardType(('Action', 'Ruins'), 'ruins.png', 0, 1),
     CardType(('Action', 'Shelter'), 'action-shelter.png'),
+    CardType(('Action', 'Attack', 'Duration'), 'duration.png'),
     CardType(('Action', 'Attack', 'Looter'), 'action.png'),
     CardType(('Action', 'Attack', 'Traveller'), 'action.png'),
     CardType(('Action', 'Reserve'), 'reserve.png'),
     CardType(('Action', 'Reserve', 'Victory'), 'reserve-victory.png'),
     CardType(('Action', 'Traveller'), 'action.png'),
+    CardType(('Action', 'Gathering'), 'action.png'),
+    CardType(('Action', 'Treasure'), 'treasre.png'),
     CardType(('Prize',), 'action.png'),
     CardType(('Event',), 'event.png'),
     CardType(('Reaction',), 'reaction.png'),
@@ -211,9 +216,11 @@ cardTypes = [
     CardType(('Victory',), 'victory.png'),
     CardType(('Victory', 'Reaction'), 'victory-reaction.png', 0, 1),
     CardType(('Victory', 'Shelter'), 'victory-shelter.png'),
+    CardType(('Victory', 'Castle'), 'victory.png'),
     CardType(('Curse',), 'curse.png', 3),
     CardType(('Expansion',), 'expansion.png', 4),
-    CardType(('Blank',), '')
+    CardType(('Blank',), ''),
+    CardType(('Landmark',), '')
 ]
 
 cardTypes = dict(((c.getTypeNames(), c) for c in cardTypes))


### PR DESCRIPTION
I've added some initial support for Empires: I've added the cards with their cost, name, and type. I added a description for some before I ran out of time. No artwork. No support for debt. I only use text on my dividers and only put the name of the card and its expansion. Hope this gets you started.

Also, fixed a bug with the --use-text-set-icon parameter.