### PR TITLE
Fixes for #284 #295 #296 #248

### DIFF
--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -129,6 +129,7 @@ class CardPlot(object):
         cropOnLeft=False,
         cropOnRight=False,
     ):
+
         self.card = card
         self.x = x  # x location of the lower left corner of the card on the page
         self.y = y  # y location of the lower left corner of the card on the page
@@ -641,8 +642,8 @@ class DividerDrawer(object):
         return pageCount
 
     def wantCentreTab(self, card):
-        return (
-            card.isExpansion() and self.options.centre_expansion_dividers
+        return ( card.isExpansion() and 
+                (self.options.centre_expansion_dividers or self.options.full_expansion_dividers)
         ) or self.options.tab_side == "centre"
 
     def drawOutline(self, item, isBack=False):
@@ -672,7 +673,7 @@ class DividerDrawer(object):
         theTabWidth = item.tabWidth
         theTabHeight = item.tabHeight
 
-        left2tab = item.getTabOffset(backside=isBack)
+        left2tab = item.getTabOffset(backside=False) # translate/scale above takes care of backside
         right2tab = dividerWidth - tabLabelWidth - left2tab
         nearZero = 0.01
         left2tab = left2tab if left2tab > nearZero else 0
@@ -1908,7 +1909,9 @@ class DividerDrawer(object):
                 if lastCardSet != card.cardset_tag:
                     # In a new expansion, so reset the tabs to start over
                     nextTabIndex = CardPlot.tabRestart()
-                    if options.tab_number > Card.sets[card.cardset_tag]["count"]:
+                    if (options.tab_number > Card.sets[card.cardset_tag]["count"] and 
+                        Card.sets[card.cardset_tag]["count"] > 0):
+
                         #  Limit to the number of tabs to the number of dividers in the expansion
                         CardPlot.tabSetup(
                             tabNumber=Card.sets[card.cardset_tag]["count"]
@@ -1932,6 +1935,13 @@ class DividerDrawer(object):
                 textTypeBack=options.text_back,
                 stackHeight=card.getStackHeight(options.thickness),
             )
+            #WGV
+            if card.isExpansion() and options.full_expansion_dividers:
+                # Fix up the item to have a full tab with text centred
+                item.tabWidth = cardWidth
+                item.tabNumber = 1
+                item.tabOffset = 0
+            #WGV
             if (
                 options.flip
                 and (options.tab_number == 2)

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -641,8 +641,12 @@ class DividerDrawer(object):
         return pageCount
 
     def wantCentreTab(self, card):
-        return ( card.isExpansion() and 
-                (self.options.centre_expansion_dividers or self.options.full_expansion_dividers)
+        return (
+            card.isExpansion()
+            and (
+                self.options.centre_expansion_dividers
+                or self.options.full_expansion_dividers
+            )
         ) or self.options.tab_side == "centre"
 
     def drawOutline(self, item, isBack=False):
@@ -672,7 +676,9 @@ class DividerDrawer(object):
         theTabWidth = item.tabWidth
         theTabHeight = item.tabHeight
 
-        left2tab = item.getTabOffset(backside=False) # translate/scale above takes care of backside
+        left2tab = item.getTabOffset(
+            backside=False
+        )  # translate/scale above takes care of backside
         right2tab = dividerWidth - tabLabelWidth - left2tab
         nearZero = 0.01
         left2tab = left2tab if left2tab > nearZero else 0
@@ -1912,8 +1918,10 @@ class DividerDrawer(object):
                 if lastCardSet != card.cardset_tag:
                     # In a new expansion, so reset the tabs to start over
                     nextTabIndex = CardPlot.tabRestart()
-                    if (options.tab_number > Card.sets[card.cardset_tag]["count"] and 
-                        Card.sets[card.cardset_tag]["count"] > 0):
+                    if (
+                        options.tab_number > Card.sets[card.cardset_tag]["count"]
+                        and Card.sets[card.cardset_tag]["count"] > 0
+                    ):
 
                         #  Limit to the number of tabs to the number of dividers in the expansion
                         CardPlot.tabSetup(

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -129,7 +129,6 @@ class CardPlot(object):
         cropOnLeft=False,
         cropOnRight=False,
     ):
-
         self.card = card
         self.x = x  # x location of the lower left corner of the card on the page
         self.y = y  # y location of the lower left corner of the card on the page
@@ -1935,13 +1934,13 @@ class DividerDrawer(object):
                 textTypeBack=options.text_back,
                 stackHeight=card.getStackHeight(options.thickness),
             )
-            #WGV
+
             if card.isExpansion() and options.full_expansion_dividers:
                 # Fix up the item to have a full tab with text centred
                 item.tabWidth = cardWidth
                 item.tabNumber = 1
                 item.tabOffset = 0
-            #WGV
+
             if (
                 options.flip
                 and (options.tab_number == 2)

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1551,6 +1551,10 @@ class DividerDrawer(object):
                 self.options.back_offset, self.options.back_offset_height
             )
             pageWidth -= 2 * self.options.back_offset
+        else:
+            self.canvas.translate(
+                self.options.front_offset, self.options.front_offset_height
+            )
 
         item.translate(self.canvas, pageWidth, isBack)
 

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -344,7 +344,13 @@ def parse_opts(cmdline_args=None):
         "--centre-expansion-dividers",
         action="store_true",
         dest="centre_expansion_dividers",
-        help="Centre the tabs on expansion dividers.",
+        help="Centre the tabs on expansion dividers (same width as dividers.)",
+    )
+    group_expansion.add_argument(
+        "--full-expansion-dividers",
+        action="store_true",
+        dest="full_expansion_dividers",
+        help="Full width expansion dividers.",
     )
     group_expansion.add_argument(
         "--expansion-reset-tabs",

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -596,6 +596,20 @@ def parse_opts(cmdline_args=None):
         help="Width of lines for card outlines and crop marks.",
     )
     group_printing.add_argument(
+        "--front-offset",
+        type=float,
+        dest="front_offset",
+        default=0,
+        help="Front page horizontal offset points to shift to the right. Only needed for some printers.",
+    )
+    group_printing.add_argument(
+        "--front-offset-height",
+        type=float,
+        dest="front_offset_height",
+        default=0,
+        help="Front page vertical offset points to shift upward. Only needed for some printers.",
+    )
+    group_printing.add_argument(
         "--back-offset",
         type=float,
         dest="back_offset",


### PR DESCRIPTION
Various changes to fix issues #284 #295 #296.
Added `--full-expansion-dividers` option to force expansion tabs to be full width with centered text.
