### PR TITLE
wvoigt small fixes

### DIFF
--- a/card_db/sets_db.json
+++ b/card_db/sets_db.json
@@ -15,6 +15,7 @@
         ], 
         "image": "adventures_set.png", 
         "set_name": "*adventures extras*", 
+        "no_randomizer": true, 
         "text_icon": "*"
     },
     "alchemy": {
@@ -52,6 +53,7 @@
         ], 
         "image": "cornucopia_set.png", 
         "set_name": "*cornucopia extras*", 
+        "no_randomizer": true, 
         "text_icon": "*"
     },
     "dark ages": {
@@ -70,6 +72,7 @@
         ], 
         "image": "dark_ages_set.png", 
         "set_name": "*dark ages extras*", 
+        "no_randomizer": true, 
         "text_icon": "*"
     },
     "dominion1stEdition": {
@@ -115,6 +118,7 @@
         ], 
         "image": "empires_set.png", 
         "set_name": "*empires extras*", 
+        "no_randomizer": true, 
         "text_icon": "*"
     },
     "extras": {
@@ -124,6 +128,7 @@
         ], 
         "image": "", 
         "set_name": "*extras*", 
+        "no_randomizer": true, 
         "text_icon": "*"
     },
     "guilds": {

--- a/domdiv/__init__.py
+++ b/domdiv/__init__.py
@@ -422,6 +422,9 @@ def read_write_card_data(options):
     with codecs.open(set_db_filepath, "r", "utf-8") as setfile:
         Card.sets = json.load(setfile)
     assert Card.sets, "Could not load any sets from database"
+    for s in Card.sets:
+        if not 'no_randomizer' in Card.sets[s]:
+            Card.sets[s]['no_randomizer'] = False
 
     # Set cardset_tag and expand cards that are used in multiple sets
     new_cards = []
@@ -580,6 +583,8 @@ def combine_cards(cards, old_card_type='', new_card_tag='', new_cardset_tag=None
                 holder.cost = ""
                 if new_cardset_tag is not None:
                     holder.cardset_tag = new_cardset_tag
+                    holder.image = None
+                    holder.image = holder.setImage()
                 if new_type is not None:
                     holder.types = (new_type, )
                 filteredCards.append(holder)
@@ -768,6 +773,12 @@ def filter_sort_cards(cards, options):
             exp = set_values["set_name"]
             if exp in cardnamesByExpansion:
                 exp_name = exp
+                
+                count = len(cardnamesByExpansion[exp])
+                if 'no_randomizer' in set_values:
+                    if set_values['no_randomizer']:
+                        count = 0
+
                 if not options.expansion_dividers_long_name:
                     if 'short_name' in set_values:
                         exp_name = set_values['short_name']
@@ -778,7 +789,7 @@ def filter_sort_cards(cards, options):
                          types=("Expansion", ),
                          cost=None,
                          description=' | '.join(sorted(cardnamesByExpansion[exp])),
-                         count=len(cardnamesByExpansion[exp]),
+                         count=count,
                          card_tag=set_tag)
                 cards.append(c)
 

--- a/domdiv/__init__.py
+++ b/domdiv/__init__.py
@@ -423,7 +423,7 @@ def read_write_card_data(options):
         Card.sets = json.load(setfile)
     assert Card.sets, "Could not load any sets from database"
     for s in Card.sets:
-        if not 'no_randomizer' in Card.sets[s]:
+        if 'no_randomizer' not in Card.sets[s]:
             Card.sets[s]['no_randomizer'] = False
 
     # Set cardset_tag and expand cards that are used in multiple sets
@@ -773,7 +773,7 @@ def filter_sort_cards(cards, options):
             exp = set_values["set_name"]
             if exp in cardnamesByExpansion:
                 exp_name = exp
-                
+
                 count = len(cardnamesByExpansion[exp])
                 if 'no_randomizer' in set_values:
                     if set_values['no_randomizer']:

--- a/domdiv/draw.py
+++ b/domdiv/draw.py
@@ -219,6 +219,7 @@ class DividerDrawer(object):
         replace = '<img src=' "'%s/coin_small_empty.png'" ' width=%d height=' "'100%%'" ' valign=' "'middle'" '/>'
         replace = replace % (path, fontsize * 1.2)
         text = re.sub('empty\s(c|C)oin(s)?', replace, text)
+        text = re.sub('\_\s(c|C)oin(s)?', replace, text)
 
         # VP
         replace = '<img src=' "'%s/victory_emblem.png'" ' width=%d height=' "'120%%'" ' valign=' "'middle'" '/>'
@@ -720,7 +721,6 @@ class DividerDrawer(object):
             while width > textWidth:
                 fontSize -= .01
                 if fontSize < 6 and not failover:
-                    print card.card_tag
                     # Start over using all available space left on line
                     textWidth = textWidth2
                     w = left_margin + (textWidth2 / 2)
@@ -767,14 +767,18 @@ class DividerDrawer(object):
         spacerHeight = 0.2 * cm
         minSpacerHeight = 0.05 * cm
 
-        descriptions = self.add_inline_text(descriptions)
+        if not card.isExpansion():
+            descriptions = self.add_inline_text(descriptions)
         descriptions = re.split("\n", descriptions)
         while True:
             paragraphs = []
             # this accounts for the spacers we insert between paragraphs
             h = (len(descriptions) - 1) * spacerHeight
             for d in descriptions:
-                dmod = self.add_inline_images(d, s.fontSize)
+                if card.isExpansion():
+                    dmod = d
+                else:
+                    dmod = self.add_inline_images(d, s.fontSize)
                 p = Paragraph(dmod, s)
                 h += p.wrap(textBoxWidth, textBoxHeight)[1]
                 paragraphs.append(p)


### PR DESCRIPTION
Fixed a number of small things:
- The extra expansion dividers really don't have randomizers.  So there should not be a "count".
- The Events and Landmarks at the global level are no longer printing a set icon.
- Removed a debug statement
- Fixed so Expansion dividers do not go through the inline graphics and text replacement.  In some cases it was replacing parts of card names with graphics (e.g., Potion)
- added "_ Coin" to print empty coin. 