### PR TITLE
allow cost / set-icon to be displayed in body-top ONLY

### DIFF
--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -296,19 +296,19 @@ def parse_opts(cmdline_args=None):
         "--cost",
         action="append",
         choices=LOCATION_CHOICES,
-        default=["tab"],
         help="Where to display the card cost; may be set to "
         "'hide' to indicate it should not be displayed, or "
-        "given multiple times to show it in multiple places.",
+        "given multiple times to show it in multiple places. "
+        "(If not given, will default to 'tab'.)",
     )
     group_tab.add_argument(
         "--set-icon",
         action="append",
         choices=LOCATION_CHOICES,
-        default=["tab"],
         help="Where to display the set icon; may be set to "
         "'hide' to indicate it should not be displayed, or "
-        "given multiple times to show it in multiple places.",
+        "given multiple times to show it in multiple places. "
+        "(If not given, will default to 'tab'.)",
     )
     group_tab.add_argument(
         "--no-tab-artwork",
@@ -737,6 +737,12 @@ def clean_opts(options):
     if options.tab_number < 3 and options.tab_serpentine:
         print("** Warning: --tab-serpentine only valid if --tab-number > 2. **")
         options.tab_serpentine = False
+
+    if options.cost is None:
+        options.cost = ["tab"]
+
+    if options.set_icon is None:
+        options.set_icon = ["tab"]
 
     if options.sleeved_thick:
         options.thickness = 3.2

--- a/tests/layout_tests.py
+++ b/tests/layout_tests.py
@@ -32,3 +32,47 @@ def test_sleeved():
     assert options.dividerWidth == 9.4 * cm
     assert options.labelHeight == 0.9 * cm
     assert options.dividerHeight == 6.15 * cm + options.labelHeight
+
+
+def test_cost():
+    options = main.parse_opts([])
+    options = main.clean_opts(options)
+    assert options.cost == ["tab"]
+
+    options = main.parse_opts(["--cost=tab"])
+    options = main.clean_opts(options)
+    assert options.cost == ["tab"]
+
+    options = main.parse_opts(["--cost=body-top"])
+    options = main.clean_opts(options)
+    assert options.cost == ["body-top"]
+
+    options = main.parse_opts(["--cost=hide"])
+    options = main.clean_opts(options)
+    assert options.cost == ["hide"]
+
+    options = main.parse_opts(["--cost=tab", "--cost=body-top"])
+    options = main.clean_opts(options)
+    assert set(options.cost) == {"tab", "body-top"}
+
+
+def test_set_icon():
+    options = main.parse_opts([])
+    options = main.clean_opts(options)
+    assert options.set_icon == ["tab"]
+
+    options = main.parse_opts(["--set-icon=tab"])
+    options = main.clean_opts(options)
+    assert options.set_icon == ["tab"]
+
+    options = main.parse_opts(["--set-icon=body-top"])
+    options = main.clean_opts(options)
+    assert options.set_icon == ["body-top"]
+
+    options = main.parse_opts(["--set-icon=hide"])
+    options = main.clean_opts(options)
+    assert options.set_icon == ["hide"]
+
+    options = main.parse_opts(["--set-icon=tab", "--set-icon=body-top"])
+    options = main.clean_opts(options)
+    assert set(options.set_icon) == {"tab", "body-top"}


### PR DESCRIPTION
previously, if you used, ie, "--cost=body-top", the cost would show in
the tab AND body-top.  Since the help text implies that the way to
accomplish this should be "--cost=tab --cost=body-top" (and because if you
put it in body-top, it's probably because you want to save space on the
tab)