### PR TITLE
Fix issue#166

### DIFF
--- a/card_db_src/en_us/sets_en_us.json
+++ b/card_db_src/en_us/sets_en_us.json
@@ -14,6 +14,11 @@
         "set_text": "There are strange things going on in your basement laboratories. They keep calling up for more barrels of quicksilver, or bits of your hair. Well it's all in the name of progress. They're looking for a way to turn lead into gold, or at least into something better than lead. That lead had just been too good of a bargain to pass up; you didn't think, where will I put all this lead, what am I going to do with this lead anyway. Well that will all be sorted out. They're also looking for a universal solvent. If they manage that one, you will take whatever they use to hold it in and build a castle out of it. A castle that can't be dissolved! Now that's progress.\nThis is the 3rd addition to <i>Dominion</i>.",
         "text_icon": "A"
     },
+    "alchemy extras": {
+        "set_name": "Alchemy Extras",
+        "set_text": "",
+        "text_icon": "A"
+    },
     "animals": {
         "set_name": "Animals",
         "set_text": "<i>Dominion: Animals</i> is a fan created expansion for the card game <i>Dominion</i>. It contains three new kingdom cards: \"Rabbits\", \"Yard dog\", and \"Gray Mustang\".\nSee https://boardgamegeek.com/boardgameexpansion/203184/animals-expansion-mini-fan-expansion-dominion.",
@@ -50,10 +55,22 @@
         "short_name": "Dominion",
         "text_icon": "D1"
     },
+    "dominion1stEdition extras": {
+        "set_name": "Dominion 1st Edition Extras",
+        "set_text": "",
+        "short_name": "Dominion Extras",
+        "text_icon": "D1"
+    },
     "dominion2ndEdition": {
         "set_name": "Dominion 2nd Edition",
         "set_text": "You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.\nBut wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn't be proud, but your grandparents, on your mother's side, would be delighted.",
         "short_name": "Dominion",
+        "text_icon": "D2"
+    },
+    "dominion2ndEdition extras": {
+        "set_name": "Dominion 2nd Edition Extras",
+        "set_text": "",
+        "short_name": "Dominion Extras",
         "text_icon": "D2"
     },
     "dominion2ndEditionUpgrade": {
@@ -91,6 +108,12 @@
         "set_name": "Intrigue 1st Edition",
         "set_text": "Something's afoot. The steward smiles at you like he has a secret, or like he thinks you have a secret, or like you think he thinks you have a secret. There are secret plots brewing, you're sure of it. At the very least, there are yours. A passing servant murmurs, \"The eggs are on the plate.\" You frantically search your codebook for the translation before realizing he means that breakfast is ready. Excellent. Everything is going according to plan.\n<i>Dominion: Intrigue</i> adds rules for playing with up to 8 players at two tables or for playing a single game with up to 6 players when combined with <i>Dominion</i>. This game adds 25 new Kingdom cards and a complete set of Treasure and Victory cards. The game can be played alone by players experienced in <i>Dominion</i> or with the basic game of <i>Dominion</i>.",
         "short_name": "Intrigue",
+        "text_icon": "I1"
+    },
+    "intrigue1stEdition extras": {
+        "set_name": "Intrigue 1st Edition Extras",
+        "set_text": "",
+        "short_name": "Intrigue Extras",
         "text_icon": "I1"
     },
     "intrigue2ndEdition": {
@@ -136,9 +159,19 @@
         "set_text": "Ah, money. There's nothing like the sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands, or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You also have the world's smallest dog, and a life-size statue of yourself made out of baklava. Sure, money can't buy happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome neighbors that must be conquered. But this time, you'll conquer them in style.\nThis is the 4th addition to the game of <i>Dominion</i>. It adds 25 new Kingdom cards to <i>Dominion</i>, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards.",
         "text_icon": "P"
     },
+    "prosperity extras": {
+        "set_name": "Prosperity Extras",
+        "set_text": "",
+        "text_icon": "P"
+    },
     "renaissance": {
         "set_name": "Renaissance",
         "set_text": "It's a momentous time. Art has been revolutionized by the invention of \"perspective,\" and also of \"funding.\" A picture used to be worth a dozen or so words; these new ones are more like a hundred. Oil paintings have gotten so realistic that you've hired an artist to do a portrait of you each morning, so you can make sure your hair is good. Busts have gotten better too; no more stopping at the shoulders, they go all the way to the ground. Science and medicine have advanced; there's no more superstition, now they know the perfect number of leeches to apply for each ailment. You have a clock accurate to within an hour, and a calendar accurate to within a week. Your physician heals himself, and your barber cuts his own hair. This is truly a golden age.\nThis is the 12th expansion to <i>Dominion</i>. It has 300 cards, with 25 new Kingdom cards. There are tokens that let you save coins and actions for later, Projects that grant abilities, and Artifacts to fight over.",
+        "text_icon": "R"
+    },
+    "renaissance extras": {
+        "set_name": "Renaissance Extras",
+        "set_text": "",
         "text_icon": "R"
     },
     "seaside": {

--- a/card_db_src/sets_db.json
+++ b/card_db_src/sets_db.json
@@ -9,17 +9,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "adventures extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "adventures_set.png",
-        "no_randomizer": true,
-        "set_name": "*adventures extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "alchemy": {
         "edition": [
             "1",
@@ -49,6 +38,7 @@
         ],
         "image": "",
         "no_randomizer": true,
+        "has_extras": false,
         "set_name": "*base*",
         "set_text": "",
         "text_icon": "*"
@@ -63,17 +53,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "cornucopia extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "cornucopia_set.png",
-        "no_randomizer": true,
-        "set_name": "*cornucopia extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "dark ages": {
         "edition": [
             "1",
@@ -81,17 +60,6 @@
         ],
         "image": "dark_ages_set.png",
         "set_name": "*dark ages*",
-        "set_text": "",
-        "text_icon": "*"
-    },
-    "dark ages extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "dark_ages_set.png",
-        "no_randomizer": true,
-        "set_name": "*dark ages extras*",
         "set_text": "",
         "text_icon": "*"
     },
@@ -121,6 +89,8 @@
             "1"
         ],
         "image": "dominion2ndEdition_set.png",
+        "has_extras": false,
+        "upgrades": "dominion1stEdition",
         "set_name": "*dominion2ndEditionUpgrade*",
         "set_text": "",
         "text_icon": "*"
@@ -135,17 +105,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "empires extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "empires_set.png",
-        "no_randomizer": true,
-        "set_name": "*empires extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "extras": {
         "edition": [
             "1",
@@ -153,6 +112,7 @@
         ],
         "image": "",
         "no_randomizer": true,
+        "has_extras": false,
         "set_name": "*extras*",
         "set_text": "",
         "text_icon": "*"
@@ -203,6 +163,8 @@
             "1"
         ],
         "image": "intrigue2ndEdition_set.png",
+        "has_extras": false,
+        "upgrades": "intrigue1stEdition",
         "set_name": "*intrigue2ndEditionUpgrade*",
         "set_text": "",
         "text_icon": "*"
@@ -217,17 +179,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "menagerie extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "menagerie_set.png",
-        "no_randomizer": true,
-        "set_name": "*menagerie extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "nocturne": {
         "edition": [
             "1",
@@ -238,23 +189,13 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "nocturne extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "nocturne_set.png",
-        "no_randomizer": true,
-        "set_name": "*nocturne extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "promo": {
         "edition": [
             "1",
             "latest"
         ],
         "image": "promo_set.png",
+        "has_extras": false,
         "set_name": "*promo*",
         "set_text": "",
         "text_icon": "*"

--- a/card_db_src/types_db.json
+++ b/card_db_src/types_db.json
@@ -320,6 +320,8 @@
             "Event"
         ],
         "card_type_image": "event.png",
+        "group_cost": "*",
+        "group_global_type": "Events",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -329,6 +331,7 @@
             "Events"
         ],
         "card_type_image": "event.png",
+        "group_cost": "*",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -356,6 +359,8 @@
             "Landmark"
         ],
         "card_type_image": "landmark.png",
+        "group_cost": "",
+        "group_global_type": "Landmarks",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -365,6 +370,7 @@
             "Landmarks"
         ],
         "card_type_image": "landmark.png",
+        "group_cost": "",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -444,6 +450,8 @@
             "Project"
         ],
         "card_type_image": "project.png",
+        "group_cost": "*",
+        "group_global_type": "Projects",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -453,6 +461,7 @@
             "Projects"
         ],
         "card_type_image": "project.png",
+        "group_cost": "*",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -647,6 +656,8 @@
             "Way"
         ],
         "card_type_image": "way.png",
+        "group_cost": "",
+        "group_global_type": "Ways",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -656,6 +667,7 @@
             "Ways"
         ],
         "card_type_image": "way.png",
+        "group_cost": "",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0

--- a/src/domdiv/card_db/cz/sets_cz.json
+++ b/src/domdiv/card_db/cz/sets_cz.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/card_db/de/sets_de.json
+++ b/src/domdiv/card_db/de/sets_de.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/card_db/en_us/sets_en_us.json
+++ b/src/domdiv/card_db/en_us/sets_en_us.json
@@ -14,6 +14,11 @@
         "set_text": "There are strange things going on in your basement laboratories. They keep calling up for more barrels of quicksilver, or bits of your hair. Well it's all in the name of progress. They're looking for a way to turn lead into gold, or at least into something better than lead. That lead had just been too good of a bargain to pass up; you didn't think, where will I put all this lead, what am I going to do with this lead anyway. Well that will all be sorted out. They're also looking for a universal solvent. If they manage that one, you will take whatever they use to hold it in and build a castle out of it. A castle that can't be dissolved! Now that's progress.\nThis is the 3rd addition to <i>Dominion</i>.",
         "text_icon": "A"
     },
+    "alchemy extras": {
+        "set_name": "Alchemy Extras",
+        "set_text": "",
+        "text_icon": "A"
+    },
     "animals": {
         "set_name": "Animals",
         "set_text": "<i>Dominion: Animals</i> is a fan created expansion for the card game <i>Dominion</i>. It contains three new kingdom cards: \"Rabbits\", \"Yard dog\", and \"Gray Mustang\".\nSee https://boardgamegeek.com/boardgameexpansion/203184/animals-expansion-mini-fan-expansion-dominion.",
@@ -50,10 +55,22 @@
         "short_name": "Dominion",
         "text_icon": "D1"
     },
+    "dominion1stEdition extras": {
+        "set_name": "Dominion 1st Edition Extras",
+        "set_text": "",
+        "short_name": "Dominion Extras",
+        "text_icon": "D1"
+    },
     "dominion2ndEdition": {
         "set_name": "Dominion 2nd Edition",
         "set_text": "You are a monarch, like your parents before you, a ruler of a small pleasant kingdom of rivers and evergreens. Unlike your parents, however, you have hopes and dreams! You want a bigger and more pleasant kingdom, with more rivers and a wider variety of trees. You want a Dominion! In all directions lie fiefs, freeholds, and feodums. All are small bits of land, controlled by petty lords and verging on anarchy. You will bring civilization to these people, uniting them under your banner.\nBut wait! It must be something in the air; several other monarchs have had the exact same idea. You must race to get as much of the unclaimed land as possible, fending them off along the way. To do this you will hire minions, construct buildings, spruce up your castle, and fill the coffers of your treasury. Your parents wouldn't be proud, but your grandparents, on your mother's side, would be delighted.",
         "short_name": "Dominion",
+        "text_icon": "D2"
+    },
+    "dominion2ndEdition extras": {
+        "set_name": "Dominion 2nd Edition Extras",
+        "set_text": "",
+        "short_name": "Dominion Extras",
         "text_icon": "D2"
     },
     "dominion2ndEditionUpgrade": {
@@ -91,6 +108,12 @@
         "set_name": "Intrigue 1st Edition",
         "set_text": "Something's afoot. The steward smiles at you like he has a secret, or like he thinks you have a secret, or like you think he thinks you have a secret. There are secret plots brewing, you're sure of it. At the very least, there are yours. A passing servant murmurs, \"The eggs are on the plate.\" You frantically search your codebook for the translation before realizing he means that breakfast is ready. Excellent. Everything is going according to plan.\n<i>Dominion: Intrigue</i> adds rules for playing with up to 8 players at two tables or for playing a single game with up to 6 players when combined with <i>Dominion</i>. This game adds 25 new Kingdom cards and a complete set of Treasure and Victory cards. The game can be played alone by players experienced in <i>Dominion</i> or with the basic game of <i>Dominion</i>.",
         "short_name": "Intrigue",
+        "text_icon": "I1"
+    },
+    "intrigue1stEdition extras": {
+        "set_name": "Intrigue 1st Edition Extras",
+        "set_text": "",
+        "short_name": "Intrigue Extras",
         "text_icon": "I1"
     },
     "intrigue2ndEdition": {
@@ -136,9 +159,19 @@
         "set_text": "Ah, money. There's nothing like the sound of coins clinking in your hands. You vastly prefer it to the sound of coins clinking in someone else's hands, or the sound of coins just sitting there in a pile that no-one can quite reach without getting up. Getting up, that's all behind you now. Life has been good to you. Just ten years ago, you were tilling your own fields in a simple straw hat. Today, your kingdom stretches from sea to sea, and your straw hat is the largest the world has ever known. You also have the world's smallest dog, and a life-size statue of yourself made out of baklava. Sure, money can't buy happiness, but it can buy envy, anger, and also this kind of blank feeling. You still have problems - troublesome neighbors that must be conquered. But this time, you'll conquer them in style.\nThis is the 4th addition to the game of <i>Dominion</i>. It adds 25 new Kingdom cards to <i>Dominion</i>, plus 2 new Basic cards that let players keep building up past Gold and Province. The central theme is wealth; there are treasures with abilities, cards that interact with treasures, and powerful expensive cards.",
         "text_icon": "P"
     },
+    "prosperity extras": {
+        "set_name": "Prosperity Extras",
+        "set_text": "",
+        "text_icon": "P"
+    },
     "renaissance": {
         "set_name": "Renaissance",
         "set_text": "It's a momentous time. Art has been revolutionized by the invention of \"perspective,\" and also of \"funding.\" A picture used to be worth a dozen or so words; these new ones are more like a hundred. Oil paintings have gotten so realistic that you've hired an artist to do a portrait of you each morning, so you can make sure your hair is good. Busts have gotten better too; no more stopping at the shoulders, they go all the way to the ground. Science and medicine have advanced; there's no more superstition, now they know the perfect number of leeches to apply for each ailment. You have a clock accurate to within an hour, and a calendar accurate to within a week. Your physician heals himself, and your barber cuts his own hair. This is truly a golden age.\nThis is the 12th expansion to <i>Dominion</i>. It has 300 cards, with 25 new Kingdom cards. There are tokens that let you save coins and actions for later, Projects that grant abilities, and Artifacts to fight over.",
+        "text_icon": "R"
+    },
+    "renaissance extras": {
+        "set_name": "Renaissance Extras",
+        "set_text": "",
         "text_icon": "R"
     },
     "seaside": {

--- a/src/domdiv/card_db/fr/sets_fr.json
+++ b/src/domdiv/card_db/fr/sets_fr.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/card_db/it/sets_it.json
+++ b/src/domdiv/card_db/it/sets_it.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/card_db/nl_du/sets_nl_du.json
+++ b/src/domdiv/card_db/nl_du/sets_nl_du.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/card_db/sets_db.json
+++ b/src/domdiv/card_db/sets_db.json
@@ -9,17 +9,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "adventures extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "adventures_set.png",
-        "no_randomizer": true,
-        "set_name": "*adventures extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "alchemy": {
         "edition": [
             "1",
@@ -49,6 +38,7 @@
         ],
         "image": "",
         "no_randomizer": true,
+        "has_extras": false,
         "set_name": "*base*",
         "set_text": "",
         "text_icon": "*"
@@ -63,17 +53,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "cornucopia extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "cornucopia_set.png",
-        "no_randomizer": true,
-        "set_name": "*cornucopia extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "dark ages": {
         "edition": [
             "1",
@@ -81,17 +60,6 @@
         ],
         "image": "dark_ages_set.png",
         "set_name": "*dark ages*",
-        "set_text": "",
-        "text_icon": "*"
-    },
-    "dark ages extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "dark_ages_set.png",
-        "no_randomizer": true,
-        "set_name": "*dark ages extras*",
         "set_text": "",
         "text_icon": "*"
     },
@@ -121,6 +89,8 @@
             "1"
         ],
         "image": "dominion2ndEdition_set.png",
+        "has_extras": false,
+        "upgrades": "dominion1stEdition",
         "set_name": "*dominion2ndEditionUpgrade*",
         "set_text": "",
         "text_icon": "*"
@@ -135,17 +105,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "empires extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "empires_set.png",
-        "no_randomizer": true,
-        "set_name": "*empires extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "extras": {
         "edition": [
             "1",
@@ -153,6 +112,7 @@
         ],
         "image": "",
         "no_randomizer": true,
+        "has_extras": false,
         "set_name": "*extras*",
         "set_text": "",
         "text_icon": "*"
@@ -203,6 +163,8 @@
             "1"
         ],
         "image": "intrigue2ndEdition_set.png",
+        "has_extras": false,
+        "upgrades": "intrigue1stEdition",
         "set_name": "*intrigue2ndEditionUpgrade*",
         "set_text": "",
         "text_icon": "*"
@@ -217,17 +179,6 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "menagerie extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "menagerie_set.png",
-        "no_randomizer": true,
-        "set_name": "*menagerie extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "nocturne": {
         "edition": [
             "1",
@@ -238,23 +189,13 @@
         "set_text": "",
         "text_icon": "*"
     },
-    "nocturne extras": {
-        "edition": [
-            "1",
-            "latest"
-        ],
-        "image": "nocturne_set.png",
-        "no_randomizer": true,
-        "set_name": "*nocturne extras*",
-        "set_text": "",
-        "text_icon": "*"
-    },
     "promo": {
         "edition": [
             "1",
             "latest"
         ],
         "image": "promo_set.png",
+        "has_extras": false,
         "set_name": "*promo*",
         "set_text": "",
         "text_icon": "*"

--- a/src/domdiv/card_db/types_db.json
+++ b/src/domdiv/card_db/types_db.json
@@ -320,6 +320,8 @@
             "Event"
         ],
         "card_type_image": "event.png",
+        "group_cost": "*",
+        "group_global_type": "Events",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -329,6 +331,7 @@
             "Events"
         ],
         "card_type_image": "event.png",
+        "group_cost": "*",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -356,6 +359,8 @@
             "Landmark"
         ],
         "card_type_image": "landmark.png",
+        "group_cost": "",
+        "group_global_type": "Landmarks",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -365,6 +370,7 @@
             "Landmarks"
         ],
         "card_type_image": "landmark.png",
+        "group_cost": "",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -444,6 +450,8 @@
             "Project"
         ],
         "card_type_image": "project.png",
+        "group_cost": "*",
+        "group_global_type": "Projects",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -453,6 +461,7 @@
             "Projects"
         ],
         "card_type_image": "project.png",
+        "group_cost": "*",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -647,6 +656,8 @@
             "Way"
         ],
         "card_type_image": "way.png",
+        "group_cost": "",
+        "group_global_type": "Ways",
         "defaultCardCount": 1,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0
@@ -656,6 +667,7 @@
             "Ways"
         ],
         "card_type_image": "way.png",
+        "group_cost": "",
         "defaultCardCount": 0,
         "tabCostHeightOffset": -1,
         "tabTextHeightOffset": 0

--- a/src/domdiv/card_db/xx/sets_xx.json
+++ b/src/domdiv/card_db/xx/sets_xx.json
@@ -140,10 +140,5 @@
         "set_name": "Menagerie",
         "text_icon": "M",
         "set_text": "Dominion, that’s what you’re trying to achieve. This time with animals! They each have a lesson to teach, whether it’s how to spit really far, or what kind of grass tastes the best. It’s a lot to keep track of, but you’re like an elephant: you remember everything. And you’re afraid of mice. You’ve taken up riding. Horses are intimidating; they say you can lead a horse to water, but you haven’t managed it. So you’re working your way up, starting with dogs. So far so good; the dog hasn’t bucked you off yet. Your menagerie got off to a poor start, with just a goat, two rats, and the advisor who suggested starting a menagerie. You couldn’t get that fox you wanted, but it was probably bad anyway. Now you’ve got some camels, which are just as useless for sewing as you’d been warned, and a turtle that can hold its breath for longer than anyone can stay interested. Soon the animal kingdom will be yours.\nThis is the 13th expansion to <i>Dominion</i>. It has 400 cards, with 30 new Kingdom cards. There are Horses that save a draw for later, Exile mats that cards can be sent to and rescued from, and Ways that give Actions another option. Events return."
-    },
-    "menagerie extras": {
-        "set_name": "Menagerie Extras",
-        "text_icon": "M",
-        "set_text": ""
     }
 }

--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -160,14 +160,20 @@ class Card(object):
     def isPrize(self):
         return self.isType("Prize")
 
+    def get_GroupGlobalType(self):
+        return self.getType().getGroupGlobalType()
+
+    def get_GroupCost(self):
+        return self.getType().getGroupCost()
+
     def get_total_cost(self, c):
         # Return a tuple that represents the total cost of card c
         # Hightest cost cards are in order:
-        # - Landmarks to sort at the very end
+        # - Types with group cost of "" sort at the very end
         # - cards with * since that can mean anything
         # - cards with numeric errors
         # convert cost (a string) into a number
-        if c.isLandmark():
+        if c.get_GroupCost() == "":
             c_cost = 999
         elif not c.cost:
             c_cost = 0  # if no cost, treat as 0
@@ -245,12 +251,16 @@ class CardType(object):
         self,
         card_type,
         card_type_image,
+        group_global_type=None,
+        group_cost=None,
         defaultCardCount=10,
         tabTextHeightOffset=0,
         tabCostHeightOffset=-1,
     ):
         self.typeNames = tuple(card_type)
         self.tabImageFile = card_type_image
+        self.group_global_type = group_global_type
+        self.group_cost = group_cost
         self.defaultCardCount = defaultCardCount
         self.tabTextHeightOffset = tabTextHeightOffset
         self.tabCostHeightOffset = tabCostHeightOffset
@@ -265,6 +275,12 @@ class CardType(object):
         if not self.tabImageFile:
             return None
         return self.tabImageFile
+
+    def getGroupGlobalType(self):
+        return self.group_global_type
+
+    def getGroupCost(self):
+        return self.group_cost
 
     def getTabTextHeightOffset(self):
         return self.tabTextHeightOffset

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1228,7 +1228,7 @@ class DividerDrawer(object):
         if (
             not card.isExpansion()
             and not card.isBlank()
-            and not card.isLandmark()
+            and card.get_GroupCost() != ""
             and not card.isType("Trash")
         ):
             if "tab" in self.options.cost:
@@ -1654,7 +1654,7 @@ class DividerDrawer(object):
 
             sets = []
             for item in pageItems:
-                setTitle = item.card.cardset.title()
+                setTitle = " ".join(word.capitalize() for word in item.card.cardset.split())
                 if setTitle not in sets:
                     sets.append(setTitle)
 

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1654,7 +1654,9 @@ class DividerDrawer(object):
 
             sets = []
             for item in pageItems:
-                setTitle = " ".join(word.capitalize() for word in item.card.cardset.split())
+                setTitle = " ".join(
+                    word.capitalize() for word in item.card.cardset.split()
+                )
                 if setTitle not in sets:
                     sets.append(setTitle)
 

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -114,6 +114,7 @@ def get_global_groups():
 
 GROUP_GLOBAL_CHOICES, GROUP_GLOBAL_VALID = get_global_groups()
 
+
 def get_types(language="en_us"):
     # get a list of valid types
     language = language.lower()
@@ -934,13 +935,13 @@ def clean_opts(options):
         ]
     # For backwards compatibility
     if options.exclude_events:
-        options.group_global.append('events')
+        options.group_global.append("events")
     if options.exclude_landmarks:
-        options.group_global.append('landmarks')
+        options.group_global.append("landmarks")
     if options.exclude_projects:
-        options.group_global.append('projects')
+        options.group_global.append("projects")
     if options.exclude_ways:
-        options.group_global.append('ways')
+        options.group_global.append("ways")
     # Remove duplicates from the list
     options.group_global = list(set(options.group_global))
 
@@ -1517,7 +1518,7 @@ def filter_sort_cards(cards, options):
                 new_type=types_to_group[t],
                 new_card_tag=types_to_group[t].lower(),
                 new_cardset_tag=EXPANSION_GLOBAL_GROUP,
-        )
+            )
         if options.expansions:
             options.expansions.append(EXPANSION_GLOBAL_GROUP)
 
@@ -1574,8 +1575,13 @@ def filter_sort_cards(cards, options):
 
         # Now fix up card costs for groups by Type (Events, Landmarks, etc.)
         for card in cards:
-            if card.card_tag in group_cards and group_cards[card.group_tag].get_GroupCost():
-                group_cards[card.group_tag].cost = group_cards[card.group_tag].get_GroupCost()
+            if (
+                card.card_tag in group_cards
+                and group_cards[card.group_tag].get_GroupCost()
+            ):
+                group_cards[card.group_tag].cost = group_cards[
+                    card.group_tag
+                ].get_GroupCost()
                 group_cards[card.group_tag].debtcost = 0
                 group_cards[card.group_tag].potcost = 0
 
@@ -1647,7 +1653,9 @@ def filter_sort_cards(cards, options):
                 expanded_expansions.append(e)
 
         # Now get the actual sets that are matched above
-        options.expansions = set([e.lower() for e in expanded_expansions])  # Remove duplicates
+        options.expansions = set(
+            [e.lower() for e in expanded_expansions]
+        )  # Remove duplicates
         knownExpansions = set()
         for e in options.expansions:
             for s in Official_sets:
@@ -1768,7 +1776,10 @@ def filter_sort_cards(cards, options):
         cardnamesByExpansion = defaultdict(dict)
         randomizerCountByExpansion = Counter()
         for c in cards:
-            if c.isBlank() or (cardSorter.isBaseExpansionCard(c) and not options.base_cards_with_expansion):
+            if c.isBlank() or (
+                cardSorter.isBaseExpansionCard(c)
+                and not options.base_cards_with_expansion
+            ):
                 continue
             if c.randomizer:
                 randomizerCountByExpansion[c.cardset] += 1

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -35,6 +35,9 @@ EDITION_CHOICES = ["1", "2", "latest", "all"]
 
 ORDER_CHOICES = ["expansion", "global", "colour", "cost"]
 
+EXPANSION_GLOBAL_GROUP = "extras"
+EXPANSION_EXTRA_POSTFIX = " extras"
+
 LANGUAGE_DEFAULT = (
     "en_us"
 )  # the primary language used if a language's parts are missing
@@ -76,8 +79,8 @@ def get_expansions():
     fan = []
     official = []
     for s in set_file:
-        if "extras" not in s:
-            # Make sure this are set either True or False
+        if EXPANSION_EXTRA_POSTFIX not in s:
+            # Make sure these are set either True or False
             set_file[s]["fan"] = set_file[s].get("fan", False)
             if set_file[s]["fan"]:
                 fan.append(s)
@@ -90,6 +93,26 @@ def get_expansions():
 
 EXPANSION_CHOICES, FAN_CHOICES = get_expansions()
 
+
+def get_global_groups():
+    type_db_filepath = os.path.join("card_db", "types_db.json")
+    with get_resource_stream(type_db_filepath) as typefile:
+        type_file = json.loads(typefile.read().decode("utf-8"))
+    assert type_file, "Could not load any card types from database"
+
+    group_global_choices = []
+    group_global_valid = []
+    for t in type_file:
+        if "group_global_type" in t:
+            group_global_valid.append("-".join(t["card_type"]).lower())
+            group_global_choices.append(t["group_global_type"].lower())
+    group_global_valid.extend(group_global_choices)
+    group_global_valid.sort()
+    group_global_choices.sort()
+    return group_global_choices, group_global_valid
+
+
+GROUP_GLOBAL_CHOICES, GROUP_GLOBAL_VALID = get_global_groups()
 
 def get_types(language="en_us"):
     # get a list of valid types
@@ -458,10 +481,30 @@ def parse_opts(cmdline_args=None):
         "If this option is not given, all base cards are placed in their own 'Base' expansion.",
     )
     group_select.add_argument(
+        "--group-special",
         "--special-card-groups",
         action="store_true",
+        dest="group_special",
         help="Group cards that generally are used together "
         "(e.g., Shelters, Tournament and Prizes, Urchin/Mercenary, etc.).",
+    )
+    group_select.add_argument(
+        "--group-kingdom",
+        action="store_true",
+        dest="group_kingdom",
+        help="Group cards that have randomizers into the expansion, "
+        "and those that don't have randomizers into the expansion's 'Extra' section.",
+    )
+    group_select.add_argument(
+        "--group-global",
+        nargs="*",
+        action="append",
+        dest="group_global",
+        help="Group all cards of the specified types across all expansions into one 'Extras' divider. "
+        "This may be called multiple times. Values are not case sensitive. "
+        "Choices available include: {}".format(
+            ", ".join("%s" % x for x in GROUP_GLOBAL_VALID)
+        ),
     )
     group_select.add_argument(
         "--no-trash",
@@ -490,22 +533,26 @@ def parse_opts(cmdline_args=None):
     group_select.add_argument(
         "--exclude-events",
         action="store_true",
-        help="Group all 'Event' cards across all expansions into one divider.",
+        help="Group all 'Event' cards across all expansions into one divider."
+        "Same as '--group-global Events'",
     )
     group_select.add_argument(
         "--exclude-landmarks",
         action="store_true",
-        help="Group all 'Landmark' cards across all expansions into one divider.",
+        help="Group all 'Landmark' cards across all expansions into one divider."
+        "Same as '--group-global landmarks'",
     )
     group_select.add_argument(
         "--exclude-projects",
         action="store_true",
-        help="Group all 'Project' cards across all expansions into one divider.",
+        help="Group all 'Project' cards across all expansions into one divider."
+        "Same as '--group-global projects'",
     )
     group_select.add_argument(
         "--exclude-ways",
         action="store_true",
-        help="Group all 'Way' cards across all expansions into one divider.",
+        help="Group all 'Way' cards across all expansions into one divider."
+        "Same as '--group-global ways'",
     )
     group_select.add_argument(
         "--only-type-any",
@@ -875,6 +922,28 @@ def clean_opts(options):
             set([item.lower() for sublist in options.only_type_all for item in sublist])
         )
 
+    if options.group_global is None:
+        options.group_global = []
+    elif not any(options.group_global):
+        # option given with nothing indicates all possible global groupings
+        options.group_global = GROUP_GLOBAL_VALID
+    else:
+        # options.group_global is a list of lists.  Reduce to single lowercase list
+        options.group_global = [
+            item.lower() for sublist in options.group_global for item in sublist
+        ]
+    # For backwards compatibility
+    if options.exclude_events:
+        options.group_global.append('events')
+    if options.exclude_landmarks:
+        options.group_global.append('landmarks')
+    if options.exclude_projects:
+        options.group_global.append('projects')
+    if options.exclude_ways:
+        options.group_global.append('ways')
+    # Remove duplicates from the list
+    options.group_global = list(set(options.group_global))
+
     if options.tabs_only and options.label_name is None:
         # default is Avery 8867
         options.label_name = "8867"
@@ -1086,10 +1155,22 @@ def read_card_data(options):
     with get_resource_stream(set_db_filepath) as setfile:
         Card.sets = json.loads(setfile.read().decode("utf-8"))
     assert Card.sets, "Could not load any sets from database"
+    new_sets = {}
     for s in Card.sets:
         # Make sure these are set either True or False
         Card.sets[s]["no_randomizer"] = Card.sets[s].get("no_randomizer", False)
         Card.sets[s]["fan"] = Card.sets[s].get("fan", False)
+        Card.sets[s]["has_extras"] = Card.sets[s].get("has_extras", True)
+        Card.sets[s]["upgrades"] = Card.sets[s].get("upgrades", None)
+        new_sets[s] = Card.sets[s]
+        # Make an "Extras" set for normal expansions
+        if Card.sets[s]["has_extras"]:
+            e = s + EXPANSION_EXTRA_POSTFIX
+            new_sets[e] = copy.deepcopy(Card.sets[s])
+            new_sets[e]["set_name"] = "*" + s + EXPANSION_EXTRA_POSTFIX + "*"
+            new_sets[e]["no_randomizer"] = True
+            new_sets[e]["has_extras"] = False
+    Card.sets = new_sets
 
     # Remove the Trash card. Do early before propagating to various sets.
     if options.no_trash:
@@ -1120,9 +1201,9 @@ def read_card_data(options):
         for x in range(0, options.include_blanks):
             c = Card(
                 card_tag="Blank",
-                cardset="extras",
-                cardset_tag="extras",
-                cardset_tags=["extras"],
+                cardset=EXPANSION_GLOBAL_GROUP,
+                cardset_tag=EXPANSION_GLOBAL_GROUP,
+                cardset_tags=[EXPANSION_GLOBAL_GROUP],
                 randomizer=False,
                 types=("Blank",),
             )
@@ -1267,7 +1348,7 @@ class CardSorter(object):
         return (
             card.cardset,
             int(card.isExpansion()),
-            card.get_total_cost(card),
+            str(card.get_total_cost(card)),
             self.strip_accents(card.name),
         )
 
@@ -1408,72 +1489,45 @@ def filter_sort_cards(cards, options):
     # Combine upgrade cards with their expansion
     if options.upgrade_with_expansion:
         for card in cards:
-            if card.cardset_tag == "dominion2ndEditionUpgrade":
-                card.cardset_tag = "dominion1stEdition"
-                options.expansions.append(card.cardset_tag.lower())
-            elif card.cardset_tag == "intrigue2ndEditionUpgrade":
-                card.cardset_tag = "intrigue1stEdition"
+            if Card.sets[card.cardset_tag]["upgrades"]:
+                card.cardset_tag = Card.sets[card.cardset_tag]["upgrades"]
                 options.expansions.append(card.cardset_tag.lower())
 
-    # Combine all Events across all expansions
-    if options.exclude_events:
-        cards = combine_cards(
-            cards,
-            old_card_type="Event",
-            new_type="Events",
-            new_card_tag="events",
-            new_cardset_tag="extras",
-        )
-        if options.expansions:
-            options.expansions.append("extras")
+    # Combine globally all cards of the given types
+    # For example, Events, Landmarks, Projects, Ways
+    if options.group_global:
+        # First find all possible types to group that match options.group_global
+        types_to_group = {}
+        for t in Card.types:
+            group_global_type = Card.types[t].getGroupGlobalType()
+            if group_global_type:
+                theType = "-".join(t)
+                # Save if either the old or the new type matches the option
+                # Remember options.global_group is already lowercase
+                if theType.lower() in options.group_global:
+                    types_to_group[theType] = group_global_type
+                elif group_global_type.lower() in options.group_global:
+                    types_to_group[theType] = group_global_type
 
-    # Combine all Landmarks across all expansions
-    if options.exclude_landmarks:
-        cards = combine_cards(
-            cards,
-            old_card_type="Landmark",
-            new_type="Landmarks",
-            new_card_tag="landmarks",
-            new_cardset_tag="extras",
+        # Now work through the matching types to group
+        for t in types_to_group:
+            cards = combine_cards(
+                cards,
+                old_card_type=t,
+                new_type=types_to_group[t],
+                new_card_tag=types_to_group[t].lower(),
+                new_cardset_tag=EXPANSION_GLOBAL_GROUP,
         )
         if options.expansions:
-            options.expansions.append("extras")
-
-    # Combine all Projects across all expansions
-    if options.exclude_projects:
-        cards = combine_cards(
-            cards,
-            old_card_type="Project",
-            new_type="Projects",
-            new_card_tag="projects",
-            new_cardset_tag="extras",
-        )
-        if options.expansions:
-            options.expansions.append("extras")
-
-    # Combine all Ways across all expansions
-    if options.exclude_ways:
-        cards = combine_cards(
-            cards,
-            old_card_type="Way",
-            new_type="Ways",
-            new_card_tag="ways",
-            new_cardset_tag="extras",
-        )
-        if options.expansions:
-            options.expansions.append("extras")
+            options.expansions.append(EXPANSION_GLOBAL_GROUP)
 
     # Take care of any blank cards
     if options.include_blanks > 0:
         if options.expansions:
-            options.expansions.append("extras")
-
-    # FIX THIS: Combine all Prizes across all expansions
-    # if options.exclude_prizes:
-    #    cards = combine_cards(cards, 'Prize', 'prizes')
+            options.expansions.append(EXPANSION_GLOBAL_GROUP)
 
     # Group all the special cards together
-    if options.special_card_groups:
+    if options.group_special:
         keep_cards = []  # holds the cards that are to be kept
         group_cards = {}  # holds the cards for each group
         for card in cards:
@@ -1496,10 +1550,8 @@ def filter_sort_cards(cards, options):
                     )  # For now, change the name to the group_tab
                     card.description = error_msg
                     card.extra = error_msg
-                    if card.isType("Event") or card.isType("Project"):
-                        card.cost = "*"
-                    if card.isType("Landmark"):
-                        card.cost = ""
+                    if card.get_GroupCost():
+                        card.cost = card.get_GroupCost()
                     # now save the card
                     keep_cards.append(card)
                 else:
@@ -1520,19 +1572,26 @@ def filter_sort_cards(cards, options):
 
         cards = keep_cards
 
-        # Now fix up card costs
+        # Now fix up card costs for groups by Type (Events, Landmarks, etc.)
         for card in cards:
-            if card.card_tag in group_cards:
-                if group_cards[card.group_tag].isType("Event") or group_cards[
-                    card.group_tag
-                ].isType("Project"):
-                    group_cards[card.group_tag].cost = "*"
-                    group_cards[card.group_tag].debtcost = 0
-                    group_cards[card.group_tag].potcost = 0
-                if group_cards[card.group_tag].isType("Landmark"):
-                    group_cards[card.group_tag].cost = ""
-                    group_cards[card.group_tag].debtcost = 0
-                    group_cards[card.group_tag].potcost = 0
+            if card.card_tag in group_cards and group_cards[card.group_tag].get_GroupCost():
+                group_cards[card.group_tag].cost = group_cards[card.group_tag].get_GroupCost()
+                group_cards[card.group_tag].debtcost = 0
+                group_cards[card.group_tag].potcost = 0
+
+    # Separate Kingdom (with Randomizer) from non-Kingdom cards (without Randomizer)
+    if options.group_kingdom:
+        new_cards = []
+        new_sets = {}
+        for card in cards:
+            if not card.randomizer and Card.sets[card.cardset_tag]["has_extras"]:
+                card.cardset_tag += EXPANSION_EXTRA_POSTFIX
+                new_sets[card.cardset_tag] = True
+            new_cards.append(card)
+        cards = new_cards
+        if options.expansions and new_cards:
+            # Add the new expansion "extras" to the overall expansion list
+            options.expansions.extend([s for s in new_sets])
 
     # Get the final type names in the requested language
     Card.type_names = add_type_text(Card.type_names, LANGUAGE_DEFAULT)
@@ -1588,7 +1647,7 @@ def filter_sort_cards(cards, options):
                 expanded_expansions.append(e)
 
         # Now get the actual sets that are matched above
-        options.expansions = set([e for e in expanded_expansions])  # Remove duplicates
+        options.expansions = set([e.lower() for e in expanded_expansions])  # Remove duplicates
         knownExpansions = set()
         for e in options.expansions:
             for s in Official_sets:
@@ -1620,7 +1679,7 @@ def filter_sort_cards(cards, options):
                 expanded_expansions.append(e)
 
         # Now get the actual sets that are matched above
-        options.fan = set([e for e in expanded_expansions])  # Remove duplicates
+        options.fan = set([e.lower() for e in expanded_expansions])  # Remove duplicates
         knownExpansions = set()
         for e in options.fan:
             for s in Fan_sets:
@@ -1630,7 +1689,13 @@ def filter_sort_cards(cards, options):
         # Give indication if an imput did not match anything
         unknownExpansions = options.fan - knownExpansions
         if unknownExpansions:
-            print("Error - unknown fan expansion(s): %s" % ", ".join(unknownExpansions))
+            print(
+                (
+                    "Error - unknown expansion(s): {}".format(
+                        ", ".join(unknownExpansions)
+                    )
+                )
+            )
 
     if options.exclude_expansions:
         # Expand out any wildcards, matching set key or set name in the given language
@@ -1703,7 +1768,7 @@ def filter_sort_cards(cards, options):
         cardnamesByExpansion = defaultdict(dict)
         randomizerCountByExpansion = Counter()
         for c in cards:
-            if cardSorter.isBaseExpansionCard(c) or c.isBlank():
+            if c.isBlank() or (cardSorter.isBaseExpansionCard(c) and not options.base_cards_with_expansion):
                 continue
             if c.randomizer:
                 randomizerCountByExpansion[c.cardset] += 1


### PR DESCRIPTION
I took a look at this yet for issue #166 again with some fresh eyes.  I propose the following changes:
Changes to Options:

* `--group-special`
  This is the same as `--special-card-groups` in the past.
* `--group-kingdom`
  This will group non-Kingdom (i.e., no randomizer) cards into an Extra section for the Expansion.
  This includes moving base cards to the Extra section if `--base-cards-with-expansion` is given.
*`--group-global [Events|Landmarks|Projects|Ways]`
  Combines the --exclude-xxx options into a single option that can contain any number of wanted card types to be included in the "Extra" section.
  This can be called once with any/all desired types, or called multiple times with one or more types.
  `--group-global` with no parameters will use ALL the global groups`.

  *QUESTION*: Should this stay as ALL, or should this be NONE (as if `--group-global` is not given.)

All three of these are independant and can be mixed.

The following are aliased and could be depricated if desired:
`--special-card-groups` aliased to `--group-special`
`--exclude-events`      aliased to `--group-global Events`
`--exclude-landmarks`   aliased to `--group-global Landmarks`
`--exclude-projects`    aliased to `--group-global Projects`
`--exclude-ways`        aliased to `--group-global Ways`

Changes to `types_db.json`:
Since all the global groups are special card types, added new fields to specify information that was hard coded in `main.py` before.
- Added "group_cost" to give the cost to display on the tab.  "*" for cards with various costs. "" for cards with no cost at all.
- Added "group_global_type" to indicate (a) the type for the resulting global group (b) indirectly, that this type can be grouped globaly.
Note: this has essentially eliminated the need for card.isEvent(), card.isLandmark(), etc.  Worked to make things generic via json entries.
Example:
```
    {
        "card_type": [
            "Event"
        ],
        "card_type_image": "event.png",
        "group_cost": "*",               <--- new
        "group_global_type": "Events",   <--- new
        "defaultCardCount": 1,
        "tabCostHeightOffset": -1,
        "tabTextHeightOffset": 0
    },
```

Changes to `cards.py`:
- for CardType(), added "group_cost" and "group_global_type" initialization (per above) and the corresponding `getGroupCost()` and `getGroupGlobalType()` methods.
- for Card(), added `get_GroupCost()` and `get_GroupGlobalType()` methods.

Changes to `sets_db.json`:
- Removed all "extras" entries.  These are now generated automatically in `main.py`.
- Added "has_extras" to designate if the set should have an Extra section.  Default is True, so only have to provide when False.
- Added "upgrades" which is used to indicate that this set upgrades another set.  Before, this was hard coded in `main.py`.  Now it is generic and is set in `sets_db.json`.
Example:
```
    "dominion2ndEditionUpgrade": {
        "edition": [
            "1"
        ],
        "image": "dominion2ndEdition_set.png",
        "has_extras": false,                    <--- new
        "upgrades": "dominion1stEdition",       <--- new
        "set_name": "*dominion2ndEditionUpgrade*",
        "set_text": "",
        "text_icon": "*"
    },
```
    
Changes to `/en_us/sets_en_us.json`:
Just needed to add a few entries for expansion extra sets that did exist previously.

Handling of most of these changes are in `main.py` and one line change in `draw.py`.

Also in `draw.py` changed `item.card.cardset.title()` to `" ".join(word.capitalize() for word in item.card.cardset.split())` to fix capitalization of 1St & 2Nd to 1st & 2nd (a pet peeve.)
