### PR TITLE
Add FAQ sections for Allies dividers.

### DIFF
--- a/card_db_src/cards_db.json
+++ b/card_db_src/cards_db.json
@@ -841,7 +841,7 @@
         ]
     },
     {
-        "card_tag": "augurs",
+        "card_tag": "Augurs",
         "cardset_tags": [
             "allies"
         ],
@@ -935,7 +935,7 @@
         ]
     },
     {
-        "card_tag": "clashes",
+        "card_tag": "Clashes",
         "cardset_tags": [
             "allies"
         ],
@@ -1026,7 +1026,7 @@
         ]
     },
     {
-        "card_tag": "forts",
+        "card_tag": "Forts",
         "cardset_tags": [
             "allies"
         ],
@@ -1206,7 +1206,7 @@
         ]
     },
     {
-        "card_tag": "odysseys",
+        "card_tag": "Odysseys",
         "cardset_tags": [
             "allies"
         ],
@@ -1437,7 +1437,7 @@
         ]
     },
     {
-        "card_tag": "townsfolk",
+        "card_tag": "Townsfolk",
         "cardset_tags": [
             "allies"
         ],
@@ -1493,7 +1493,7 @@
         ]
     },
     {
-        "card_tag": "wizards",
+        "card_tag": "Wizards",
         "cardset_tags": [
             "allies"
         ],

--- a/card_db_src/en_us/cards_en_us.json
+++ b/card_db_src/en_us/cards_en_us.json
@@ -351,277 +351,277 @@
     },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
-    "augurs": {
+    "Augurs": {
         "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Augurs"
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
-    "clashes": {
+    "Clashes": {
         "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Clashes"
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
-    "forts": {
+    "Forts": {
         "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
         "name": "Forts"
     },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
-    "odysseys": {
+    "Odysseys": {
         "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Odysseys"
     },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
     },
-    "townsfolk": {
+    "Townsfolk": {
         "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Townsfolk"
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
     },
-    "wizards": {
+    "Wizards": {
         "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
         "name": "Wizards"
     },
     "Grey Mustang": {
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": "You draw 2 cards and get an extra Buy this turn, and then draw 2 more cards and get another extra Buy at the start of your next turn. You don't draw your extra 2 cards for the next turn until that turn actually starts. Leave this in front of you until the Clean-up phase of your next turn.",
         "name": "Wharf"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
@@ -3364,11 +3344,6 @@
         "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
         "name": "Tournament and Prizes"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",

--- a/src/domdiv/card_db/cards_db.json
+++ b/src/domdiv/card_db/cards_db.json
@@ -812,6 +812,90 @@
         ]
     },
     {
+        "card_tag": "Augurs",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "3*",
+        "count": "16",
+        "group_tag": "Augurs",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Augur"
+        ]
+    },
+    {
+        "card_tag": "Clashes",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "3*",
+        "count": "16",
+        "group_tag": "Clashes",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Clash"
+        ]
+    },
+    {
+        "card_tag": "Forts",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "3*",
+        "count": "16",
+        "group_tag": "Forts",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Fort"
+        ]
+    },
+    {
+        "card_tag": "Odysseys",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "3*",
+        "count": "16",
+        "group_tag": "Odysseys",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Odyssey"
+        ]
+    },
+    {
+        "card_tag": "Townsfolk",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "2*",
+        "count": "16",
+        "group_tag": "Townsfolk",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Townsfolk"
+        ]
+    },
+    {
+        "card_tag": "Wizards",
+        "cardset_tags": [
+            "allies"
+        ],
+        "cost": "3*",
+        "count": "16",
+        "group_tag": "Wizards",
+        "group_top": true,
+        "types": [
+            "Action",
+            "Wizard"
+        ]
+    },
+    {
         "card_tag": "acolyte",
         "cardset_tags": [
             "allies"
@@ -850,20 +934,6 @@
         "randomizer": false,
         "types": [
             "Ally"
-        ]
-    },
-    {
-        "card_tag": "augurs",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "3*",
-        "count": "16",
-        "group_tag": "Augurs",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Augur"
         ]
     },
     {
@@ -992,20 +1062,6 @@
         "randomizer": false,
         "types": [
             "Ally"
-        ]
-    },
-    {
-        "card_tag": "clashes",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "3*",
-        "count": "16",
-        "group_tag": "Clashes",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Clash"
         ]
     },
     {
@@ -1155,20 +1211,6 @@
         "randomizer": false,
         "types": [
             "Ally"
-        ]
-    },
-    {
-        "card_tag": "forts",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "3*",
-        "count": "16",
-        "group_tag": "Forts",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Fort"
         ]
     },
     {
@@ -1407,20 +1449,6 @@
         "randomizer": false,
         "types": [
             "Ally"
-        ]
-    },
-    {
-        "card_tag": "odysseys",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "3*",
-        "count": "16",
-        "group_tag": "Odysseys",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Odyssey"
         ]
     },
     {
@@ -1689,20 +1717,6 @@
         ]
     },
     {
-        "card_tag": "townsfolk",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "2*",
-        "count": "16",
-        "group_tag": "Townsfolk",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Townsfolk"
-        ]
-    },
-    {
         "card_tag": "trappers_lodge",
         "cardset_tags": [
             "allies"
@@ -1754,20 +1768,6 @@
             "Duration",
             "Attack",
             "Clash"
-        ]
-    },
-    {
-        "card_tag": "wizards",
-        "cardset_tags": [
-            "allies"
-        ],
-        "cost": "3*",
-        "count": "16",
-        "group_tag": "Wizards",
-        "group_top": true,
-        "types": [
-            "Action",
-            "Wizard"
         ]
     },
     {

--- a/src/domdiv/card_db/cz/cards_cz.json
+++ b/src/domdiv/card_db/cz/cards_cz.json
@@ -349,25 +349,50 @@
         "extra": "This Kingdom card is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point per 3 Action cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Round down; if you have 11 Action cards, Vineyard is worth 3 victory points. During set-up, put all 12 Vineyards in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game. Cards with multiple types, one of which is Action, are Actions and so are counted by Vineyard.",
         "name": "Vineyard"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": "You draw 2 cards and get an extra Buy this turn, and then draw 2 more cards and get another extra Buy at the start of your next turn. You don't draw your extra 2 cards for the next turn until that turn actually starts. Leave this in front of you until the Clean-up phase of your next turn.",
         "name": "Wharf"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
@@ -3364,11 +3344,6 @@
         "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
         "name": "Tournament and Prizes"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",

--- a/src/domdiv/card_db/de/cards_de.json
+++ b/src/domdiv/card_db/de/cards_de.json
@@ -349,25 +349,50 @@
         "extra": "Diese Karte ist eine Punktekarte und hat bis zum Ende des Spiels keine Funktion. Bei Spielende erhält der Spieler, der diese Karte in seinem Kartensatz (Nachziehstapel, Ablagestapel und Handkarten) hat, für jeweils 3 Aktionskarten (auch kombinierte Aktionskarten) 1 Siegpunkt. Es wird immer abgerundet, d. h. wer z.B. 12, 13 oder 14 Aktionskarten besitzt, erhält 4 Siegpunkte. Wer mehrere WEINBERGE besitzt, erhält für jeden WEINBERG die entsprechende Anzahl Siegpunkte.",
         "name": "Weinberg"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": "Die WERFT ist eine Dauerkarte. Du musst sofort 2 Karten nachziehen und darfst einen weiteren Kauf tätigen. Zu Beginn deines nächsten Zuges (nicht vorher) musst du wieder 2 Karten ziehen und darfst einen weiteren Kauf tätigen.",
         "name": "Werft"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Grenzposten</u>:</left><n>+1 Aktion<br><br>Decke die obersten 2 Karten deines Nachziehstapels auf. Nimm eine davon auf deine Hand und lege die andere ab. Sind beide Aktionskarten, erhalte die Laterne oder das Horn.<n><left><u>Horn</u>:</left><n>Einmal pro Zug: wenn du einen Grenzposten aus dem Spiel ablegst, darfst du ihn auf deinen Nachziehstapel legen<n><left><u>Laterne</u>:</left><n>Deine Grenzposten decken jeweils 3 Karten auf und legen 2 ab. (Alle 3 müssen Aktionskarten sein, um das Horn zu erhalten).",
         "extra": "Wenn ihr den GRENZPOSTEN verwendet, sucht zu Spielbeginn das HORN und die LATERNE heraus und legt sie neben dem Vorrat bereit. Wenn du einen GRENZPOSTEN ausspielst und nicht die LATERNE hast, deckst du die obersten 2 Karten deines Nachziehstapels auf, wählst eine davon und nimmst sie zu deinen Handkarten; die andere legst du ab. Wenn beide Karten Aktionskarten sind, erhältst du danach die LATERNE oder das HORN. Wenn du nicht 2 Karten aufdecken kannst bzw. nicht 3 Karten, wenn du die LATERNE hast, erhältst du kein Artefakt.<n><n>Das Horn und die Laterne sind Artefakte. Artefakte sind Effekte, die für einen Spieler gelten und nicht durch normale Karten oder Ereignisse ausgelöst werden. Sie funktionieren ähnlich wie Zustände (aus Nocturne). Artefakte sind keine \"Karten\"; alle Texte, die sich auf \"Karten\" beziehen finden keine Anwendung auf Artefakte. Es gibt jeden Artefakt nur genau einmal; wenn ein Spieler einen Artefakt immt wird die Artefakt-Karte vor ihm abgelegt, bis ein anderer Spieler sie nimmt.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Friedhof</u>:</left><center>2 <*VP*></center><line>Wenn du diese Karte nimmst, entsorge bis zu 4 Handkarten.<br><i>Erbstück: Zauberspiegel</i><left><u>Zauberspiegel</u>:</left><center>1 <*COIN*></center><line>Wenn du diese Karte entsorgst, darfst du eine Aktionskarte ablegen. Wenn du das tust: Nimm einen Geist vom Geist-Stapel.",
         "extra": "<u>Friedhof</u>: In der Spielvorbereitung erhält jeder Spieler ein ERBSTÜCK ZAUBERSPIEGEL und dafür ein KUPFER weniger. Wenn du einen FRIEDHOF nimmst, entsorge 0 bis 4 Karten aus deiner Hand.\n<u>Zauberspiegel</u>: Dieses ERBSTÜCK wird nur verwendet, wenn die Königreichkarte FRIEDHOF verwendet wird. Du darfst diesen ZAUBERSPIEGEL nur entsorgen, wenn du dies durch die Anweisung einer anderen Karte tun darfst - der ZAUBERSPIEGEL selbst gibt dir dazu nicht das Recht. Solltest du aber eine Möglichkeit haben, diesen ZAUBERSPIEGEL zu entsorgen, darfst du eine Aktionskarte aus der Hand ablegen und einen GEIST von seinem Stapel nehmen.",
         "name": "Friedhof / Zauberspiegel"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Feldlager</u>:</left><n>+2 Karten<br>+2 Aktionen<n>Du darfst ein Gold oder ein Diebesgut aus deiner Hand aufdecken. Wenn du das nicht tust: Lege dieses Feldlager zur Seite und lege es zu Beginn der Aufräumphase in den Vorrat zurück.<n><left><u>Diebesgut</u>:</left><n>+2 Coins<br>+1 <VP>-Marker",
@@ -3279,11 +3269,6 @@
         "extra": "<u>Narr</u>: In der Spielvorbereitung erhält jeder Spieler ein ERBSTÜCK GLÜCKSTALER und dafür ein KUPFER weniger. Wenn du bereits den Zustand IM WALD VERIRRT vor dir liegen hast, passiert nichts. Wenn du IM WALD VERIRRT nicht hast, erhalte es (wenn es gerade bei einem Spieler liegt, gibt er es dir), lege es vor dir ab und decke dann die obersten 3 Gaben des Gaben- Stapels auf. Empfange die Gaben in einer von dir festgelegten Reihenfolge (diese musst du nicht zu Beginn festlegen - du kannst eine Gabe empfangen und dann die nächste wählen usw.) und lege sie direkt nach Empfang ab bzw. bewahre sie bis zu deiner Aufräumphase auf, wenn eine Gabe dies erfordert. Der Zustand bleibt vor dir liegen, bis ein anderer Spieler ihn mit Hilfe des NARREN erhält.\n<u>Glückstaler</u>: Dieses ERBSTÜCK wird nur verwendet, wenn die Königreichkarte NARR verwendet wird.",
         "name": "Narr / Glückstaler"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>+2 Coin<n>Decke eine Handkarte auf. Dein linker Mitspieler darf eine Handkarte mit gleichem Namen aufdecken. Wenn er das nicht tut: +1 Coin und entsorge einen Gladiator vom Vorrat.<n><left><u>Reichtum</u>:</left><n>+1 Kauf<n>Wenn du diese Karte ausspielst, verdoppelt sich dein Coin; nur 1x pro Zug möglich.<line>Wenn du diese Karte nimmst, nimm ein Gold pro Gladiator, den du im Spiel hast.",
         "extra": "<u>Gladiator</u>: Wenn du mindestens 1 Handkarte hast, musst du diese aufdecken. Wenn dein linker Mitspieler keine Karte mit gleichem Namen aufdecken kann oder will (z.B. auch, wenn du keine Handkarte aufdecken konntest, weil du keine hast), erhältst du zusätzlich + 1 Coin. Sind noch Karten auf dem GLADIATOR-Vorratsstapel vorhanden, musst du eine entsorgen. Deckt der Mitspieler eine Karte mit gleichem Namen auf, erhältst du nur + 2 Coins und darfst keinen GLADIATOR entsorgen.<n><u>Reichtum</u>: Es werden nur alle Coin verdoppelt, die du vor dem Ausspielen dieser Karte ausgespielt hast und nur, wenn du in diesem Zug noch keinen REICHTUM ausgespielt hast. Für jedes weitere Ausspielen eines REICHTUMS erhältst du nur + 1 Kauf.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Totenbeschwörer</u>:</left><center>Spiele eine Aktionskarte, die mit der Vorderseite nach oben im Müll liegt und keine Dauerkarte ist, lasse sie dort und drehe sie für diesen Zug mit der Bildseite nach unten.</center><line>Spielvorbereitung: Legt die 3 Zombies in den Müll.<left><u>Zombie-Lehrling</u>:</left><center>Du darfst eine Aktionskarte aus der Hand entsorgen. Wenn du das tust: +3 Karten und +1 Aktion.</center><left><u>Zombie-Maurer</u>:</left><center>Entsorge die oberste Karte deines Nachziehstapels. Du darfst eine Karte nehmen, die bis zu 1 Coin mehr kostet als die entsorgte Karte.</center><left><u>Zombie-Spion</u>:</left><center>+1 Karte</center><center>+1 Aktion</center><center>Sieh die oberste Karte deines Nachziehstapels an. Lege sie ab oder zurück auf den Nachziehstapel.</center>",
         "extra": "<u>Totenbeschwörer</u>: In der Spielvorbereitung werden die 3 ZOMBIES aufgedeckt auf den Müllstapel gelegt. Der TOTENBESCHWÖRER kann damit mindestens einen der 3 ZOMBIES spielen, da diese von Spielbeginn an im Müll liegen. Im Verlauf des Spiels können weitere Aktionskarten, die im Müll landen, gespielt werden. Spiele eine Aktionskarte, die mit der Vorderseite nach oben im Müll liegt und keine Dauerkarte ist, lasse sie dort und drehe sie für diesen Zug mit der Bildseite nach unten - damit kann jede Karte des Müllstapels maximal einmal pro Zug gespielt werden. Am Ende des Zuges wird die Karte wieder umgedreht. Die so gespielte Aktionskarte befindet sich nicht 'im Spiel' und verbleibt auf jeden Fall im Müllstapel, auch wenn sie durch die Anweisung eigentlich anderswo hingelegt werden würde.\n<u>Zombie-Lehrling</u>: Nur, wenn du eine Karte aus der Hand entsorgst, ziehst du 3 Karten nach und erhältst + 1 Aktion. <u>Zombie-Maurer</u>: Du musst, auch wenn du eine Karte entsorgt hast, keine Karte nehmen. Du kannst auch nur eine Karte entsorgen und nichts weiter tun. Du kannst, wenn du eine Karte nimmst, auch eine Karte mit gleichen Kosten oder eine billigere nehmen, auch eine gleiche wie die entsorgte Karte. <u>Zombie-Spion</u>: Ziehe eine Karte, bevor du dir die oberste Karte des Nachziehstapels ansiehst.",
         "name": "Totenbeschwörer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>PAGE wird in einen SCHATZSUCHER eingetauscht, welcher in einen KRIEGER eingetauscht wird, welcher in einen HELDEN eingetauscht wird, welcher in einen CHAMPION eingetauscht wird.</justify><left><u>Page</u>: +1 Karte; +1 Aktion</left><left><u>Schatzsucher</u>: +1 Aktion; +1 Coin; Nimm dir pro Karte, die dein rechter Mitspieler in seinem letzten Zug genommen hat, ein Silber.</left><left><u>Krieger</u>: +2 Karten;Für jeden Reisenden (inklusive diesem), den du im Spiel hast, müssen alle Mitspieler die oberste Karte ihres Nachziehstapels ablegen und sie entsorgen, wenn sie 3 coins oder 4 coins kostet.</left><left><u>Held</u>: +2 Coins; Nimm dir eine Geldkarte.</left><left><u>Champion</u>: +1 Aktion; Immer wenn ein Mitspieler eine Angriffskarte spielt, bist du davon nicht betroffen. Immer wenn du eine Aktionskarte spielst: +1 Aktion </left><justify><i>(Diese Karte bleibt bis zum Spielende im Spiel.)</i>)</justify>",
@@ -3364,11 +3344,6 @@
         "extra": "Beim Ausspielen eines TURNIERS erhältst du +1 Aktion. Dann darfst du eine PROVINZ aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, musst du dich entscheiden, entweder eine Preiskarte oder ein HERZOGTUM zu nehmen. Entscheidest du dich für die Preiskarte, suchst du dir eine der Karten vom Preisstapel aus. Entscheidest du dich für das HERZOGTUM, nimmst du dir ein HERZOGTUM vom Vorrat. Du kannst dich auch für einen der beiden Stapel entscheiden, wenn dieser leer ist. Ist der Stapel für den du dich entscheidest leer, nimmst du dir keine Karte.<n>Nun dürfen alle deine Mitspieler eine PROVINZ aus ihrer Hand aufdecken. Deine Mitspieler zeigen die PROVINZ vor und nehmen sie dann zurück auf ihre Hand. Wenn keiner deiner Mitspieler eine PROVINZ aufdeckt, erhältst du +1 Karte und +1 coin. Es gibt also 4 mögliche Ergebnisse: 1. Du legst keine PROVINZ ab und keiner deiner Mitspieler deckt eine PROVINZ auf: Du erhältst +1 Karte, +1 Aktion und +1 coin. 2. Du legst keine PROVINZ ab und mindestens einer deiner Mitspieler deckt eine PROVINZ auf: Du erhältst +1 Aktion. 3. Du legst eine PROVINZ ab aber keiner deiner Mitspieler deckt eine PROVINZ auf: Du nimmst dir eine Preiskarte oder ein HERZOGTUM und erhältst +1 Karte, +1 Aktion und +1 coin. 4. Du legst eine PROVINZ ab und mindestens einer deiner Mitspieler deckt eine PROVINZ auf: Du nimmst dir eine Preiskarte oder ein HERZOGTUM und erhältst +1 Aktion.<n> Du darfst den Preisstapel jederzeit durchsehen.",
         "name": "Turnier und Preise"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Fährtensucher</u>:</left><center>+1 Coin</center><center>Empfange eine Gabe.</center><line><center>Wenn diese Karte im Spiel ist und du eine Karte nimmst, darfst du die genommene Karte auf deinen Nachziehstapel legen.</center><left><i>Erbstück: Beutel</i></left><left><u>Beutel</u>:</left><center>1 <*COIN*></center><n><n>+1 Kauf",
         "extra": "<u>Fährtensucher</u>: In der Spielvorbereitung erhält jeder Spieler ein ERBSTÜCK BEUTEL und dafür ein KUPFER weniger. Wenn du diese Karte ausspielst und danach mehr als eine Karte nimmst (kaufst oder auf andere Art und Weise nimmst), darfst du für jede genommene Karte neu entscheiden, ob du sie auf deinen Nachziehstapel legst. Wenn du die durch den FÄHRTENSUCHER empfangene Gabe ausführst und dadurch eine Karte nimmst (z.B. ein SILBER durch GESCHENK DES BERGES), darfst du diese auf deinen Nachziehstapel legen.\n<u>Beutel</u>: Dieses ERBSTÜCK wird nur verwendet, wenn die Königreichkarte FÄHRTENSUCHER verwendet wird.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampirin</u>:</left><center>Jeder Mitspieler empfängt die nächste Plage.</center><center>Nimm eine Karte, außer einer Vampirin, die bis zu 5 Coin kostet.</center><center>Tausche diese Karte (die Vampirin) in eine Fledermaus ein.</center><left><u>Fledermaus</u>:</left><center>Entsorge bis zu 2 Handkarten. Wenn du mindestens 1 Karte entsorgt hast, tausche diese Karte in eine Vampirin ein.</center><left><i>(Diese Karte gehört nicht zum Vorrat.)</i></left>",
         "extra": "<u>Vampirin</u>: Diese Karte ist eine Nachtkarte und kann nur in der Nachtphase ausgespielt werden. Führe die drei Anweisungen in der vorgegebenen Reihenfolge aus. Decke zuerst die oberste Plage auf. Jeder Mitspieler führt die Anweisung darauf (im Uhrzeigersinn, beginnend bei deinem linken Nachbarn) aus. Lege die Plage danach auf den separaten Plagen-Ablagestapel. Nimm dir dann eine Karte, die bis zu 5 Coins kostet (außer einer VAMPIRIN) und tausche dann die VAMPIRIN in eine FLEDERMAUS ein.\n<u>Fledermaus</u>: Diese Karte kann nicht gekauft werden - sie kann nur durch die Anweisung auf der Königreichkarte VAMPIRIN genommen werden. Diese Karte ist eine Nachtkarte und kann nur in der Nachtphase ausgespielt werden. Wenn du diese FLEDERMAUS in eine VAMPIRIN eintauschst, lege die FLEDERMAUS zurück auf ihren Stapel. Ist keine VAMPIRIN mehr im Vorrat vorhanden, kannst du die FLEDERMAUS nicht eintauschen, du kannst sie aber trotzdem ausspielen und Karten entsorgen.",
         "name": "Vampirin / Fledermaus"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Ereignisse sind keine Königreichkarten. In der Kaufphase eines Spielers kann der Spieler, wenn er auch eine Karte kaufen könnte, stattdessen ein Ereignis erwerben. Ein Ereignis zu erwerben bedeutet, die Kosten, die auf dem Ereignis angegeben sind, zu bezahlen und dann den Effekt des Ereignis' auszuführen. Das Ereignis bleibt dabei einfach auf dem Tisch, der Spieler nimmt es sich nicht; es ist in keinster Weise möglich, dass ein Spieler ein Ereignis nimmt oder eines in seinem Deck hat. Ein Ereignis zu erwerben benötigt einen Kauf, normalerweise kann sich ein Spieler entweder eine Karte kaufen oder ein Event erwerben. Hat ein Spieler zwei Käufe, weil er beispielsweise einen WILDHÜTER gespielt hat, so kann er sich zwei Karten kaufen, oder er erwirbt zwei Ereignisse, oder er kauft sich eine Karte und erwirbt ein Ereignis (in beliebiger Reihenfolge). Das selbe Ereignis kann in derselben Runde mehrfach erworben werden, falls der Spieler genügend Käufe verfügbar hat. Manche Ereignisse geben +Käufe und erlauben somit dem Spieler, später weitere Karten oder Ereignisse zu kaufen. Spieler können in einem Zug keine weiteren Schatzkarten spielen nachdem sie ein Ereignis erworben haben. Der Erwerb eines Ereignisses gilt nicht als Kaufen einer Karte. So findet z.B. die SUMPFHEXE keine Anwendung beim Erwerb eines Ereignisses. Die Kosten eines Ereignisses werden auch nicht von Karten wie dem BRÜCKENTROLL, die die Kosten von Karten betreffen, beeinflusst.</justify>",

--- a/src/domdiv/card_db/en_us/cards_en_us.json
+++ b/src/domdiv/card_db/en_us/cards_en_us.json
@@ -349,25 +349,50 @@
         "extra": "This Kingdom card is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point per 3 Action cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Round down; if you have 11 Action cards, Vineyard is worth 3 victory points. During set-up, put all 12 Vineyards in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game. Cards with multiple types, one of which is Action, are Actions and so are counted by Vineyard.",
         "name": "Vineyard"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": "You draw 2 cards and get an extra Buy this turn, and then draw 2 more cards and get another extra Buy at the start of your next turn. You don't draw your extra 2 cards for the next turn until that turn actually starts. Leave this in front of you until the Clean-up phase of your next turn.",
         "name": "Wharf"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
@@ -3364,11 +3344,6 @@
         "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
         "name": "Tournament and Prizes"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",

--- a/src/domdiv/card_db/fr/cards_fr.json
+++ b/src/domdiv/card_db/fr/cards_fr.json
@@ -349,25 +349,50 @@
         "description": "Vaut 1 <VP> pour chaque 3 cartes <i>Action</i> dans votre deck<n>(arrondi à l'unité inférieure).",
         "extra": "Cette carte <i>Royaume</i> est une carte <i>Victoire</i> et non une carte <i>Action</i>. Elle n'a pas d'effet avant la fin de la partie, où elle vaut 1 point de victoire pour chaque lot de 3 cartes <i>Action</i> dans votre deck (incluant toutes vos cartes: celles de votre défausse, votre deck et votre main). Le tout arrondi à l'unité inférieure: si vous avez 11 cartes <i>Action</i>, votre <i>Vignoble</i> vaut 3 points de victoire. Lors de la mise en place, placez dans la réserve 12 cartes <i>Vignoble</i> à 3 et 4 joueurs et 8 cartes <i>Vignoble</i> à 2 joueurs. Les cartes de plus d'un types dont l'un d'eux et <i>Action</i> comptent pour le <i>Vignoble</i>."
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "description": "Maintenant et au début de votre prochain tour : +2 Cartes et +1 Achat.",
         "extra": "Quai: Vous piochez 2 cartes et avez un achat supplémentaire ce tour-ci. Ensuite, au début de votre prochain tour, vous piochez à nouveau 2 cartes supplémentaires et vous avez un achat de plus. Vous ne piochez pas les 2 cartes de plus pour votre prochain tour avant que ce tour ne débute vraiment Laissez cette carte devant vous jusqu'à la phase <b>Ajustement</b> de votre prochain tour."
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page est échangée contre Chasseuse de Trésors, qui est échangée contre Guerrière, qui est échangée contre Héroïne, qui est échangée contre Championne.</justify><left><u>Page</u>: +1 Carte ; +1 Action</left><left><u>Chasseuse de Trésors</u>: +1 Action ; +1 Coin ; Recevez une carte <i>Argent</i> par carte que le joueur à votre droite a reçue lors de son dernier tour.</left><left><u>Guerrière</u>: +2 Cartes ; Pour chaque carte <i>Itinérant</i> que vous avez en jeu (incluant celle-ci), tous vos adversaires défaussent la première carte de leur deck et l'écartent si celle-ci coûte 3 Coins ou 4 Coins.</left><left><u>Héroïne</u>: +2 Coins ; Recevez une carte Trésor.</left><left><u>Championne</u>: +1 Action ; Pour le reste de la partie, lorsqu'un adversaire joue une carte <i>Attaque</i>, elle n'a pas d'effet sur vous, et quand vous jouez une carte <i>Action</i> : +1 Action. <i>(Cette carte reste en jeu.)</i></left>",
@@ -3364,11 +3344,6 @@
         "description": "+ 1 Action<n> Chaque joueur peut dévoiler une carte <i>Province</i> de sa main. Si vous le faites, défaussez-la et recevez une carte <i>Prix</i> (de la pile <i>Prix</i>) ou <i>Duché</i>, que vous placez sur votre deck. Si personne d'autre ne le fait: +1 Carte et +1 Coin.<n><justify>Prix: <u>Sac d'or</u>, <u>Diadème</u>, <u>Partisans</u>, <u>Princesse</u>, <u>Fidèle destrier</u></justify>",
         "extra": "Vous obtenez d'abord +1 Action. Ensuite, tous les joueurs peuvent dévoiler une carte <i>Province</i> de leur main,y compris vous. Ceux qui dévoilent une carte <i>Province</i> la défausse, reçoivent une carte <i>Prix</i> de leur choix ou un <i>Duché</i> et ils placent la carte reçue sur leur deck. S'il n'y a plus de carte dans votre deck, ce sera donc la seule carte. Il y a cinq cartes <i>Prix</i>, placées près de la réserve au début de la partie (voir la mise en place). Vous ne pouvez prendre qu'une carte <i>Prix</i> de la pile <i>Prix</i>. Vous pouvez y prendre la carte <i>Prix</i> que vous voulez, vous n'avez pas à prendre celle du dessus. Vous pouvez également prendre une carte <i>Duché</i>, même si la pile <i>Prix</i> n'est pas vide. Vous pouvez également choisir un <i>Prix</i> ou un <i>Duché</i>, même si la pile respective est vide ; dans ce cas, vous ne recevez rien. Après avoir reçu ou non une carte, si aucun aune joueur n'a dévoilé une carte <i>Province</i> ; piochez une carte et obtenez +1 Coin.<br>Lorsque vous jouez <i>Tournoi</i>, quatre situations peuvent se produire:<br>1) Ni vous, ni vos adversaires ne dévoilent de <i>Province</i>: vous obtenez +1 Action, +1 Carte et +1 Coin.<br>2) Vous êtes le seul à dévoiler une <i>Province</i>: vous recevez une carte <i>Prix</i> ou <i>Duché</i> que vous piochez et vous obtenez +1 Action et +1 Coin.<br>3) Vous et au moins un autre joueur dévoilez une <i>Province</i>: vous recevez une carte <I>Prix</i> ou <I>Duché</i> que vous mettez sur votre deck et +1 Action.<br>4) Vous ne dévoilez pas de <i>Province</i> mais au moins un autre joueur le fait: vous obtenez uniquement +1 Action.<br>Lorsque vous recevez un <i>Prix</i>, prenez la carte <i>Prix</i> toujours disponible de votre choix. Vous pouvez consulter la pile de cartes Prix à tout moment."
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Les Événements ne sont pas des cartes Royaume. Pendant la phase d'achat, au lieu d'acheter (et recevoir) une carte, vous pouvez acheter un Événement à la place. Acheter un Événement consiste à payer le coût indiqué sur la carte et faire ce qui est écrit dessus. La carte Événement reste en place sur la table et vous ne la prendrez jamais ; il n'y a AUCUN moyen de recevoir une carte Événement ou d'en avoir une dans son deck. Acheter un Événement consomme un Achat du tour ; en temps normal, vous ne pourrez acheter soit une carte (de la réserve), soit un Événement. Si vous avez deux Achats, comme par exemple après avoir joué Forestier, vous pourrez acheter deux cartes ou deux Événements, ou une carte et un Événement (dans l'ordre de votre choix). Un même Événement peut être acheté plusieurs fois dans un même tour si vous avez les Achats et des _ Coins suffisantes. Certains événements donnent des +Achats et permettent ainsi d'acheter d'autres cartes/Événements par la suite. Vous ne pourrez plus jouer de nouveaux Trésors une fois que vous avez acheté un Événement (mais vous pouvez jouer tous vos Trésor avant en prévision). Acheter un Événement n'est pas acheter une carte et ne déclenchera donc pas des cartes comme la Sorcière des Marais ou Fiers-à-Bras (de Dominion - Prospérité). Le coût des Événements n'est pas altéré par des cartes comme Pont aux Trolls.</justify>",

--- a/src/domdiv/card_db/it/cards_it.json
+++ b/src/domdiv/card_db/it/cards_it.json
@@ -349,25 +349,50 @@
         "extra": " Questa carta Regno è una carta Vittoria, non una carta Azione. Non fa nulla fino alla fine della partita, quando varrà 1 punto vittoria per ogni 3 carte Azione nel tuo mazzo (contando tutte le tue carte, la tua pila degli scarti e la mano fan parte del tuo mazzo a quel punto). Arrotonda per difetto; se hai 11 carte Azione, Vigna vale 3 punti vittoria. Durante la preparazione, metti 12 Vigne nella Riserva per una partita con 3, 4, 5 o 6 giocatori, 8 nella Riserva per una partita a 2 giocatori.",
         "name": "Vigna"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": " Peschi 2 carte ed hai un Acquisto extra in questo turno, e peschi altre 2 carte con un Acquisto extra all'inizio del tuo prossimo turno. Non peschi le 2 carte extra per il prossimo turno fin quando quel turno non inizia. Tieni questa carta davanti a te fino alla fase Pulizia del prossimo turno.",
         "name": "Molo"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
@@ -3364,11 +3344,6 @@
         "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
         "name": "Tournament and Prizes"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",

--- a/src/domdiv/card_db/nl_du/cards_nl_du.json
+++ b/src/domdiv/card_db/nl_du/cards_nl_du.json
@@ -349,25 +349,50 @@
         "extra": "Deze koninkrijkkaart is een overwinningskaart, geen actiekaart. De Wijnberg bevindt zich uitsluitend in het spel als deze aan het begin van het spel bij de 10 uitgekozen of getrokken koninkrijkkaart behoort. De kaart doet tijdens het spel niets. Aan het einde van het spel is de Wijnberg 1 <VP> waard per 3 actiekaarten in je deck (al je kaarten tellen mee, dus bijvoorbeeld ook je handkaarten). Rond naar beneden af. Voorbeeld: als je 11 actiekaarten in je deck hebt is de Wijnberg 3 <VP> waard. Een kaart die bij meerdere soorten kaarten hoort, waaronder actiekaarten, geldt als een actiekaart en wordt bij het bepalen van de overwinningspunten voor de Wijnberg meegeteld. Gebruik 8 Wijnbergkaarten in een spel met 2 spelers en 12 in een spel met 3 of meer spelers.",
         "name": "Wijnberg"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -3239,11 +3239,6 @@
         "extra": "Je trekt eerst 2 extra kaarten en krijgt 1 extra aanschaf in deze beurt. Aan het begin van je volgende beurt trek je nog 2 extra kaarten en krijg je 1 extra aanschaf in die beurt. Je trekt deze 2 kaarten pas als je volgende beurt begonnen is. De Scheepswerf blijft tot en met de opschoonfase van je volgende beurt in het spel.",
         "name": "Scheepswerf"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Grenswacht</u>:</left>\n+1 Actie\nToon de bovenste 2 kaarten van je trekstapel. Doe er één in je hand en leg de andere af. Als beide actiekaarten waren, neem dan de Lantaarn of de Hoorn.\n<left><u>Lantaarn</u>:</left>\nJe Grenswachten tonen 3 kaarten en leggen er 2 af. (Om de Hoorn te nemen, moeten ze alle 3 Acties tonen.)\n<left><u>Hoorn</u>:</left>\nEenmaal per beurt, als je een Grenswacht die in het spel is aflegt, mag je die op je trekstapel leggen.",
         "extra": "Speel je de Grenswacht en heb je de Lantaarn niet, dan toon je de bovenste 2 kaarten van je trekstapel. Je kiest er één en doet die in je hand. De andere leg je af. Waren deze beide actiekaarten, dan neem je de Lantaarn of de Hoorn. Speel je de Grenswacht en heb je de Lantaarn wel, dan toon je de bovenste 3 kaarten van je trekstapel. Je kiest er één en doet die in je hand. De andere 2 leg je af. Waren deze alle drie actiekaarten, dan mag je de Hoorn nemen. Toon je minder dan 2 kaarten, of minder dan 3 kaarten als je de Lantaarn hebt, dan mag je geen artefact nemen. Zowel de Hoorn als de Lantaarn functioneren in de beurt dat je ze neemt.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Kerkhof</u>:</left>\n2 <*VP*><line>Als je deze kaart pakt, vernietig dan ten hoogste 4 kaarten uit je hand.\n<i>Erfstuk: Spookspiegel</i>\n<left><u>Spookspiegel</u>:</left>\n1 <*COIN*><line>Als je deze kaart vernietigt, mag je een actiekaart afleggen om een Geest van de betreffende stapel te pakken.",
         "extra": "<left><u>Kerkhof</u>:</left>\nIn een spel met deze kaart: vervang één van je startkoperkaarten door een Spookspiegel. Als je een kerkhof pakt, vernietig je 0, 1, 2, 3 of 4 kaarten uit je hand.<left><u>Spookspiegel</u>:</left>\nDeze kaart geeft je geen mogelijkheid tot het vernietigen van een kaart, maar doet iets als je er op een andere manier in slaagt om een kaart te vernietigen.",
         "name": "Kerkhof / Spookspiegel"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "Deze stapel bestaat aan het begin van het spel uit 5 exemplaren Kampement en daaronder 5 exemplaren Plunderen. Uitsluitend de bovenste kaart van de stapel kan worden gepakt of gekocht.\n<line><left><u>Kampement</u>:</left>\n+2 Kaarten\n+2 Acties<n>Je mag een Goud- of een Plunderenkaart uit je hand tonen. Doe je dat niet, leg deze kaart dan opzij en leg hem aan het begin van je opschoonfase terug in de voorraad.\n<left><u>Plunderen</u>:</left>\n+2 Coin\n+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "<left><u>Dwaas</u>:</left>\nAls je Verdwaald in het Bos hebt, doet het spelen van Dwaas niets. Heb je Verdwaald in het Bos niet, dan neem je die (ook als een andere speler die momenteel bezit), trek je 3 Gunsten en ontvangt die in een volgorde naar keuze (je legt ze daarna af of houdt ze, zoals erop aangegeven). Het is niet verplicht om alle Gunsten in één keer te trekken. Je kunt er ook eerst één trekken, die uitvoeren, er weer één trekken, enzovoort. De speler met Verdwaald in het Bos (als die er is), mag aan het begin van zijn beurt kiezen of hij een kaart wil afleggen om een Gunst te ontvangen. In een spel met de Dwaas, vervangt iedere speler één van zijn startkoperkaarten door een Geluksmunt.\n<left><u>Geluksmunt</u>:</left>\nJe mag ervoor kiezen om Geluksmunt niet te spelen en dus geen Zilver te pakken.",
         "name": "Dwaas / Geluksmunt"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "Deze stapel bestaat aan het begin van het spel uit 5 exemplaren Gladiator en daaronder 5 exemplaren Fortuin. Uitsluitend de bovenste kaart van de stapel kan worden gepakt of gekocht.<line><left><u>Gladiator</u>:</left>\n+2 Coin\nToon een kaart uit je hand. Je linkerbuurman mag een zelfde exemplaar uit zijn hand tonen. Doet hij dit niet, dan +2 Coins en vernietig een Gladiator uit de voorraad.\n<left><u>Fortuin</u>:</left>\n+1 Aanschaf\nVerdubbel bij het spelen van deze kaart je _ Coin als je dat deze beurt nog niet hebt gedaan.<line>Als je deze kaart pakt, pak dan een Goud per Gladiator die je in het spel hebt.",
         "extra": "<left><u>Gladiator</u>:</left>\nZijn er geen Gladiators in voorraad, dan kun je geen Gladiators meer vernietigen, maar je krijgt nog wel de +1 Coin. Heb je geen kaarten in je hand, dan kan je de linkerbuurman geen exemplaar tonen van de kaart die jij toonde, dus je krijgt de +1 Coin en vernietigt een Gladiator.\n<left><u>Fortuin</u>:</left>\nJe verdubbelt je _ Coin alleen bij de eerste keer dat je Fortuin in je beurt speelt, bij elk volgende krijg je uitsluitend +1 Aanschaf.",
@@ -3298,11 +3283,6 @@
         "description": "Voorbereiding: leg de 3 Zombies op de stapel \"Vernietigde kaarten\".<line><left><u>Dodenbezweerder</u>:</left>\nSpeel een open, niet-duurzame actiekaart van de stapel \"Vernietigde kaarten\", laat de kaart daar liggen en draai deze om, zodat de kaart de rest van de beurt gedekt is.\n<left><u>Metselende Zombie</u>:</left>\nVernietig de bovenste kaart van je trekstapel. Je mag een kaart pakken die ten hoogste 1 Coin meer kost dan de vernietigde kaart.\n<left><u>Spionerende Zombie</u>:</left>\n+1 Kaart\n+1 Actie\nBekijk de bovenste kaart van je trekstapel. Leg deze af of leg deze terug.\n<left><u>Studerende Zombie</u>:</left>\nJe mag een actiekaart uit je hand vernietigen om +3 Kaarten en +1 Actie te krijgen.",
         "extra": "<left><u>Dodenbezweerder</u>:</left>\nHiermee speel je een niet-duurzame actiekaart uit de stapel \"Vernietigde kaarten\". Normaal gesproken kun je uit de 3 Zombies kiezen, die er aan het begin van het spel worden gelegd. Mochten er andere actiekaarten in de stapel zitten, dan mag je ook voor één van die kiezen. Draai op deze manier gespeelde kaarten om, om bij te houden dat elk ervan niet meer dan eenmaal per beurt op deze manier mag worden gebruikt. Draai de kaart(en) aan het einde van de beurt weer terug. Dodenbezweerder mag een andere Dodenbezweerder spelen, maar dat is normaal gesproken niet nuttig. De actiekaart blijft in de stapel \"Vernietigde kaarten\". Probeert een eigenschap de kaart te verplaatsen (zoals Kampement uit Dominion: Keizerrijken een kaart naar de voorraad verplaatst), dan lukt de verplaatsing niet. Dodenbezweerder mag gebruikt worden om een kaart te spelen die zichzelf vernietigt. Als de kaart controleert of deze was vernietigd (zoals Elfje), dan is dat niet het geval. Controleert de kaart dit niet (zoals Tragische Held), dan functioneert deze zoals gebruikelijk. Omdat de gespeelde kaart niet in het spel is, doen eigenschappen gecombineerd aan bijvoorbeeld \"zolang de kaart in het spel is\" (zoals die van Spoorzoeker) niets.<left><u>Metselende Zombie</u>:</left>\nHet pakken van een kaart is optioneel. Je mag een kaart pakken die 1 Coin meer kost dan de vernietigde kaart of een goedkopere kaart. Je zou bijvoorbeeld een exemplaar van de vernietigde kaart mogen pakken.\n<left><u>Spionerende Zombie</u>:</left>\nJe trekt een kaart vóórdat je de bovenste kaart bekijkt.\n<left><u>Studerende Zombie</u>:</left>\nVernietig je een kaart uit je hand, dan trek je 3 kaarten en krijg je +1 Actie.",
         "name": "Dodenbezweerder / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Deze kaarten zijn een koninkrijkkaart van het soort Reiziger. Een Wapenknecht kan bij afleggen naar een Roofridder worden opgewaardeerd, deze op zijn beurt naar een Krijger, deze op zijn beurt naar een Held en deze op zijn beurt naar een Kampioen.</justify><line><left><u>Wapenknecht</u>:</left>\n+1 Kaart\n+1 Actie\n<left><u>Roofridder</u>:</left>\n+1 Actie\n+1 Coin\nPak 1 Zilver per kaart die de speler rechts van je in zijn laatste beurt heeft gepakt.\n<left><u>Krijger</u>:</left>\n+2 Kaarten\nVoor iedere Reiziger die je in het spel hebt (met inbegrip van deze kaart), legt iedere andere speler de bovenste kaart van zijn gedekte stapel af en vernietigt deze als de waarde ervan 3 Coins of 4 Coins is.\n<left><u>Held</u>:</left>\n+2 Coins\nPak een geldkaart.\n<left><u>Kampioen</u>:</left>\n+1 Actie\nJe bent voor de rest van het spel beschermd tegen aanvalskaarten van andere spelers. Elke keer dat je een actie speelt: +1 Actie.\n<left><i>(De stapels met Roofridder, Krijger, Held en Kampioen kaarten bevinden zich niet in de voorraad.)</i></left>",
@@ -3364,11 +3344,6 @@
         "extra": "Eerst krijg je +1 Actie. Daarna mag iedere speler, inclusief jijzelf, een Provincie uit zijn hand tonen. Toon jij zelf een Provincie, leg deze dan af en pak een Prijs naar keuze of een Hertogdom. Leg de gekozen kaart op je trekstapel. Heb je geen kaarten in je trekstapel, dan wordt de gekozen kaart de enige kaart van je trekstapel. Er zijn 5 Prijzen in het spel. Je mag uitsluitend Prijzen uit de voorraad pakken. Je mag zelf kiezen welke Prijs je pakt, dat hoeft dus niet de bovenste van de stapel te zijn. Ook als de Prijzen niet op zijn, mag je ervoor kiezen om een Hertogdom te pakken. Je kunt er ook voor kiezen om een Hertogdom te pakken als deze niet meer beschikbaar zijn. In dat geval pak je niets. Toon geen van de andere spelers een Provincie, dan trek je 1 kaart en je krijgt +1 Coin (ongeacht of je al dan niet een kaart gepakt). Als je een Prijs pakt, mag je vrij uit de Prijsstapel kiezen. Iedere speler mag op elk moment de Prijsstapel doorkijken.<line>Deze kaarten zijn nooit onderdeel van de voorraad. Dit is de enige regel voor Prijzen, maar dit heeft verschillende gevolgen. Is de stapel Prijzen leeg, dan telt deze niet mee bij het bepalen van het einde van het spel. Prijzen kunnen niet worden gekocht of worden gepakt als gevolg van bepaalde kaarten (zoals bijvoorbeeld Hoorn des Overvloeds). Ze kunnen uitsluitend via de kaart Toernooi worden gepakt of als gevolg van kaarten die geen betrekking op de voorraad hebben (zoals bijvoorbeeld de Dief uit het basisspel). De Boodschapper (uit Dominion: Hijs de Zeilen!) kan geen Prijzen naar de Prijsstapel terugsturen. Vernietigde Prijzen komen zoals gebruikelijk op de stapel Vernietigde Kaarten. Prijzen kunnen niet worden gekocht, maar hebben een waarde van 0 Coins, die van belang is voor kaarten zoals bijvoorbeeld Nieuwe Versie.",
         "name": "Toernooi en Prijzen"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Spoorzoeker</u>:</left>\n+ 1 Coins\nOntvang een Gunst<line>Zolang deze kaart in het spel is, mag je een kaart die je pakt op je trekstapel leggen.\n<i>Erfstuk: Buidel</i>\n<left><u>Buidel</u>:</left>\n1 <*COIN*>\n+1 Aanschaf",
         "extra": "<left><u>Spoorzoeker</u>:</left>\nPak je meerdere kaarten terwijl je de Spoorzoeker in het spel hebt, dan geldt diens eigenschap voor elk van die kaarten. Je mag er zoveel je wilt op je trekstapel leggen. Dit geldt zowel voor gekochte kaarten als kaarten die je op een andere manier hebt gepakt terwijl Spoorzoeker in het spel is. Spoorzoeker is in het spel op het moment dat je de Gunst ontvangt, dus als de Gunst je een kaart laat pakken (zoals bijvoorbeeld Zilver bij de Gift van de Bergen), mag je die kaart op je trekstapel leggen. In spellen met Spoorzoeker vervangt iedere speler één van zijn startkoperkaarten door een Buidel.\n<left><u>Buidel</u>:</left>\nHet spelen van deze kaart geeft je 1 Coin en +1 Aanschaf.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampier</u>:</left>\nIedere andere speler krijgt de volgende Spreuk.<n>Pak een kaart die ten hoogste 5 Coins kost (geen Vampier).<n>Ruil deze Vampierkaart tegen een Vleermuis.\n<left><u>Vleermuis</u>:</left>\nVernietig ten hoogste 2 kaarten uit je hand. Heb je ten minste 1 kaart vernietigd, ruil deze Vleermuis dan tegen een Vampier.\n<i>(Vleermuizen zijn geen onderdeel van de voorraad.)</i>",
         "extra": "<left><u>Vampier</u>:</left>\nVolg de aanwijzingen in volgorde op. Is de stapel \"Vleermuizen\" op, dan kun je de Vampier niet tegen een Vleermuis ruilen, maar je voert de rest wel uit. Leg de Vleermuis op je aflegstapel.\n<left><u>Vleermuis</u>:</left>\nLeg de Vampier op je aflegstapel. Als de stapel Vampieren leeg is, kun je de Vleermuis niet tegen een Vampier ruilen, maar je mag nog wel kaarten vernietigen.",
         "name": "Vampier / Vleermuis"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Gebeurteniskaarten gelden niet als koninkrijkkaarten. Een speler mag in zijn aanschaffase in plaats van een kaart een gebeurtenis kopen. Hij betaalt dan de op de gebeurteniskaart aangegeven kosten en voert de bijbehorende functie uit. De gebeurtenis blijft op tafel liggen (deze kan zich nooit in een stapel, op een tableau of in de hand van een speler bevinden). Met het kopen van een gebeurtenis verbruikt de speler 1 aanschaf. Heeft een speler meer aanschaffen in zijn beurt, dan mag hij deze naar believen (en in een volgorde naar keuze) verdelen over het kopen van kaarten en gebeurtenissen.</justify>",

--- a/src/domdiv/card_db/xx/cards_xx.json
+++ b/src/domdiv/card_db/xx/cards_xx.json
@@ -349,25 +349,50 @@
         "extra": "This Kingdom card is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point per 3 Action cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Round down; if you have 11 Action cards, Vineyard is worth 3 victory points. During set-up, put all 12 Vineyards in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game. Cards with multiple types, one of which is Action, are Actions and so are counted by Vineyard.",
         "name": "Vineyard"
     },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
     "acolyte": {
         "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
-        "extra": "",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
         "name": "Acolyte"
     },
     "archer": {
         "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
-        "extra": "",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
         "name": "Archer"
     },
     "architects_guild": {
         "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
         "extra": "",
         "name": "Architects' Guild"
-    },
-    "augurs": {
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Augurs"
     },
     "band_of_nomads": {
         "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
@@ -376,37 +401,37 @@
     },
     "barbarian": {
         "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
-        "extra": "",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
         "name": "Barbarian"
     },
     "battle_plan": {
         "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
         "name": "Battle Plan"
     },
     "bauble": {
         "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
-        "extra": "",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
         "name": "Bauble"
     },
     "blacksmith": {
         "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
         "name": "Blacksmith"
     },
     "broker": {
         "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
-        "extra": "",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
         "name": "Broker"
     },
     "capital_city": {
         "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
         "name": "Capital City",
-        "extra": ""
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful."
     },
     "carpenter": {
         "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
-        "extra": "",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
         "name": "Carpenter"
     },
     "cave_dwellers": {
@@ -424,11 +449,6 @@
         "extra": "",
         "name": "City-state"
     },
-    "clashes": {
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Clashes"
-    },
     "coastal_haven": {
         "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
         "extra": "",
@@ -436,17 +456,17 @@
     },
     "conjurer": {
         "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
-        "extra": "",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
         "name": "Conjurer"
     },
     "contract": {
         "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
-        "extra": "",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
         "name": "Contract"
     },
     "courier": {
         "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
-        "extra": "",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
         "name": "Courier"
     },
     "crafters_guild": {
@@ -461,17 +481,17 @@
     },
     "distant_shore": {
         "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
         "name": "Distant Shore"
     },
     "elder": {
         "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
-        "extra": "",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
         "name": "Elder"
     },
     "emissary": {
         "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
-        "extra": "",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
         "name": "Emissary"
     },
     "family_of_inventors": {
@@ -489,14 +509,9 @@
         "extra": "",
         "name": "Forest Dwellers"
     },
-    "forts": {
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Forts"
-    },
     "galleria": {
         "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
-        "extra": "",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
         "name": "Galleria"
     },
     "gang_of_pickpockets": {
@@ -506,42 +521,42 @@
     },
     "garrison": {
         "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
-        "extra": "",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
         "name": "Garrison"
     },
     "guildmaster": {
         "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
-        "extra": "",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
         "name": "Guildmaster"
     },
     "herb_gatherer": {
         "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
-        "extra": "",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
         "name": "Herb Gatherer"
     },
     "highwayman": {
         "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
-        "extra": "",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
         "name": "Highwayman"
     },
     "hill_fort": {
         "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
-        "extra": "",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
         "name": "Hill Fort"
     },
     "hunter": {
         "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
-        "extra": "",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
         "name": "Hunter"
     },
     "importer": {
         "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
-        "extra": "",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
         "name": "Importer"
     },
     "innkeeper": {
         "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
-        "extra": "",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
         "name": "Innkeeper"
     },
     "island_folk": {
@@ -561,7 +576,7 @@
     },
     "lich": {
         "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
-        "extra": "",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
         "name": "Lich"
     },
     "market_towns": {
@@ -571,22 +586,22 @@
     },
     "marquis": {
         "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
-        "extra": "",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
         "name": "Marquis"
     },
     "merchant_camp": {
         "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
         "name": "Merchant Camp"
     },
     "miller": {
         "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
-        "extra": "",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
         "name": "Miller"
     },
     "modify": {
         "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
-        "extra": "",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
         "name": "Modify"
     },
     "mountain_folk": {
@@ -594,14 +609,9 @@
         "extra": "",
         "name": "Mountain Folk"
     },
-    "odysseys": {
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Odysseys"
-    },
     "old_map": {
         "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
-        "extra": "",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
         "name": "Old Map"
     },
     "order_of_astrologers": {
@@ -626,88 +636,83 @@
     },
     "royal_galley": {
         "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
-        "extra": "",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
         "name": "Royal Galley"
     },
     "sentinel": {
         "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
-        "extra": "",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
         "name": "Sentinel"
     },
     "sibyl": {
         "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
-        "extra": "",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
         "name": "Sibyl"
     },
     "skirmisher": {
-        "extra": "",
-        "name": "Skirmisher",
-        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand."
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher"
     },
     "sorcerer": {
         "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
-        "extra": "",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
         "name": "Sorcerer"
     },
     "sorceress": {
         "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
-        "extra": "",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
         "name": "Sorceress"
     },
     "specialist": {
         "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
-        "extra": "",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
         "name": "Specialist"
     },
     "stronghold": {
         "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
-        "extra": "",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
         "name": "Stronghold"
     },
     "student": {
         "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
-        "extra": "",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
         "name": "Student"
     },
     "sunken_treasure": {
         "description": "Gain an Action card you don't have a copy of in play.",
-        "extra": "",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
         "name": "Sunken Treasure"
     },
     "swap": {
         "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
-        "extra": "",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
         "name": "Swap"
     },
     "sycophant": {
         "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
-        "extra": "",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
         "name": "Sycophant"
     },
     "tent": {
         "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
-        "extra": "",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
         "name": "Tent"
     },
     "territory": {
         "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
-        "extra": "",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
         "name": "Territory"
     },
     "town": {
         "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
-        "extra": "",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
         "name": "Town"
     },
     "town_crier": {
         "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
-        "extra": "",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
         "name": "Town Crier"
-    },
-    "townsfolk": {
-        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that orer. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Townsfolk"
     },
     "trappers_lodge": {
         "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
@@ -716,23 +721,18 @@
     },
     "underling": {
         "description": "+1 Card<br>+1Action<br>+1 Favor",
-        "extra": "",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
         "name": "Underling"
     },
     "voyage": {
         "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
-        "extra": "",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
         "name": "Voyage"
     },
     "warlord": {
         "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
-        "extra": "",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
         "name": "Warlord"
-    },
-    "wizards": {
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
-        "extra": "",
-        "name": "Wizards"
     },
     "woodworkers_guild": {
         "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
@@ -2196,7 +2196,7 @@
     },
     "Way of the Butterfly": {
         "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
-        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like HorseHorse.jpg) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
         "name": "Way of the Butterfly"
     },
     "Way of the Camel": {
@@ -3239,11 +3239,6 @@
         "extra": "You draw 2 cards and get an extra Buy this turn, and then draw 2 more cards and get another extra Buy at the start of your next turn. You don't draw your extra 2 cards for the next turn until that turn actually starts. Leave this in front of you until the Clean-up phase of your next turn.",
         "name": "Wharf"
     },
-    "Augurs": {
-        "extra": "",
-        "name": "Augurs",
-        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought."
-    },
     "Border Guard - LanternHorn": {
         "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
         "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
@@ -3258,11 +3253,6 @@
         "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
         "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
         "name": "Cemetery / Haunted Mirror"
-    },
-    "Clashes": {
-        "extra": "",
-        "name": "Clashes",
-        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought."
     },
     "Encampment - Plunder": {
         "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1<VP>",
@@ -3279,11 +3269,6 @@
         "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
         "name": "Fool / Lucky Coin"
     },
-    "Forts": {
-        "extra": "",
-        "name": "Forts",
-        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought."
-    },
     "Gladiator - Fortune": {
         "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
         "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
@@ -3298,11 +3283,6 @@
         "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
         "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
         "name": "Necromancer / Zombies"
-    },
-    "Odysseys": {
-        "extra": "",
-        "name": "Odysseys",
-        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought."
     },
     "Page -> Champion": {
         "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
@@ -3364,11 +3344,6 @@
         "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
         "name": "Tournament and Prizes"
     },
-    "Townsfolk": {
-        "extra": "",
-        "name": "Townsfolk",
-        "description": ""
-    },
     "Tracker - Pouch": {
         "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
         "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
@@ -3388,11 +3363,6 @@
         "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
         "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
         "name": "Vampire / Bat"
-    },
-    "Wizards": {
-        "extra": "",
-        "name": "Wizards",
-        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought."
     },
     "adventures events": {
         "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",


### PR DESCRIPTION
First pass at adding "extra" fields for Allies dividers.  I had to do some cleanup regarding the split piles randomizers, choosing to index by capitalized name for consistency with the grouping tags.  Not doing that led to errors from update_languages.