### PR TITLE
standardize arguments to use hyphens

### DIFF
--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -154,7 +154,7 @@ def parse_opts(cmdline_args=None):
         'Divider Tab',
         'Changes what is displayed on on the Divider Tab.')
     group_tab.add_argument(
-        "--tab_side",
+        "--tab-side",
         choices=TAB_SIDE_CHOICES,
         dest="tab_side",
         default="right-alternate",
@@ -165,7 +165,7 @@ def parse_opts(cmdline_args=None):
         "'centre' will force all label tabs to the centre; "
         "'full' will force all label tabs to be full width of the divider.")
     group_tab.add_argument(
-        "--tab_name_align",
+        "--tab-name-align",
         choices=NAME_ALIGN_CHOICES + ["center"],
         dest="tab_name_align",
         default="left",
@@ -188,7 +188,7 @@ def parse_opts(cmdline_args=None):
         "'hide' to indicate it should not be displayed, or "
         "given multiple times to show it in multiple places.")
     group_tab.add_argument(
-        "--set_icon",
+        "--set-icon",
         action="append",
         choices=LOCATION_CHOICES,
         default=['tab'],
@@ -211,18 +211,18 @@ def parse_opts(cmdline_args=None):
         'Expansion Dividers',
         'Adding separator dividers for each expansion.')
     group_expansion.add_argument(
-        "--expansion_dividers",
+        "--expansion-dividers",
         action="store_true",
         dest="expansion_dividers",
         help="Add dividers describing each expansion set. "
         "A list of cards in the expansion will be shown on the front of the divider.")
     group_expansion.add_argument(
-        "--centre_expansion_dividers",
+        "--centre-expansion-dividers",
         action="store_true",
         dest="centre_expansion_dividers",
         help='Centre the tabs on expansion dividers.')
     group_expansion.add_argument(
-        "--expansion_dividers_long_name",
+        "--expansion-dividers-long-name",
         action="store_true",
         dest="expansion_dividers_long_name",
         help="Use the long name with edition information on the expansion divider tab. "
@@ -275,31 +275,31 @@ def parse_opts(cmdline_args=None):
         "'all' is for all editions of expansions; "
         " This can be combined with other options to refine the expansions to include in the output.")
     group_select.add_argument(
-        "--upgrade_with_expansion",
+        "--upgrade-with-expansion",
         action="store_true",
         dest="upgrade_with_expansion",
         help="Include any new edition upgrade cards with the expansion being upgraded.")
     group_select.add_argument(
-        "--base_cards_with_expansion",
+        "--base-cards-with-expansion",
         action="store_true",
         help="Print the base cards as part of the expansion (i.e., a divider for 'Silver' "
         "will be printed as both a 'Dominion' card and as an 'Intrigue 1st Edition' card). "
         "If this option is not given, all base cards are placed in their own 'Base' expansion.")
     group_select.add_argument(
-        "--special_card_groups",
+        "--special-card-groups",
         action="store_true",
         help="Group cards that generally are used together "
         "(e.g., Shelters, Tournament and Prizes, Urchin/Mercenary, etc.).")
     group_select.add_argument(
-        "--include_blanks",
+        "--include-blanks",
         action="store_true",
         help="Include a few dividers with extra text.")
     group_select.add_argument(
-        "--exclude_events",
+        "--exclude-events",
         action="store_true",
         help="Group all 'Event' cards across all expansions into one divider.")
     group_select.add_argument(
-        "--exclude_landmarks",
+        "--exclude-landmarks",
         action="store_true",
         help="Group all 'Landmark' cards across all expansions into one divider.")
 
@@ -320,17 +320,17 @@ def parse_opts(cmdline_args=None):
         "Typically unsleeved cards are 2.0, thin sleeved cards are 2.4, and thick sleeved cards are 3.2. "
         "This is only valid with the --wrapper option.")
     group_wrapper.add_argument(
-        "--sleeved_thick",
+        "--sleeved-thick",
         action="store_true",
         dest="sleeved_thick",
         help="Same as --size=sleeved --thickness 3.2.")
     group_wrapper.add_argument(
-        "--sleeved_thin",
+        "--sleeved-thin",
         action="store_true",
         dest="sleeved_thin",
         help="Same as --size=sleeved --thickness 2.4.")
     group_wrapper.add_argument(
-        "--notch_length",
+        "--notch-length",
         type=float,
         default=0.0,
         help="Length of thumb notch on wrapper in centimeters "
@@ -363,24 +363,24 @@ def parse_opts(cmdline_args=None):
         default=0.1,
         help="Width of lines for card outlines and crop marks.")
     group_printing.add_argument(
-        "--back_offset",
+        "--back-offset",
         type=float,
         dest="back_offset",
         default=0,
         help="Back page horizontal offset points to shift to the right. Only needed for some printers.")
     group_printing.add_argument(
-        "--back_offset_height",
+        "--back-offset-height",
         type=float,
         dest="back_offset_height",
         default=0,
         help="Back page vertical offset points to shift upward. Only needed for some printers.")
     group_printing.add_argument(
-        "--vertical_gap",
+        "--vertical-gap",
         type=float,
         default=0.0,
         help="Vertical gap between dividers in centimeters.")
     group_printing.add_argument(
-        "--horizontal_gap",
+        "--horizontal-gap",
         type=float,
         default=0.0,
         help="Horizontal gap between dividers in centimeters.")
@@ -390,7 +390,7 @@ def parse_opts(cmdline_args=None):
         dest="no_page_footer",
         help="Do not print the expansion name at the bottom of the page.")
     group_printing.add_argument(
-        "--num_pages",
+        "--num-pages",
         type=int,
         default=-1,
         help="Stop generating dividers after this many pages, -1 for all.")
@@ -406,7 +406,7 @@ def parse_opts(cmdline_args=None):
         help="Only generate a preview png image of the first page"
     )
     group_printing.add_argument(
-        "--preview_resolution",
+        "--preview-resolution",
         type=int,
         default=150,
         help="resolution in DPI to render preview at, for --preview option")
@@ -419,7 +419,7 @@ def parse_opts(cmdline_args=None):
         dest="cardlist",
         help="Path to file that enumerates each card to be printed on its own line.")
     group_special.add_argument(
-        "--write_json",
+        "--write-json",
         action="store_true",
         dest="write_json",
         help="Write json version of card definitions and extras.")

--- a/domdiv/tests/text_tab_tests.py
+++ b/domdiv/tests/text_tab_tests.py
@@ -98,7 +98,7 @@ class TestTextTabs(unittest.TestCase):
     # --tab_name_align left
     def test_tab_left_left(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'left', '--tab_side', 'left'])
+            ['--tab-name-align', 'left', '--tab-side', 'left'])
         self.assertEquals(options.tab_name_align, 'left')
         self.assertEquals(options.tab_side, 'left')
         main.calculate_layout(options)
@@ -107,7 +107,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_left_right(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'left', '--tab_side', 'right'])
+            ['--tab-name-align', 'left', '--tab-side', 'right'])
         self.assertEquals(options.tab_name_align, 'left')
         self.assertEquals(options.tab_side, 'right')
         main.calculate_layout(options)
@@ -116,7 +116,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_left_leftalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'left', '--tab_side',
+            ['--tab-name-align', 'left', '--tab-side',
              'left-alternate'])
         self.assertEquals(options.tab_name_align, 'left')
         self.assertEquals(options.tab_side, 'left-alternate')
@@ -126,7 +126,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_left_rightalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'left', '--tab_side',
+            ['--tab-name-align', 'left', '--tab-side',
              'right-alternate'])
         self.assertEquals(options.tab_name_align, 'left')
         self.assertEquals(options.tab_side, 'right-alternate')
@@ -136,7 +136,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_left_full(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'left', '--tab_side', 'full'])
+            ['--tab-name-align', 'left', '--tab-side', 'full'])
         self.assertEquals(options.tab_name_align, 'left')
         self.assertEquals(options.tab_side, 'full')
         main.calculate_layout(options)
@@ -146,7 +146,7 @@ class TestTextTabs(unittest.TestCase):
         # --tab_name_align right
     def test_tab_right_left(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'right', '--tab_side', 'left'])
+            ['--tab-name-align', 'right', '--tab-side', 'left'])
         self.assertEquals(options.tab_name_align, 'right')
         self.assertEquals(options.tab_side, 'left')
         main.calculate_layout(options)
@@ -154,8 +154,8 @@ class TestTextTabs(unittest.TestCase):
         self.assertEquals(options.tab_side, 'left')
 
     def test_tab_right_right(self):
-        options = main.parse_opts(['--tab_name_align',
-                                   'right', '--tab_side', 'right'])
+        options = main.parse_opts(['--tab-name-align',
+                                   'right', '--tab-side', 'right'])
         self.assertEquals(options.tab_name_align, 'right')
         self.assertEquals(options.tab_side, 'right')
         main.calculate_layout(options)
@@ -164,7 +164,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_right_leftalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'right', '--tab_side',
+            ['--tab-name-align', 'right', '--tab-side',
              'left-alternate'])
         self.assertEquals(options.tab_name_align, 'right')
         self.assertEquals(options.tab_side, 'left-alternate')
@@ -174,7 +174,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_right_rightalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'right', '--tab_side',
+            ['--tab-name-align', 'right', '--tab-side',
              'right-alternate'])
         self.assertEquals(options.tab_name_align, 'right')
         self.assertEquals(options.tab_side, 'right-alternate')
@@ -184,7 +184,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_right_full(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'right', '--tab_side', 'full'])
+            ['--tab-name-align', 'right', '--tab-side', 'full'])
         self.assertEquals(options.tab_name_align, 'right')
         self.assertEquals(options.tab_side, 'full')
         main.calculate_layout(options)
@@ -194,7 +194,7 @@ class TestTextTabs(unittest.TestCase):
     # --tab_name_align edge
     def test_tab_edge_left(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'edge', '--tab_side', 'left'])
+            ['--tab-name-align', 'edge', '--tab-side', 'left'])
         self.assertEquals(options.tab_name_align, 'edge')
         self.assertEquals(options.tab_side, 'left')
         main.calculate_layout(options)
@@ -203,7 +203,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_edge_right(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'edge', '--tab_side', 'right'])
+            ['--tab-name-align', 'edge', '--tab-side', 'right'])
         self.assertEquals(options.tab_name_align, 'edge')
         self.assertEquals(options.tab_side, 'right')
         main.calculate_layout(options)
@@ -212,7 +212,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_edge_leftalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'edge', '--tab_side',
+            ['--tab-name-align', 'edge', '--tab-side',
              'left-alternate'])
         self.assertEquals(options.tab_name_align, 'edge')
         self.assertEquals(options.tab_side, 'left-alternate')
@@ -222,7 +222,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_edge_rightalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'edge', '--tab_side',
+            ['--tab-name-align', 'edge', '--tab-side',
              'right-alternate'])
         self.assertEquals(options.tab_name_align, 'edge')
         self.assertEquals(options.tab_side, 'right-alternate')
@@ -232,7 +232,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_edge_full(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'edge', '--tab_side', 'full'])
+            ['--tab-name-align', 'edge', '--tab-side', 'full'])
         self.assertEquals(options.tab_name_align, 'edge')
         self.assertEquals(options.tab_side, 'full')
         main.calculate_layout(options)
@@ -242,8 +242,8 @@ class TestTextTabs(unittest.TestCase):
 
         # --tab_name_align centre
     def test_tab_centre_left(self):
-        options = main.parse_opts(['--tab_name_align',
-                                   'centre', '--tab_side', 'left'])
+        options = main.parse_opts(['--tab-name-align',
+                                   'centre', '--tab-side', 'left'])
         self.assertEquals(options.tab_name_align, 'centre')
         self.assertEquals(options.tab_side, 'left')
         main.calculate_layout(options)
@@ -251,8 +251,8 @@ class TestTextTabs(unittest.TestCase):
         self.assertEquals(options.tab_side, 'left')
 
     def test_tab_centre_right(self):
-        options = main.parse_opts(['--tab_name_align',
-                                   'centre', '--tab_side', 'right'])
+        options = main.parse_opts(['--tab-name-align',
+                                   'centre', '--tab-side', 'right'])
         self.assertEquals(options.tab_name_align, 'centre')
         self.assertEquals(options.tab_side, 'right')
         main.calculate_layout(options)
@@ -261,7 +261,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_centre_leftalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'centre', '--tab_side',
+            ['--tab-name-align', 'centre', '--tab-side',
              'left-alternate'])
         self.assertEquals(options.tab_name_align, 'centre')
         self.assertEquals(options.tab_side, 'left-alternate')
@@ -271,7 +271,7 @@ class TestTextTabs(unittest.TestCase):
 
     def test_tab_centre_rightalt(self):
         options = main.parse_opts(
-            ['--tab_name_align', 'centre', '--tab_side',
+            ['--tab-name-align', 'centre', '--tab-side',
              'right-alternate'])
         self.assertEquals(options.tab_name_align, 'centre')
         self.assertEquals(options.tab_side, 'right-alternate')
@@ -280,8 +280,8 @@ class TestTextTabs(unittest.TestCase):
         self.assertEquals(options.tab_side, 'right-alternate')
 
     def test_tab_centre_full(self):
-        options = main.parse_opts(['--tab_name_align',
-                                   'centre', '--tab_side', 'full'])
+        options = main.parse_opts(['--tab-name-align',
+                                   'centre', '--tab-side', 'full'])
         self.assertEquals(options.tab_name_align, 'centre')
         self.assertEquals(options.tab_side, 'full')
         main.calculate_layout(options)
@@ -290,8 +290,8 @@ class TestTextTabs(unittest.TestCase):
 
     # --tab_name_align center.  Just do one since this is an alias to centre
     def test_tab_center_left(self):
-        options = main.parse_opts(['--tab_name_align',
-                                   'center', '--tab_side', 'left'])
+        options = main.parse_opts(['--tab-name-align',
+                                   'center', '--tab-side', 'left'])
         self.assertEquals(options.tab_name_align, 'center')
         self.assertEquals(options.tab_side, 'left')
         main.calculate_layout(options)


### PR DESCRIPTION
Some of the arguments used hyphens/dashes `-` and some use underscores `_`. I think that they should at least be consistent. [GNU](https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html) recommends using hyphens/dashes.

This is a breaking change.