### PR TITLE
Fix for base cards printing with expansions

### DIFF
--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -961,9 +961,9 @@ def filter_sort_cards(cards, options):
     cardSorter = CardSorter(
         options.order,
         {card.card_tag: card.name for card in cards if 'base' in [set_name.lower() for set_name in card.cardset_tags]})
-    if options.base_cards_with_expansion:
-        cards = [card for card in cards if card.cardset_tag.lower() != 'base']
-    else:
+
+    # Optionally remove base cards from expansions that have them
+    if not options.base_cards_with_expansion:
         cards = [card for card in cards
                  if not cardSorter.isBaseExpansionCard(card)]
 

--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -960,7 +960,7 @@ def filter_sort_cards(cards, options):
     # Set up the card sorter
     cardSorter = CardSorter(
         options.order,
-        {card.card_tag: card.name for card in cards if card.cardset_tag.lower() == 'base'})
+        {card.card_tag: card.name for card in cards if 'base' in [set_name.lower() for set_name in card.cardset_tags]})
     if options.base_cards_with_expansion:
         cards = [card for card in cards if card.cardset_tag.lower() != 'base']
     else:


### PR DESCRIPTION
Fix issue recorded at sumpfork/bgtools_web#11
This is a more simple fix than the one proposed in Pull Request #181.

A few things to note:

1. As it is right now, per line 964 of main.py

```
    if options.base_cards_with_expansion:
        cards = [card for card in cards if card.cardset_tag.lower() != 'base']
    else:
        cards = [card for card in cards
                 if not cardSorter.isBaseExpansionCard(card)]
```
If you want the base cards with the expansion, it will not print the base cards separately.  That may not be intuitive via the web interface.

2, As it is right now, when included in an expansion, the base cards are sorted to the end.

