### PR TITLE
Fix for #247 Promo Card Icons

### DIFF
--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -190,9 +190,9 @@ class Card(object):
             self.potcost = other.potcost
             self.debtcost = other.debtcost
 
-    def setImage(self):
+    def setImage(self, use_set_icon=False):
         setImage = None
-        if self.image is not None:
+        if not use_set_icon and self.image is not None:
             setImage = self.image
         else:
             if self.cardset_tag in Card.sets:

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1255,7 +1255,7 @@ class DividerDrawer(object):
             self.canvas.drawCentredString(item.tabWidth - 10, textHeight + 2, setText)
             textInsetRight = 15
         else:
-            setImage = card.setImage()
+            setImage = card.setImage(self.options.use_set_icon)
             if setImage and "tab" in self.options.set_icon:
                 setImageHeight = 3 + card.getType().getTabTextHeightOffset()
 
@@ -1419,7 +1419,7 @@ class DividerDrawer(object):
 
         Image_x_right = item.cardWidth - 4
         if "body-top" in self.options.set_icon and not card.isExpansion():
-            setImage = card.setImage()
+            setImage = card.setImage(self.options.use_set_icon)
             if setImage:
                 Image_x_right -= 16
                 self.drawSetIcon(

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -328,6 +328,12 @@ def parse_opts(cmdline_args=None):
         dest="use_text_set_icon",
         help="Use text/letters to represent a card's set instead of the set icon.",
     )
+    group_tab.add_argument(
+        "--use-set-icon",
+        action="store_true",
+        dest="use_set_icon",
+        help="Use set icon instead of a card icon.  Applies to Promo cards.",
+    )
 
     # Expanion Dividers
     group_expansion = parser.add_argument_group(


### PR DESCRIPTION
Added `--use-set-icon` option to force cards with unique icons to instead use their standard set icon.  This really only applies to Promo cards.

This is a fix for Issue #247 