### PR TITLE
Fixed "Settlers / Bustling Village" per #81

### DIFF
--- a/card_db/de/card_groups.json
+++ b/card_db/de/card_groups.json
@@ -48,5 +48,47 @@
             "Mercenary"
         ],
         "new_name": "Urchin \/ Mercenary"
+    },
+    "Catapult \/ Rocks" : {
+        "subcards": [
+            "Catapult",
+            "Rocks"
+        ],
+        "new_name": "Catapult \/ Rocks"
+    },
+    "Encampment \/ Plunder": {
+        "subcards": [
+            "Encampment",
+            "Plunder"
+        ],
+        "new_name": "Encampment \/ Plunder"
+    },
+    "Gladiator \/ Fortune": {
+        "subcards": [
+            "Gladiator",
+            "Fortune"
+        ],
+        "new_name": "Gladiator \/ Fortune"
+    },
+    "Patrician \/ Emporium": {
+        "subcards": [
+            "Patrician",
+            "Emporium"
+        ],
+        "new_name": "Patrician \/ Emporium"
+    },
+    "Settlers \/ Bustling Village": {
+        "subcards": [
+            "Settlers",
+            "Bustling Village"
+        ],
+        "new_name": "Settlers \/ Bustling Village"
+    },
+    "Sauna \/ Avanto": {
+        "subcards": [
+            "Sauna",
+            "Avanto"
+        ],
+        "new_name": "Sauna \/ Avanto"
     }
 }

--- a/card_db/en_us/card_groups.json
+++ b/card_db/en_us/card_groups.json
@@ -77,12 +77,12 @@
         ],
         "new_name": "Patrician \/ Emporium"
     },
-    "Bustling Village \/ Settlers": {
+    "Settlers \/ Bustling Village": {
         "subcards": [
-            "Bustling Village",
-            "Settlers"
+            "Settlers",
+            "Bustling Village"
         ],
-        "new_name": "Bustling Village \/ Settlers"
+        "new_name": "Settlers \/ Bustling Village"
     },
     "Sauna \/ Avanto": {
         "subcards": [

--- a/card_db/fr/card_groups.json
+++ b/card_db/fr/card_groups.json
@@ -48,5 +48,47 @@
             "Mercenary"
         ],
         "new_name": "Urchin \/ Mercenary"
+    },
+    "Catapult \/ Rocks": {
+        "subcards": [
+            "Catapult",
+            "Rocks"
+        ],
+        "new_name": "Catapult \/ Rocks"
+    },
+    "Encampment \/ Plunder": {
+        "subcards": [
+            "Encampment",
+            "Plunder"
+        ],
+        "new_name": "Encampment \/ Plunder"
+    },
+    "Gladiator \/ Fortune": {
+        "subcards": [
+            "Gladiator",
+            "Fortune"
+        ],
+        "new_name": "Gladiator \/ Fortune"
+    },
+    "Patrician \/ Emporium": {
+        "subcards": [
+            "Patrician",
+            "Emporium"
+        ],
+        "new_name": "Patrician \/ Emporium"
+    },
+    "Settlers \/ Bustling Village": {
+        "subcards": [
+            "Settlers",
+            "Bustling Village"
+        ],
+        "new_name": "Settlers \/ Bustling Village"
+    },
+    "Sauna \/ Avanto": {
+        "subcards": [
+            "Sauna",
+            "Avanto"
+        ],
+        "new_name": "Sauna \/ Avanto"
     }
 }

--- a/card_db/it/card_groups.json
+++ b/card_db/it/card_groups.json
@@ -48,5 +48,47 @@
             "Mercenary"
         ],
         "new_name": "Urchin \/ Mercenary"
+    },
+    "Catapult \/ Rocks": {
+        "subcards": [
+            "Catapult",
+            "Rocks"
+        ],
+        "new_name": "Catapult \/ Rocks"
+    },
+    "Encampment \/ Plunder": {
+        "subcards": [
+            "Encampment",
+            "Plunder"
+        ],
+        "new_name": "Encampment \/ Plunder"
+    },
+    "Gladiator \/ Fortune": {
+        "subcards": [
+            "Gladiator",
+            "Fortune"
+        ],
+        "new_name": "Gladiator \/ Fortune"
+    },
+    "Patrician \/ Emporium": {
+        "subcards": [
+            "Patrician",
+            "Emporium"
+        ],
+        "new_name": "Patrician \/ Emporium"
+    },
+    "Settlers \/ Bustling Village": {
+        "subcards": [
+            "Settlers",
+            "Bustling Village"
+        ],
+        "new_name": "Settlers \/ Bustling Village"
+    },
+    "Sauna \/ Avanto": {
+        "subcards": [
+            "Sauna",
+            "Avanto"
+        ],
+        "new_name": "Sauna \/ Avanto"
     }
 }


### PR DESCRIPTION
Fixed "Settlers / Bustling Village" group per #81 as it was backward causing it not to match cards.json.  

As I checked for the same problem in the other translations, I found that they weren't translations but just copies of a card_groups.json from before 7355c8f6 .  I have copied the updates from that sha into the other three card_groups.json with the fix for Settlers / Bustling Village.  

This means more entries needing translation, but if the code tries to use the translations at least they are complete.