### PR TITLE
Initial code refactoring for card db change

### DIFF
--- a/card_db/sets_db.json
+++ b/card_db/sets_db.json
@@ -1,0 +1,201 @@
+{
+    "adventures": {
+        "image": "adventures_set.png",
+        "set_name": "*adventures*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "adventures extras": {
+        "image": "adventures_set.png",
+        "set_name": "*adventures extras*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "alchemy": {
+        "image": "alchemy_set.png",
+        "set_name": "*alchemy*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "base": {
+        "image": "base_set.png",
+        "set_name": "*base*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "2",
+            "latest"
+        ]
+    },
+    "cornucopia": {
+        "image": "cornucopia_set.png",
+        "set_name": "*cornucopia*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "cornucopia extras": {
+        "image": "cornucopia_set.png",
+        "set_name": "*cornucopia extras*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "dark ages": {
+        "image": "dark_ages_set.png",
+        "set_name": "*dark ages*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "dark ages extras": {
+        "image": "dark_ages_set.png",
+        "set_name": "*dark ages extras*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "dominion1stEdition": {
+        "image": "base_set.png",
+        "set_name": "*dominion1stEdition*",
+        "short_name": "Dominion",
+        "text_icon": "",
+        "edition": [
+            "1"
+        ]
+    },
+    "dominion2ndEdition": {
+        "image": "base_set.png",
+        "set_name": "*dominion2ndEdition*",
+        "short_name": "Dominion",
+        "text_icon": "",
+        "edition": [
+            "2",
+            "latest"
+        ]
+    },
+    "dominion2ndEditionUpgrade": {
+        "image": "base_set.png",
+        "set_name": "*dominion2ndEditionUpgrade*",
+        "text_icon": "",
+        "edition": [
+            "1"
+        ]
+    },
+    "empires": {
+        "image": "empires_set.png",
+        "set_name": "*empires*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "empires extras": {
+        "image": "empires_set.png",
+        "set_name": "*empires extras*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "guilds": {
+        "image": "guilds_set.png",
+        "set_name": "*guilds*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "hinterlands": {
+        "image": "hinterlands_set.png",
+        "set_name": "*hinterlands*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "intrigue1stEdition": {
+        "image": "intrigue_set.png",
+        "set_name": "*intrigue1stEdition*",
+        "short_name": "Intrigue",
+        "text_icon": "",
+        "edition": [
+            "1"
+        ]
+    },
+    "intrigue2ndEdition": {
+        "image": "intrigue_set.png",
+        "set_name": "*intrigue2ndEdition*",
+        "short_name": "Intrigue",
+        "text_icon": "",
+        "edition": [
+            "2",
+            "latest"
+        ]
+    },
+    "intrigue2ndEditionUpgrade": {
+        "image": "intrigue_set.png",
+        "set_name": "*intrigue2ndEditionUpgrade*",
+        "text_icon": "",
+        "edition": [
+            "1"
+        ]
+    },
+    "promo": {
+        "image": "promo_set.png",
+        "set_name": "*promo",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "prosperity": {
+        "image": "prosperity_set.png",
+        "set_name": "*prosperity*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "seaside": {
+        "image": "seaside_set.png",
+        "set_name": "*seaside*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    },
+    "extras": {
+        "image": "",
+        "set_name": "*extras*",
+        "text_icon": "",
+        "edition": [
+            "1",
+            "latest"
+        ]
+    }
+}

--- a/domdiv/draw.py
+++ b/domdiv/draw.py
@@ -794,7 +794,7 @@ class DividerDrawer(object):
 
             sets = []
             for c in pageCards:
-                setTitle = c.cardset.title()
+                setTitle = c.cardset
                 if setTitle not in sets:
                     sets.append(setTitle)
 


### PR DESCRIPTION
This assumes the following file structure:

```
card_db/
    cards_db.json
    sets_db.json
    <language>/
        cards_text.json
        sets_text.json
```
Files that are needed are:

- cards_db.json
- cards_text.json and sets_text.json for each supported language

**Other changes:**

Added option called `--edition` that can be "1", "2", "latest", or "all". Defaults to "all".
This allows for a quick filtering for those that don't want everything (i.e., "all").

- "1" is for all 1st editions of expansions. It also includes 2nd edition update packs.
- "2" is for all 2nd editions of expansions. So base, Dominion 2nd ed., and Intrigue 2nd ed. (no update packs, since already in 2nd edition)
- "latest" is for base, Dominion 2nd ed., and Intrigue 2nd ed., and all the remaining 1st editions.

Cards can be grouped 3 ways:

- No grouping (default)
- In expansion grouping invoked with `--special_card_groups`.
- Grouping across expansions with `--exclude_events` and `--exclude_landmarks`.  These groups are placed in a set called "Extras".   `--exclude_prizes` is not currently implemented.

Added an option called `--upgrade_with_expansion` which will put the upgraded cards into the corresponding earlier expansion.  So all 1st edition cards as well as the upgrade cards appear in the 1st edition set.  That way the cards are listed on the expansion dividers and any tab/ordering fit the expansion as a whole.  And because of the deleted cards in 2nd edition, this is a different list of cards than just using the 2nd edition.