### PR TITLE
Test language tool run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 # command to install dependencies
 install:
   - pip install -U setuptools
+  - pip install -U pycodestyle
   - pip install .
 # command to run tests
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - pip install -U pytest
   - pip install -U setuptools
-  - pip install -U pycodestyle
   - pip install .
 # command to run tests
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ python:
   - "2.7"
 # command to install dependencies
 install:
+  - pip install -U pytest
   - pip install -U setuptools
   - pip install -U pycodestyle
   - pip install .
 # command to run tests
-script: nosetests
+script: py.test

--- a/domdiv/tests/carddb_tests.py
+++ b/domdiv/tests/carddb_tests.py
@@ -1,58 +1,85 @@
-import unittest
+from __future__ import print_function
+import subprocess
+import shutil
+import os
+
+import pytest
+
 from .. import main
 from .. import cards as domdiv_cards
 
 
-class TestCardDB(unittest.TestCase):
+@pytest.fixture
+def rmtestcardb(request):
 
-    def test_cardread(self):
-        options = main.parse_opts([])
+    def rmd():
+        testcardb_dir = os.path.join(str(request.config.rootdir), 'tools/card_db')
+        if os.path.exists(testcardb_dir):
+            print('removing {}'.format(testcardb_dir))
+            shutil.rmtree(testcardb_dir)
+    request.addfinalizer(rmd)
+
+
+def test_cardread():
+    options = main.parse_opts([])
+    options.data_path = '.'
+    cards = main.read_card_data(options)
+    assert len(cards) == 524
+    valid_cardsets = {
+        u'base',
+        u'dominion1stEdition',
+        u'dominion2ndEdition',
+        u'dominion2ndEditionUpgrade',
+        u'intrigue1stEdition',
+        u'intrigue2ndEdition',
+        u'intrigue2ndEditionUpgrade',
+        u'seaside',
+        u'alchemy',
+        u'prosperity',
+        u'cornucopia extras',
+        u'cornucopia',
+        u'hinterlands',
+        u'dark ages',
+        u'dark ages extras',
+        u'guilds',
+        u'adventures',
+        u'adventures extras',
+        u'empires',
+        u'empires extras',
+        u'nocturne',
+        u'nocturne extras',
+        u'promo',
+        u'extras',
+        u'animals'
+    }
+    for c in cards:
+        assert isinstance(c, domdiv_cards.Card)
+        assert c.cardset_tag in valid_cardsets
+
+
+def test_languages():
+    languages = main.get_languages('card_db')
+    for lang in languages:
+        print('checking ' + lang)
+        # for now, just test that they load
+        options = main.parse_opts(['--language', lang])
         options.data_path = '.'
         cards = main.read_card_data(options)
-        self.assertEquals(len(cards), 524)
-        valid_cardsets = {
-            u'base',
-            u'dominion1stEdition',
-            u'dominion2ndEdition',
-            u'dominion2ndEditionUpgrade',
-            u'intrigue1stEdition',
-            u'intrigue2ndEdition',
-            u'intrigue2ndEditionUpgrade',
-            u'seaside',
-            u'alchemy',
-            u'prosperity',
-            u'cornucopia extras',
-            u'cornucopia',
-            u'hinterlands',
-            u'dark ages',
-            u'dark ages extras',
-            u'guilds',
-            u'adventures',
-            u'adventures extras',
-            u'empires',
-            u'empires extras',
-            u'nocturne',
-            u'nocturne extras',
-            u'promo',
-            u'extras',
-            u'animals'
-        }
-        for c in cards:
-            self.assertIsInstance(c, domdiv_cards.Card)
-            self.assertIn(c.cardset_tag, valid_cardsets)
+        assert cards, '"{}" cards did not read properly'.format(lang)
+        cards = main.add_card_text(options, cards, 'en_us')
+        cards = main.add_card_text(options, cards, lang)
+        if lang == 'it':
+            assert "Maledizione" in [card.name for card in cards]
+        elif lang == 'de':
+            assert "Fluch" in [card.name for card in cards]
 
-    def test_languages(self):
-        languages = main.get_languages('card_db')
-        for lang in languages:
-            print('checking ' + lang)
-            # for now, just test that they load
-            options = main.parse_opts(['--language', lang])
-            options.data_path = '.'
-            cards = main.read_card_data(options)
-            self.assertTrue(cards, '"{}" cards did not read properly'.format(lang))
-            cards = main.add_card_text(options, cards, 'en_us')
-            cards = main.add_card_text(options, cards, lang)
-            if lang == 'it':
-                self.assertIn("Maledizione", [card.name for card in cards])
-            elif lang == 'de':
-                self.assertIn("Fluch", [card.name for card in cards])
+
+def test_languagetool_run(pytestconfig):
+    cmd = 'cd {} ; python tools/update_language.py'.format(pytestconfig.rootdir)
+    print(cmd)
+    assert subprocess.check_call(cmd.split()) == 0
+    cmd = 'cd {} ; diff -r domdiv/card_db tols/card_db'.format(pytestconfig.rootdir)
+    print(subprocess.check_output(['ls', os.path.join(str(pytestconfig.rootdir), 'tools/card_db')]))
+    out = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
+    print(out)
+    assert out == ''

--- a/domdiv/tests/carddb_tests.py
+++ b/domdiv/tests/carddb_tests.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import subprocess
 import shutil
 import os
+import contextlib
 
 import pytest
 
@@ -74,12 +75,22 @@ def test_languages():
             assert "Fluch" in [card.name for card in cards]
 
 
+@contextlib.contextmanager
+def change_cwd(d):
+    curdir = os.getcwd()
+    try:
+        os.chdir(d)
+        yield
+    finally:
+        os.chdir(curdir)
+
+
 def test_languagetool_run(pytestconfig):
-    cmd = 'cd {} ; python tools/update_language.py'.format(pytestconfig.rootdir)
-    print(cmd)
-    assert subprocess.check_call(cmd.split()) == 0
-    cmd = 'cd {} ; diff -r domdiv/card_db tols/card_db'.format(pytestconfig.rootdir)
-    print(subprocess.check_output(['ls', os.path.join(str(pytestconfig.rootdir), 'tools/card_db')]))
-    out = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
-    print(out)
-    assert out == ''
+    with change_cwd(str(pytestconfig.rootdir)):
+        cmd = 'python tools/update_language.py'
+        print(cmd)
+        assert subprocess.check_call(cmd.split()) == 0
+        cmd = 'diff -rw domdiv/card_db tools/card_db'
+        out = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
+        print(out)
+        assert out == ''

--- a/domdiv/tests/codestyle_tests.py
+++ b/domdiv/tests/codestyle_tests.py
@@ -1,13 +1,10 @@
-import unittest
-import pycodestyle
 import glob
 
+import pycodestyle
 
-class TestCodeFormat(unittest.TestCase):
 
-    def test_conformance(self):
-        """Test that we conform to PEP-8."""
-        style = pycodestyle.StyleGuide(max_line_length=120)
-        result = style.check_files(glob.glob('*.py') + glob.glob('domdiv/*.py') + glob.glob('tests/*.py'))
-        self.assertEqual(result.total_errors, 0,
-                         "Found code style errors (and warnings).")
+def test_conformance():
+    """Test that we conform to PEP-8."""
+    style = pycodestyle.StyleGuide(max_line_length=120)
+    result = style.check_files(glob.glob('*.py') + glob.glob('domdiv/*.py') + glob.glob('tests/*.py'))
+    assert result.total_errors == 0, "Found code style errors (and warnings)."

--- a/domdiv/tests/layout_tests.py
+++ b/domdiv/tests/layout_tests.py
@@ -1,34 +1,34 @@
-import unittest
-from .. import main
 from reportlab.lib.units import cm
 
+from .. import main
 
-class TestLayout(unittest.TestCase):
 
-    def test_horizontal(self):
-        # should be the default
-        options = main.parse_opts([])
-        self.assertEquals(options.orientation, 'horizontal')
-        main.calculate_layout(options)
-        self.assertEquals(options.numDividersHorizontal, 2)
-        self.assertEquals(options.numDividersVertical, 3)
-        self.assertEquals(options.dividerWidth, 9.1 * cm)
-        self.assertEquals(options.labelHeight, 0.9 * cm)
-        self.assertEquals(options.dividerHeight, 5.9 * cm + options.labelHeight)
+def test_horizontal():
+    # should be the default
+    options = main.parse_opts([])
+    assert options.orientation == 'horizontal'
+    main.calculate_layout(options)
+    assert options.numDividersHorizontal == 2
+    assert options.numDividersVertical == 3
+    assert options.dividerWidth == 9.1 * cm
+    assert options.labelHeight == 0.9 * cm
+    assert options.dividerHeight == 5.9 * cm + options.labelHeight
 
-    def test_vertical(self):
-        options = main.parse_opts(['--orientation', 'vertical'])
-        self.assertEquals(options.orientation, 'vertical')
-        main.calculate_layout(options)
-        self.assertEquals(options.numDividersHorizontal, 3)
-        self.assertEquals(options.numDividersVertical, 2)
-        self.assertEquals(options.dividerWidth, 5.9 * cm)
-        self.assertEquals(options.labelHeight, 0.9 * cm)
-        self.assertEquals(options.dividerHeight, 9.1 * cm + options.labelHeight)
 
-    def test_sleeved(self):
-        options = main.parse_opts(['--size', 'sleeved'])
-        main.calculate_layout(options)
-        self.assertEquals(options.dividerWidth, 9.4 * cm)
-        self.assertEquals(options.labelHeight, 0.9 * cm)
-        self.assertEquals(options.dividerHeight, 6.15 * cm + options.labelHeight)
+def test_vertical():
+    options = main.parse_opts(['--orientation', 'vertical'])
+    assert options.orientation == 'vertical'
+    main.calculate_layout(options)
+    assert options.numDividersHorizontal == 3
+    assert options.numDividersVertical == 2
+    assert options.dividerWidth == 5.9 * cm
+    assert options.labelHeight == 0.9 * cm
+    assert options.dividerHeight == 9.1 * cm + options.labelHeight
+
+
+def test_sleeved():
+    options = main.parse_opts(['--size', 'sleeved'])
+    main.calculate_layout(options)
+    assert options.dividerWidth == 9.4 * cm
+    assert options.labelHeight == 0.9 * cm
+    assert options.dividerHeight == 6.15 * cm + options.labelHeight

--- a/domdiv/tests/text_tab_tests.py
+++ b/domdiv/tests/text_tab_tests.py
@@ -1,300 +1,321 @@
-import unittest
 from .. import main
 
 
-class TestTextTabs(unittest.TestCase):
+####################
+# Card Text and Tab Default Test
+####################
+def test_text_tabs_default():
+    # should be the default
+    options = main.parse_opts([])
+    assert options.text_front == 'card'
+    assert options.text_back == 'rules'
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'right-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
 
-    ####################
-    # Card Text and Tab Default Test
-    ####################
-    def test_text_tabs_default(self):
-        # should be the default
-        options = main.parse_opts([])
-        self.assertEquals(options.text_front, 'card')
-        self.assertEquals(options.text_back, 'rules')
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'right-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
+####################
+# Card Text Tests
+####################
 
-    ####################
-    # Card Text Tests
-    ####################
-    def test_text_card_rules(self):
-        options = main.parse_opts(
-            ['--front', 'card', '--back', 'rules'])
-        self.assertEquals(options.text_front, 'card')
-        self.assertEquals(options.text_back, 'rules')
 
-    def test_text_card_blank(self):
-        options = main.parse_opts(
-            ['--front', 'card', '--back', 'blank'])
-        self.assertEquals(options.text_front, 'card')
-        self.assertEquals(options.text_back, 'blank')
+def test_text_card_rules():
+    options = main.parse_opts(
+        ['--front', 'card', '--back', 'rules'])
+    assert options.text_front == 'card'
+    assert options.text_back == 'rules'
 
-    def test_text_card_card(self):
-        options = main.parse_opts(
-            ['--front', 'card', '--back', 'card'])
-        self.assertEquals(options.text_front, 'card')
-        self.assertEquals(options.text_back, 'card')
 
-    def test_text_card_none(self):
-        options = main.parse_opts(
-            ['--front', 'card', '--back', 'none'])
-        self.assertEquals(options.text_front, 'card')
-        self.assertEquals(options.text_back, 'none')
+def test_text_card_blank():
+    options = main.parse_opts(
+        ['--front', 'card', '--back', 'blank'])
+    assert options.text_front == 'card'
+    assert options.text_back == 'blank'
 
-    def test_text_rules_rules(self):
-        options = main.parse_opts(
-            ['--front', 'rules', '--back', 'rules'])
-        self.assertEquals(options.text_front, 'rules')
-        self.assertEquals(options.text_back, 'rules')
 
-    def test_text_rules_blank(self):
-        options = main.parse_opts(
-            ['--front', 'rules', '--back', 'blank'])
-        self.assertEquals(options.text_front, 'rules')
-        self.assertEquals(options.text_back, 'blank')
+def test_text_card_card():
+    options = main.parse_opts(
+        ['--front', 'card', '--back', 'card'])
+    assert options.text_front == 'card'
+    assert options.text_back == 'card'
 
-    def test_text_rules_card(self):
-        options = main.parse_opts(
-            ['--front', 'rules', '--back', 'card'])
-        self.assertEquals(options.text_front, 'rules')
-        self.assertEquals(options.text_back, 'card')
 
-    def test_text_rules_none(self):
-        options = main.parse_opts(
-            ['--front', 'rules', '--back', 'none'])
-        self.assertEquals(options.text_front, 'rules')
-        self.assertEquals(options.text_back, 'none')
+def test_text_card_none():
+    options = main.parse_opts(
+        ['--front', 'card', '--back', 'none'])
+    assert options.text_front == 'card'
+    assert options.text_back == 'none'
 
-    def test_text_blank_rules(self):
-        options = main.parse_opts(
-            ['--front', 'blank', '--back', 'rules'])
-        self.assertEquals(options.text_front, 'blank')
-        self.assertEquals(options.text_back, 'rules')
 
-    def test_text_blank_blank(self):
-        options = main.parse_opts(
-            ['--front', 'blank', '--back', 'blank'])
-        self.assertEquals(options.text_front, 'blank')
-        self.assertEquals(options.text_back, 'blank')
+def test_text_rules_rules():
+    options = main.parse_opts(
+        ['--front', 'rules', '--back', 'rules'])
+    assert options.text_front == 'rules'
+    assert options.text_back == 'rules'
 
-    def test_text_blank_card(self):
-        options = main.parse_opts(
-            ['--front', 'blank', '--back', 'card'])
-        self.assertEquals(options.text_front, 'blank')
-        self.assertEquals(options.text_back, 'card')
 
-    def test_text_blank_none(self):
-        options = main.parse_opts(
-            ['--front', 'blank', '--back', 'none'])
-        self.assertEquals(options.text_front, 'blank')
-        self.assertEquals(options.text_back, 'none')
+def test_text_rules_blank():
+    options = main.parse_opts(
+        ['--front', 'rules', '--back', 'blank'])
+    assert options.text_front == 'rules'
+    assert options.text_back == 'blank'
 
-    ####################
-    # Card Tab Tests
-    ####################
-    # --tab_name_align left
-    def test_tab_left_left(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'left', '--tab-side', 'left'])
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'left')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'left')
 
-    def test_tab_left_right(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'left', '--tab-side', 'right'])
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'right')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'right')
+def test_text_rules_card():
+    options = main.parse_opts(
+        ['--front', 'rules', '--back', 'card'])
+    assert options.text_front == 'rules'
+    assert options.text_back == 'card'
 
-    def test_tab_left_leftalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'left', '--tab-side',
-             'left-alternate'])
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'left-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'left-alternate')
 
-    def test_tab_left_rightalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'left', '--tab-side',
-             'right-alternate'])
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'right-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'right-alternate')
+def test_text_rules_none():
+    options = main.parse_opts(
+        ['--front', 'rules', '--back', 'none'])
+    assert options.text_front == 'rules'
+    assert options.text_back == 'none'
 
-    def test_tab_left_full(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'left', '--tab-side', 'full'])
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'full')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'left')
-        self.assertEquals(options.tab_side, 'full')
 
-        # --tab_name_align right
-    def test_tab_right_left(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'right', '--tab-side', 'left'])
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'left')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'left')
+def test_text_blank_rules():
+    options = main.parse_opts(
+        ['--front', 'blank', '--back', 'rules'])
+    assert options.text_front == 'blank'
+    assert options.text_back == 'rules'
 
-    def test_tab_right_right(self):
-        options = main.parse_opts(['--tab-name-align',
-                                   'right', '--tab-side', 'right'])
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'right')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'right')
 
-    def test_tab_right_leftalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'right', '--tab-side',
-             'left-alternate'])
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'left-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'left-alternate')
+def test_text_blank_blank():
+    options = main.parse_opts(
+        ['--front', 'blank', '--back', 'blank'])
+    assert options.text_front == 'blank'
+    assert options.text_back == 'blank'
 
-    def test_tab_right_rightalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'right', '--tab-side',
-             'right-alternate'])
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'right-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'right-alternate')
 
-    def test_tab_right_full(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'right', '--tab-side', 'full'])
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'full')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'right')
-        self.assertEquals(options.tab_side, 'full')
+def test_text_blank_card():
+    options = main.parse_opts(
+        ['--front', 'blank', '--back', 'card'])
+    assert options.text_front == 'blank'
+    assert options.text_back == 'card'
 
-    # --tab_name_align edge
-    def test_tab_edge_left(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'edge', '--tab-side', 'left'])
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'left')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'left')
 
-    def test_tab_edge_right(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'edge', '--tab-side', 'right'])
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'right')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'right')
+def test_text_blank_none():
+    options = main.parse_opts(
+        ['--front', 'blank', '--back', 'none'])
+    assert options.text_front == 'blank'
+    assert options.text_back == 'none'
 
-    def test_tab_edge_leftalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'edge', '--tab-side',
-             'left-alternate'])
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'left-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'left-alternate')
+####################
+# Card Tab Tests
+####################
+# --tab_name_align left
 
-    def test_tab_edge_rightalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'edge', '--tab-side',
-             'right-alternate'])
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'right-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'right-alternate')
 
-    def test_tab_edge_full(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'edge', '--tab-side', 'full'])
-        self.assertEquals(options.tab_name_align, 'edge')
-        self.assertEquals(options.tab_side, 'full')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align,
-                          'left')  # special check for odd condition
-        self.assertEquals(options.tab_side, 'full')
+def test_tab_left_left():
+    options = main.parse_opts(
+        ['--tab-name-align', 'left', '--tab-side', 'left'])
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'left'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'left'
 
-        # --tab_name_align centre
-    def test_tab_centre_left(self):
-        options = main.parse_opts(['--tab-name-align',
-                                   'centre', '--tab-side', 'left'])
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'left')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'left')
 
-    def test_tab_centre_right(self):
-        options = main.parse_opts(['--tab-name-align',
-                                   'centre', '--tab-side', 'right'])
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'right')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'right')
+def test_tab_left_right():
+    options = main.parse_opts(
+        ['--tab-name-align', 'left', '--tab-side', 'right'])
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'right'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'right'
 
-    def test_tab_centre_leftalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'centre', '--tab-side',
-             'left-alternate'])
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'left-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'left-alternate')
 
-    def test_tab_centre_rightalt(self):
-        options = main.parse_opts(
-            ['--tab-name-align', 'centre', '--tab-side',
-             'right-alternate'])
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'right-alternate')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'right-alternate')
+def test_tab_left_leftalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'left', '--tab-side', 'left-alternate'])
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'left-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'left-alternate'
 
-    def test_tab_centre_full(self):
-        options = main.parse_opts(['--tab-name-align',
-                                   'centre', '--tab-side', 'full'])
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'full')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align, 'centre')
-        self.assertEquals(options.tab_side, 'full')
 
-    # --tab_name_align center.  Just do one since this is an alias to centre
-    def test_tab_center_left(self):
-        options = main.parse_opts(['--tab-name-align',
-                                   'center', '--tab-side', 'left'])
-        self.assertEquals(options.tab_name_align, 'center')
-        self.assertEquals(options.tab_side, 'left')
-        main.calculate_layout(options)
-        self.assertEquals(options.tab_name_align,
-                          'centre')  # check for change in value
-        self.assertEquals(options.tab_side, 'left')
+def test_tab_left_rightalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'left', '--tab-side', 'right-alternate'])
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'right-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'right-alternate'
+
+
+def test_tab_left_full():
+    options = main.parse_opts(
+        ['--tab-name-align', 'left', '--tab-side', 'full'])
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'full'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'
+    assert options.tab_side == 'full'
+
+    # --tab_name_align right
+
+
+def test_tab_right_left():
+    options = main.parse_opts(
+        ['--tab-name-align', 'right', '--tab-side', 'left'])
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'left'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'left'
+
+
+def test_tab_right_right():
+    options = main.parse_opts(['--tab-name-align', 'right', '--tab-side', 'right'])
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'right'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'right'
+
+
+def test_tab_right_leftalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'right', '--tab-side', 'left-alternate'])
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'left-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'left-alternate'
+
+
+def test_tab_right_rightalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'right', '--tab-side', 'right-alternate'])
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'right-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'right-alternate'
+
+
+def test_tab_right_full():
+    options = main.parse_opts(
+        ['--tab-name-align', 'right', '--tab-side', 'full'])
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'full'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'right'
+    assert options.tab_side == 'full'
+
+# --tab_name_align edge
+
+
+def test_tab_edge_left():
+    options = main.parse_opts(
+        ['--tab-name-align', 'edge', '--tab-side', 'left'])
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'left'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'left'
+
+
+def test_tab_edge_right():
+    options = main.parse_opts(
+        ['--tab-name-align', 'edge', '--tab-side', 'right'])
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'right'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'right'
+
+
+def test_tab_edge_leftalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'edge', '--tab-side', 'left-alternate'])
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'left-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'left-alternate'
+
+
+def test_tab_edge_rightalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'edge', '--tab-side', 'right-alternate'])
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'right-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'right-alternate'
+
+
+def test_tab_edge_full():
+    options = main.parse_opts(
+        ['--tab-name-align', 'edge', '--tab-side', 'full'])
+    assert options.tab_name_align == 'edge'
+    assert options.tab_side == 'full'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'left'  # special check for odd condition
+    assert options.tab_side == 'full'
+
+    # --tab_name_align centre
+
+
+def test_tab_centre_left():
+    options = main.parse_opts(['--tab-name-align', 'centre', '--tab-side', 'left'])
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'left'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'left'
+
+
+def test_tab_centre_right():
+    options = main.parse_opts(['--tab-name-align', 'centre', '--tab-side', 'right'])
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'right'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'right'
+
+
+def test_tab_centre_leftalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'centre', '--tab-side', 'left-alternate'])
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'left-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'left-alternate'
+
+
+def test_tab_centre_rightalt():
+    options = main.parse_opts(
+        ['--tab-name-align', 'centre', '--tab-side', 'right-alternate'])
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'right-alternate'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'right-alternate'
+
+
+def test_tab_centre_full():
+    options = main.parse_opts(['--tab-name-align', 'centre', '--tab-side', 'full'])
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'full'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'
+    assert options.tab_side == 'full'
+
+# --tab_name_align center.  Just do one since this is an alias to centre
+
+
+def test_tab_center_left():
+    options = main.parse_opts(['--tab-name-align', 'center', '--tab-side', 'left'])
+    assert options.tab_name_align == 'center'
+    assert options.tab_side == 'left'
+    main.calculate_layout(options)
+    assert options.tab_name_align == 'centre'  # check for change in value
+    assert options.tab_side == 'left'

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=["reportlab>=3.4.0",
                       "Pillow>=4.1.0"],
+    tests_require=["pytest", "pycodestyle"],
     url='http://domtabs.sandflea.org',
     include_package_data=True,
     author="Peter Gorniak",


### PR DESCRIPTION
This is a minimal integration of @wvoigt's language fix up tool into the unit tests. Mainly makes sure that if we run the language tool and diff the output to what's checked into the `domdiv` package there are no important differences - especially, nothing got reverted to English because the 'untranslated' field was not updated. This is the main mistake I've seen from helpful contributions providing translations.

This PR also
- minimally turns the language tool into a more easily runnable script by taking arguments and not assuming that it's run from a specific directory
- switches testing to py.test - it seems to be the thing nowadays, and I have more experience with it than other frameworks