### PR TITLE
correct the count of Platinum cards

### DIFF
--- a/domdiv/card_db/cards_db.json
+++ b/domdiv/card_db/cards_db.json
@@ -870,7 +870,8 @@
         "base", 
         "prosperity"
     ], 
-    "cost": "9", 
+    "cost": "9",
+    "count": "12", 
     "types": [
         "Treasure"
     ]


### PR DESCRIPTION
From BGG user Aziden:

`The count for Platinum (in Base/Prosperity) is incorrect. There are 12 Platinum, not 10.`
