### PR TITLE
Initial Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.dockerignore
+.dockerfile
+README.md
+requirements.txt
+.github
+tools
+*pdf

--- a/README.md
+++ b/README.md
@@ -45,3 +45,31 @@ Tests can be run (and their dependencies installed) via `python setup.py test`, 
 ## Image Sources
 
 There is a separate [repo](https://github.com/sumpfork/dominiontabs_img_sources) for the image sources. While these are optional, they can be useful reference and/or used for creating new or recreating old tab banners, icons, etc. Many of these were originally scans of the physical game. Some of them have a lot of layers and are approaching 1GB in size, so they are hosted via [Git LFS](https://git-lfs.com/). As the Github version of that incurs a higher monthly cost, I instead host them on a private LFS server. If you would like the images or would like to contribute images let me know and I can make you an account on said server, or you I can copy them for you for easier access.
+
+## Docker
+
+The project can be compiled into a container:
+
+`docker build . -t dominiontabs`
+
+Once you have the `dominiontabs` container you can run it from your CLI and pass it arguments like so:
+
+`docker run dominiontabs`
+
+<!--TODO update this doc to pull pre-built images from GitHub once those are set up-->
+
+Which will, by default, dump the output of the help text of the CLI tool. But we're going to want to add in some extra args 99% of the time. 
+
+1. Bind mount to an output directory (`-v`) and tell the script to output there so that we get a PDF in the local filesystem when things are done (`--outfile ./output/foo.pdf`).
+2. Add the `--rm` argo to tell docker not to save a container each time it runs.
+3. Add a few CLI args to reduce the runtime and file size (`--expansions cornucopia`).
+
+So now we have
+
+`docker run --rm -v $PWD/output:/app/output dominiontabs --expansions cornucopia --outfile ./output/dominion_dividers_docker.pdf`
+
+Once that runs you should have under your current directory: 
+
+`./output/dominion_dividers_docker.pdf`
+
+From there you feel free to add other arguments as you like!

--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ Once you have the `dominiontabs` container you can run it from your CLI and pass
 
 <!--TODO update this doc to pull pre-built images from GitHub once those are set up-->
 
-Which will, by default, dump the output of the help text of the CLI tool. But we're going to want to add in some extra args 99% of the time. 
+Which will, by default, dump the output of the help text of the CLI tool. But we're going to want to add in some extra args 99% of the time.
 
 1. Bind mount to an output directory (`-v`) and tell the script to output there so that we get a PDF in the local filesystem when things are done (`--outfile ./output/foo.pdf`).
-2. Add the `--rm` argo to tell docker not to save a container each time it runs.
-3. Add a few CLI args to reduce the runtime and file size (`--expansions cornucopia`).
+1. Add the `--rm` argo to tell docker not to save a container each time it runs.
+1. Point to the fonts built in to the image with `--font-dir /fonts`
+1. Add a few CLI args to reduce the runtime and file size (`--expansions cornucopia`).
 
 So now we have
 
 `docker run --rm -v $PWD/output:/app/output dominiontabs --expansions cornucopia --outfile ./output/dominion_dividers_docker.pdf`
 
-Once that runs you should have under your current directory: 
+Once that runs you should have under your current directory:
 
 `./output/dominion_dividers_docker.pdf`
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Which will, by default, dump the output of the help text of the CLI tool. But we
 
 So now we have
 
-`docker run --rm -v $PWD/output:/app/output dominiontabs --expansions cornucopia --outfile ./output/dominion_dividers_docker.pdf`
+`docker run -v $PWD/output:/app/output --rm dominiontabs --font-dir /fonts --expansions cornucopia --outfile ./output/dominion_dividers_docker.pdf`
 
 Once that runs you should have under your current directory:
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9-slim AS compile-image
 
+# get fonts
+COPY --from=pacodrokad/fonts /fonts /fonts
+
 # Add git for hooks
 RUN apt-get update && apt-get install -y --no-install-recommends git
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.9-slim AS compile-image
+
+# Add git for hooks
+RUN apt-get update && apt-get install -y --no-install-recommends git
+
+# get pip tools for computing requirements, and compile them
+RUN python -m pip install pip-tools
+
+# Set the working directory in the container (creating it in the process)
+WORKDIR /app
+
+# compile our requirements and then install them
+COPY requirements.in .
+RUN pip-compile --no-emit-index-url requirements.in && \
+    pip install -r requirements.txt
+
+# Copy the local directory contents into the container at /app
+COPY . .
+
+# install the application
+RUN python setup.py develop
+
+ENTRYPOINT ["/usr/local/bin/dominion_dividers"]
+CMD ["--help"]


### PR DESCRIPTION
This adds a `dockerfile` that can be built more easily and platform-agnostic than the Python virtual env and some instructions for how to run that via CLI. This was based on my own suggested in [another PR](https://github.com/sumpfork/dominiontabs/pull/499#issuecomment-1954833806).

@sumpfork LMK if you have questions, otherwise go ahead and merge this.

Potential next steps:

1. Build the dockerfile via GitHub Workflows and host a pre-built one in this project
2. Add additional dockerfile-based testing steps to make testing easier
3. Add instructions to bind mount the project dir to use docker in development iteration loop