### PR TITLE
Fix cards list order for accents in expansion card

### DIFF
--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -1655,7 +1655,8 @@ def filter_sort_cards(cards, options):
                     "name": c.name.strip().replace(" ", "&nbsp;"),
                     "randomizer": c.randomizer,
                     "count": 1,
-                    "sort": "%03d%s" % (order, c.name.strip()),
+                    "sort": "%03d%s"
+                    % (order, CardSorter.strip_accents(c.name.strip())),
                 }
 
         for set_tag, set_values in Card.sets.items():


### PR DESCRIPTION
Thank you so much for this incredible project!

Here is a bug fix: expansion card didn't sort cards list in the true alphabetical order, like the other part of the code did.

For example, the cards for the french expansion Hinterlands were printed in the correct order (the alternation of left and right tabs were correct), but the expansion summary card did not.

Expected: `[…] 'Complot', 'Développement', 'Duchesse', 'Écuries', 'Mandarin', […]`
Actual: `[…] 'Complot', 'Duchesse', 'Développement', 'Mandarin', […], 'Écuries'`