### PR TITLE
Add only-type-any and only-type-all options

### DIFF
--- a/domdiv/main.py
+++ b/domdiv/main.py
@@ -335,8 +335,7 @@ def parse_opts(cmdline_args=None):
         "'*' any number of characters, '?' matches any single character, "
         "'[seq]' matches any character in seq, and '[!seq]' matches any character not in seq. "
         "For example, 'dominion*' will match all expansions that start with 'dominion'. "
-        "Choices available in all languages include: %s" %
-        ", ".join("%s" % x for x in EXPANSION_CHOICES))
+        "Choices available in all languages include: {}".format(", ".join("%s" % x for x in EXPANSION_CHOICES)))
     group_select.add_argument(
         "--fan",
         nargs="*",
@@ -350,8 +349,7 @@ def parse_opts(cmdline_args=None):
         "Values are not case sensitive. Wildcards may be used: "
         "'*' any number of characters, '?' matches any single character, "
         "'[seq]' matches any character in seq, and '[!seq]' matches any character not in seq. "
-        "Choices available in all languages include: %s" %
-        ", ".join("%s" % x for x in FAN_CHOICES))
+        "Choices available in all languages include: {}".format(", ".join("%s" % x for x in FAN_CHOICES)))
     group_select.add_argument(
         "--edition",
         choices=EDITION_CHOICES,
@@ -413,23 +411,21 @@ def parse_opts(cmdline_args=None):
         action="append",
         dest="only_type_any",
         help="Limit dividers to only those with the specified types. "
-        "A divider is kept if ANY of the provided types are associated with the divider."
+        "A divider is kept if ANY of the provided types are associated with the divider. "
         "Default is all types are included. "
         "Any type with a space in the name must be enclosed in double quotes. "
         "Values are not case sensitive. "
-        "Choices available in all languages include: %s" %
-        ", ".join("%s" % x for x in TYPE_CHOICES))
+        "Choices available in all languages include: {}".format(", ".join("%s" % x for x in TYPE_CHOICES)))
     group_select.add_argument(
         "--only-type-all", "--type-all",
         nargs="*",
         action="append",
         dest="only_type_all",
         help="Limit dividers to only those with the specified types. "
-        "A divider is kept if ALL of the provided types are associated with the divider."
+        "A divider is kept if ALL of the provided types are associated with the divider. "
         "Any type with a space in the name must be enclosed in double quotes. "
         "Values are not case sensitive. "
-        "Choices available in all languages include: %s" %
-        ", ".join("%s" % x for x in TYPE_CHOICES))
+        "Choices available in all languages include: {}".format(", ".join("%s" % x for x in TYPE_CHOICES)))
 
     # Divider Sleeves/Wrappers
     group_wrapper = parser.add_argument_group(
@@ -1460,8 +1456,7 @@ def filter_sort_cards(cards, options):
                 type_unknown.append(x)
 
         # Indicate if unknown types are given
-        if type_unknown:
-            print(("Error - unknown type(s): {}".format(", ".join(type_unknown))))
+        assert not type_unknown, "Error - unknown type(s): {}".format(", ".join(type_unknown))
 
         # If there are any valid Types left, go through the cards and keep cards that match
         if type_known_any or type_known_all:

--- a/domdiv/tests/carddb_tests.py
+++ b/domdiv/tests/carddb_tests.py
@@ -111,3 +111,19 @@ def test_languagetool_run(pytestconfig):
         except subprocess.CalledProcessError as e:
             assert e.output == ''
         assert out.decode('utf-8') == ''
+
+
+def test_only_type():
+    options = main.parse_opts(['--expansions', 'base', 'alchemy',
+                               '--include-blanks', '5',
+                               '--only-type-any', 'blank', 'curse',
+                               '--only-type-all', 'attack', 'action'])
+    options = main.clean_opts(options)
+    options.data_path = '.'
+    cards = main.read_card_data(options)
+    cards = main.filter_sort_cards(cards, options)
+    # Total 8 from
+    #      Blank:         +5 added in options
+    #      Curse:         +1 from base
+    #      Action Attack: +2 from Alchemy
+    assert len(cards) == 8

--- a/tools/update_language.py
+++ b/tools/update_language.py
@@ -408,7 +408,7 @@ def main(args):
                 else:
                     if lang != LANGUAGE_DEFAULT:
                         for x in lang_default[s]:
-                            if x not in lang_set_data[s] and x is not 'used':
+                            if x not in lang_set_data[s] and x != 'used':
                                 lang_set_data[s][x] = lang_default[s][x]
 
                 lang_out.write(json_dict_entry({s: lang_set_data[s]}, sep))


### PR DESCRIPTION
Inspired by Issue #240  I think this solves that issue as well as provides some added function.

This adds two new options that limit/reduce the number of dividers to the matching type(s) given. This would happen after any other options are used to select expansions, group cards, etc. Basically this is done right before the dividers are sorted just before they are printed.

* `--only-type-any,` alias `--type-any`, alias `--only-type`
  keeps any dividers that have _any_ of specified types
* `--only-type-all`, alias `--type-all`
  keeps any dividers that match _all_ of the specified types

For example:
`--only-type-any project expansion` would include in the output only expansion and project dividers
`--only-type-all duration attack` would include in the output only dividers that had both duration and attack types.
`--only-type-any landmark --only-type-all duration action` would include in the output any landmark dividers AND any dividers that had both duration and action.

Matches would be to these type names or their corresponding text in the language specified. All case insensitive. 

In addition, instead of using a hard coded list in main.py of all the supported types, code was added to automitically pull the supported types from a json file.   After implementing it, I thought a similar technique should be used for getting the supported expansions.  This way, a new expansion is automatically picked up as soon as the json set file is updated.