### PR TITLE
Fix setNames intruding into dividers when back_offset_height given negative value

### DIFF
--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1975,39 +1975,35 @@ class DividerDrawer(object):
         for pageNum, pageInfo in enumerate(self.pages):
             hMargin, vMargin, page = pageInfo
 
-            # Front page footer
-            if not self.options.no_page_footer and (
+            drawFooter = not self.options.no_page_footer and (
                 not self.options.tabs_only and self.options.order != "global"
-            ):
-                self.drawSetNames(page)
+            )
 
-            # Front page
-            for item in page:
-                # print the dividor
-                self.drawDivider(
-                    item, isBack=False, horizontalMargin=hMargin, verticalMargin=vMargin
-                )
-            self.canvas.showPage()
-            if pageNum + 1 == self.options.num_pages:
-                break
             if (
                 self.options.tabs_only
                 or self.options.text_back == "none"
                 or self.options.wrapper
             ):
                 # Don't print the sheets with the back of the dividers
-                continue
+                backSides = [False]
+            else:
+                backSides = [False, True]
 
-            # back page footer
-            if not self.options.no_page_footer and self.options.order != "global":
-                self.drawSetNames(page)
+            for isBack in backSides:
+                # Page footer
+                if drawFooter:
+                    self.drawSetNames(page)
 
-            # Back page
-            for item in page:
-                # print the dividor
-                self.drawDivider(
-                    item, isBack=True, horizontalMargin=hMargin, verticalMargin=vMargin
-                )
-            self.canvas.showPage()
+                # Page
+                for item in page:
+                    # print the dividor
+                    self.drawDivider(
+                        item,
+                        isBack=isBack,
+                        horizontalMargin=hMargin,
+                        verticalMargin=vMargin,
+                    )
+                self.canvas.showPage()
+
             if pageNum + 1 == self.options.num_pages:
                 break

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1573,8 +1573,6 @@ class DividerDrawer(object):
             font = pdfmetrics.getFont(fontname)
             fontHeightRelative = (font.face.ascent + abs(font.face.descent)) / 1000.0
 
-            canFit = False
-
             layouts = [
                 {
                     "rotation": 0,
@@ -1592,21 +1590,29 @@ class DividerDrawer(object):
                 },
             ]
 
-            for layout in layouts:
+            # Pick whether to print setnames horizontally along bottom
+            # (i=0) or vertically along left (i=1).  We pick whichever has more
+            # space.
+            fontsize = 0
+            maxAvailableMargin = 0
+            layoutIndex = -1
+            for i, layout in enumerate(layouts):
                 availableMargin = (
                     layout["totalMarginHeight"] - layout["minMarginHeight"]
                 )
-                fontsize = availableMargin / fontHeightRelative
-                fontsize = min(maxFontsize, fontsize)
-                if fontsize >= minFontsize:
-                    canFit = True
-                    break
+                if availableMargin > maxAvailableMargin:
+                    maxAvailableMargin = availableMargin
+                    fontsize = availableMargin / fontHeightRelative
+                    fontsize = min(maxFontsize, fontsize)
+                    layoutIndex = i
 
-            if not canFit:
+            if fontsize < minFontsize:
                 import warnings
 
                 warnings.warn("Not enough space to display set names")
                 return
+
+            layout = layouts[layoutIndex]
 
             self.canvas.setFont(fontname, fontsize)
 

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1561,7 +1561,7 @@ class DividerDrawer(object):
         # retore the canvas state to the way we found it
         self.canvas.restoreState()
 
-    def drawSetNames(self, pageItems):
+    def drawSetNames(self, pageItems, backside=False):
         # print sets for this page
         self.canvas.saveState()
 
@@ -1579,13 +1579,15 @@ class DividerDrawer(object):
                 {
                     "rotation": 0,
                     "minMarginHeight": self.options.minVerticalMargin,
-                    "totalMarginHeight": self.options.verticalMargin,
+                    "totalMarginHeight": self.options.verticalMargin
+                    + (self.options.back_offset_height if backside else 0),
                     "width": self.options.paperwidth,
                 },
                 {
                     "rotation": 90,
                     "minMarginHeight": self.options.minHorizontalMargin,
-                    "totalMarginHeight": self.options.horizontalMargin,
+                    "totalMarginHeight": self.options.horizontalMargin
+                    + (-self.options.back_offset if backside else 0),
                     "width": self.options.paperheight,
                 },
             ]
@@ -1988,7 +1990,7 @@ class DividerDrawer(object):
             for isBack in backSides:
                 # Page footer
                 if drawFooter:
-                    self.drawSetNames(page)
+                    self.drawSetNames(page, isBack)
 
                 # Page
                 for item in page:

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1608,24 +1608,20 @@ class DividerDrawer(object):
 
             self.canvas.setFont(fontname, fontsize)
 
+            # Centered on page
             xPos = layout["width"] / 2
             # Place at the very edge of the margin
             yPos = layout["minMarginHeight"]
+
+            if layout["rotation"]:
+                self.canvas.rotate(layout["rotation"])
+                yPos = -yPos
 
             sets = []
             for item in pageItems:
                 setTitle = item.card.cardset.title()
                 if setTitle not in sets:
                     sets.append(setTitle)
-
-                # Centered on page
-                xPos = layout["width"] / 2
-                # Place at the very edge of the margin
-                yPos = layout["minMarginHeight"]
-
-                if layout["rotation"]:
-                    self.canvas.rotate(layout["rotation"])
-                    yPos = -yPos
 
             self.canvas.drawCentredString(xPos, yPos, "/".join(sets))
         finally:


### PR DESCRIPTION
So, I encountered a situation where when I used `--back_offset_height -10`, the setName text was intruding into the divider back.

Apparently the code for printing the dividers doesn't take the back offset settings into account, so I fixed it so that it at least uses it in it's calculations for the available space.

This made the location alternate between bottom (for front) and left (for back), which felt a bit odd, so I also made the code just place the setNames on whichever side has the most space, which is probably a good idea in general.

The commit breakdown is:

- The first two commits (46450c923b2d1d6c1ff7cf88da8f764998dc970f and d9070a62e57ff4910b29e34ad745141c9f651fcc) clean up and consolidate code (in ways that make subsequent commits easier)
- 55dbc01c667a827e342b2fc69f4dde066880d5ab fixes setName placement calculation to account for back_offset and back_offset_height
- 277c895a7dd4889910abb6ec435939d99ea9cf25 makes setNames print on whichever side has more space (instead of only printing on left if it's impossible to print on bottom)