### PR TITLE
Preview option

### DIFF
--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -400,6 +400,10 @@ def parse_opts(cmdline_args=None):
         dest="tabs_only",
         help="Draw only the divider tabs and no divider outlines. "
         "Used to print the divider tabs on labels.")
+    group_printing.add_argument(
+        "--preview",
+        action='store_true'
+    )
 
     # Special processing
     group_special = parser.add_argument_group(
@@ -463,11 +467,12 @@ def generate_sample(options):
     from wand.image import Image
     buf = cStringIO.StringIO()
     options.num_pages = 1
+    options.outfile = buf
     generate(options)
-    sample_out = cStringIO.cStringIO()
+    sample_out = cStringIO.StringIO()
     with Image(blob=buf.getvalue()) as sample:
         sample.format = 'png'
-        sample.save(fp=sample_out)
+        sample.save(sample_out)
         return sample_out
 
 
@@ -1127,4 +1132,7 @@ def generate(options):
 def main():
     options = parse_opts()
     options = clean_opts(options)
+    if options.preview:
+        open('preview.png', 'wb').write(generate_sample(options).getvalue())
+        return
     return generate(options)

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -1138,6 +1138,7 @@ def main():
     options = parse_opts()
     options = clean_opts(options)
     if options.preview:
-        open('preview.png', 'wb').write(generate_sample(options).getvalue())
-        return
-    return generate(options)
+        fname = '{}.{}'.format(os.path.splitext(options.outfile)[0], 'png')
+        open(fname, 'wb').write(generate_sample(options).getvalue())
+    else:
+        generate(options)

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -470,7 +470,7 @@ def generate_sample(options):
     options.outfile = buf
     generate(options)
     sample_out = cStringIO.StringIO()
-    with Image(blob=buf.getvalue()) as sample:
+    with Image(blob=buf.getvalue(), resolution=300) as sample:
         sample.format = 'png'
         sample.save(sample_out)
         return sample_out

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -463,10 +463,12 @@ def generate_sample(options):
     from wand.image import Image
     buf = cStringIO.StringIO()
     options.num_pages = 1
-    generate(options, '.', buf)
+    generate(options)
+    sample_out = cStringIO.cStringIO()
     with Image(blob=buf.getvalue()) as sample:
         sample.format = 'png'
-        sample.save(filename='sample.png')
+        sample.save(fp=sample_out)
+        return sample_out
 
 
 def parse_papersize(spec):

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -402,7 +402,8 @@ def parse_opts(cmdline_args=None):
         "Used to print the divider tabs on labels.")
     group_printing.add_argument(
         "--preview",
-        action='store_true'
+        action='store_true',
+        help="Only generate a preview png image of the first page"
     )
     group_printing.add_argument(
         "--preview_resolution",

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -404,7 +404,11 @@ def parse_opts(cmdline_args=None):
         "--preview",
         action='store_true'
     )
-
+    group_printing.add_argument(
+        "--preview_resolution",
+        type=int,
+        default=150,
+        help="resolution in DPI to render preview at, for --preview option")
     # Special processing
     group_special = parser.add_argument_group(
         'Miscellaneous',
@@ -470,7 +474,7 @@ def generate_sample(options):
     options.outfile = buf
     generate(options)
     sample_out = cStringIO.StringIO()
-    with Image(blob=buf.getvalue(), resolution=300) as sample:
+    with Image(blob=buf.getvalue(), resolution=options.preview_resolution) as sample:
         sample.format = 'png'
         sample.save(sample_out)
         return sample_out


### PR DESCRIPTION
This updates/fixes the existing preview code that generates a png image of the first page of the dividers.

It also adds two new command line options, `--preview` to use the code above to write a preview image instead of generating the whole pdf divider set, and `--preview_resolution` to set the DPI of the generated preview images.