### PR TITLE
exclude start deck from randomizer

### DIFF
--- a/domdiv/card_db/cards_db.json
+++ b/domdiv/card_db/cards_db.json
@@ -888,6 +888,7 @@
     ], 
     "cost": "", 
     "count": "0", 
+    "randomizer": false, 
     "types": [
         "Start Deck"
     ]


### PR DESCRIPTION
As the start deck will always be there, IMHO it should not be included in a randomizer (there is no Start Deck randomizer card in Dominion sets). 