### PR TITLE
Fix Prosperity rules text running over

### DIFF
--- a/domdiv/draw.py
+++ b/domdiv/draw.py
@@ -232,7 +232,7 @@ class DividerDrawer(object):
                               fontsize_multiplier,
                               height_percent,
                               text_fontsize_multiplier=None):
-            replace_template = '<img src="{fpath}" width={width} height="{height_percent}%" valign="middle" />&thinsp;'
+            replace_template = '<img src="{fpath}" width={width} height="{height_percent}%" valign="middle" />'
             offset = 0
             for match in re.finditer(tag_pattern, text):
                 replace = replace_template


### PR DESCRIPTION
This mostly fixes Issue #155.  This seems to occur only with the VP image.  I've seen several coin and potion, and debt images at the end of a line and they are justified correctly.  There is some strange interaction with the VP image and the paragraph wrap function in reportlab.
While not completely fixing the image out of the normal paragraph boundary, at least this keeps it within the margins of the card.