### PR TITLE
feat: added label sheet Herma 4201

### DIFF
--- a/src/domdiv/card_db/labels_db.json
+++ b/src/domdiv/card_db/labels_db.json
@@ -83,5 +83,22 @@
         "tab-height": 0.9,
         "tab-only": false,
         "width": 8.57
+    },
+    {
+        "gap-horizontal": 0.254,
+        "gap-vertical": 0.0,
+        "height": 1.693,
+        "margin-left": 0.975,
+        "margin-top": 1.306,
+        "name": "Label Herma 4201 A4",
+        "names": [
+            "H4201"
+        ],
+        "pad-horizontal": 0.2,
+        "pad-vertical": 0.2,
+        "paper": "A4",
+        "tab-height": 1.5,
+        "tab-only": true,
+        "width": 4.572
     }
 ]


### PR DESCRIPTION
I added config for these labels:

https://www.herma.com/office-home/product/tab-labels-a4-superprint-4201/

since they fit perfectly with these dividers:

https://www.bcwsupplies.com/trading-card-dividers-horizontal

![dominion-tabs](https://user-images.githubusercontent.com/7619889/77229029-a587fb80-6b8b-11ea-9a22-e7f2474bf247.jpeg)
