### PR TITLE
Fix Dutch Adventurer translation

### DIFF
--- a/domdiv/card_db/nl_du/cards_nl_du.json
+++ b/domdiv/card_db/nl_du/cards_nl_du.json
@@ -729,7 +729,7 @@
     "Adventurer": {
         "description": "Draai achtereenvolgens de bovenste kaarten van je trekstapel om totdat je in totaal 2 geldkaarten hebt. Neem ze op handen. Leg de overige omgedraaide kaarten op je aflegstapel.", 
         "extra": " Als je trekstapel uitgeput raakt, schud dan je aflegstapel. Schud de omgedraaide kaarten niet. Deze komen pas op de aflegstapel, nadat je het omdraaien helemaal hebt voltooid. Als je na het omdraaien van alle kaarten maar één geldkaart hebt, krijg je uitsluitend deze.", 
-        "name": "Advonturier"
+        "name": "Avonturier"
     },
     "Chancellor": {
         "description": "+2 Coins\nJe mag je trekstapel direct op je aflegstapel leggen.", 


### PR DESCRIPTION
The Dutch translation of the name of the Adventurer card was incorrect. This commit fixes that translation.

Source: http://wiki.dominionstrategy.com/index.php/Adventurer