### PR TITLE
Remove use of pkg_resources

### DIFF
--- a/src/domdiv/db.py
+++ b/src/domdiv/db.py
@@ -1,6 +1,5 @@
 import copy
 import functools
-import importlib.resources
 import json
 import os
 
@@ -20,18 +19,18 @@ LANGUAGE_XX = "xx"  # a dummy language for starting translations
 @functools.lru_cache()
 def get_languages(path="card_db"):
     languages = []
-    for name in importlib.resources.files(f"domdiv").joinpath(path).iterdir():
-        dir_path = os.path.join(path, name)
-        if importlib.resources.files("domdiv").joinpath(dir_path).is_dir():
-            cards_file = os.path.join(dir_path, f"cards_{name}.json.gz")
-            sets_file = os.path.join(dir_path, f"sets_{name}.json.gz")
-            types_file = os.path.join(dir_path, f"types_{name}.json.gz")
+    for name in resource_handling.iter_resource_dir(path):
+        lang = os.path.basename(name)
+        if resource_handling.is_resource_dir(name):
+            cards_file = os.path.join(name, f"cards_{lang}.json.gz")
+            sets_file = os.path.join(name, f"sets_{lang}.json.gz")
+            types_file = os.path.join(name, f"types_{lang}.json.gz")
             if (
                 resource_handling.resource_exists(cards_file)
                 and resource_handling.resource_exists(sets_file)
                 and resource_handling.resource_exists(types_file)
             ):
-                languages.append(name)
+                languages.append(lang)
     if LANGUAGE_XX in languages:
         languages.remove(LANGUAGE_XX)
     return languages

--- a/src/domdiv/db.py
+++ b/src/domdiv/db.py
@@ -1,13 +1,12 @@
 import copy
 import functools
-import gzip
+import importlib.resources
 import json
 import os
 
-import pkg_resources
 from loguru import logger
 
-from . import config_options, db
+from . import config_options, db, resource_handling
 from .cards import Card, CardType
 
 EXPANSION_EXTRA_POSTFIX = " extras"
@@ -21,16 +20,16 @@ LANGUAGE_XX = "xx"  # a dummy language for starting translations
 @functools.lru_cache()
 def get_languages(path="card_db"):
     languages = []
-    for name in pkg_resources.resource_listdir("domdiv", path):
+    for name in importlib.resources.files(f"domdiv").joinpath(path).iterdir():
         dir_path = os.path.join(path, name)
-        if pkg_resources.resource_isdir("domdiv", dir_path):
+        if importlib.resources.files("domdiv").joinpath(dir_path).is_dir():
             cards_file = os.path.join(dir_path, f"cards_{name}.json.gz")
             sets_file = os.path.join(dir_path, f"sets_{name}.json.gz")
             types_file = os.path.join(dir_path, f"types_{name}.json.gz")
             if (
-                pkg_resources.resource_exists("domdiv", cards_file)
-                and pkg_resources.resource_exists("domdiv", sets_file)
-                and pkg_resources.resource_exists("domdiv", types_file)
+                resource_handling.resource_exists(cards_file)
+                and resource_handling.resource_exists(sets_file)
+                and resource_handling.resource_exists(types_file)
             ):
                 languages.append(name)
     if LANGUAGE_XX in languages:
@@ -38,16 +37,10 @@ def get_languages(path="card_db"):
     return languages
 
 
-def get_resource_stream(path):
-    return gzip.GzipFile(
-        fileobj=pkg_resources.resource_stream("domdiv", path),
-    )
-
-
 @functools.lru_cache()
 def get_expansions():
     set_db_filepath = os.path.join("card_db", "sets_db.json.gz")
-    with get_resource_stream(set_db_filepath) as setfile:
+    with resource_handling.get_resource_stream(set_db_filepath) as setfile:
         set_file = json.loads(setfile.read().decode("utf-8"))
     assert set_file, "Could not load any sets from database"
 
@@ -69,7 +62,7 @@ def get_expansions():
 @functools.lru_cache()
 def get_global_groups():
     type_db_filepath = os.path.join("card_db", "types_db.json.gz")
-    with get_resource_stream(type_db_filepath) as typefile:
+    with resource_handling.get_resource_stream(type_db_filepath) as typefile:
         type_file = json.loads(typefile.read().decode("utf-8"))
     assert type_file, "Could not load any card types from database"
 
@@ -90,7 +83,7 @@ def get_types(language=LANGUAGE_DEFAULT):
     # get a list of valid types
     language = language.lower()
     type_text_filepath = os.path.join("card_db", language, f"types_{language}.json.gz")
-    with get_resource_stream(type_text_filepath) as type_text_file:
+    with resource_handling.get_resource_stream(type_text_filepath) as type_text_file:
         type_text = json.loads(type_text_file.read().decode("utf-8"))
     assert type_text, "Could not load type file for %r" % language
 
@@ -105,7 +98,7 @@ def get_label_data():
     label_choices = []
     label_keys = []
     label_selections = []
-    with get_resource_stream(labels_db_filepath) as labelfile:
+    with resource_handling.get_resource_stream(labels_db_filepath) as labelfile:
         label_info = json.loads(labelfile.read().decode("utf-8"))
     assert label_info, "Could not load label information from database"
     for label in label_info:
@@ -151,7 +144,7 @@ def find_index_of_object(lst=None, attributes=None):
 def read_card_data(options):
     # Read in the card types
     types_db_filepath = os.path.join("card_db", "types_db.json.gz")
-    with db.get_resource_stream(types_db_filepath) as typefile:
+    with resource_handling.get_resource_stream(types_db_filepath) as typefile:
         Card.types = json.loads(
             typefile.read().decode("utf-8"), object_hook=CardType.decode_json
         )
@@ -171,14 +164,14 @@ def read_card_data(options):
 
     # Read in the card database
     card_db_filepath = os.path.join("card_db", "cards_db.json.gz")
-    with get_resource_stream(card_db_filepath) as cardfile:
+    with resource_handling.get_resource_stream(card_db_filepath) as cardfile:
         cards = json.loads(
             cardfile.read().decode("utf-8"), object_hook=Card.decode_json
         )
     assert cards, "Could not load any cards from database"
 
     set_db_filepath = os.path.join("card_db", "sets_db.json.gz")
-    with get_resource_stream(set_db_filepath) as setfile:
+    with resource_handling.get_resource_stream(set_db_filepath) as setfile:
         Card.sets = json.loads(setfile.read().decode("utf-8"))
     assert Card.sets, "Could not load any sets from database"
     new_sets = {}

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -3,7 +3,6 @@ import numbers
 import os
 import re
 
-import pkg_resources
 from loguru import logger
 from PIL import Image, ImageEnhance
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT
@@ -16,6 +15,7 @@ from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen import canvas
 from reportlab.platypus import Paragraph, XPreformatted
 
+from . import resource_handling
 from .cards import Card
 
 
@@ -476,10 +476,6 @@ class DividerDrawer(object):
         self.pages = None
         self.options = options
 
-    @staticmethod
-    def get_image_filepath(fname):
-        return pkg_resources.resource_filename("domdiv", os.path.join("images", fname))
-
     def draw(self, cards=None, options=None):
         if cards is None:
             cards = []
@@ -581,7 +577,7 @@ class DividerDrawer(object):
                         fontpaths[font] = (fpath, True)
                         break
                 fpath = os.path.join("fonts", fname)
-                if pkg_resources.resource_exists("domdiv", fpath):
+                if resource_handling.resource_exists(fpath):
                     fontpaths[font] = (fpath, False)
                     break
         logger.trace(fontpaths)
@@ -694,7 +690,7 @@ class DividerDrawer(object):
                     (
                         fontpath
                         if is_local
-                        else pkg_resources.resource_filename("domdiv", fontpath)
+                        else resource_handling.get_resource_filepath(fontpath)
                     ),
                 )
             )
@@ -1163,7 +1159,7 @@ class DividerDrawer(object):
                     )
                     replace = font_replace + replace
                 replace = replace.format(
-                    fpath=DividerDrawer.get_image_filepath(fname),
+                    fpath=resource_handling.get_image_filepath(fname),
                     width=fontsize * fontsize_multiplier,
                     height_percent=height_percent,
                 )
@@ -1258,7 +1254,7 @@ class DividerDrawer(object):
             width += 16
             x -= 16
             self.canvas.drawImage(
-                DividerDrawer.get_image_filepath("card.png"),
+                resource_handling.get_image_filepath("card.png"),
                 x,
                 countHeight,
                 16,
@@ -1363,7 +1359,7 @@ class DividerDrawer(object):
             self.canvas.restoreState()
 
         def scaleImage(name, x, y, h, mask="auto"):
-            path = DividerDrawer.get_image_filepath(name)
+            path = resource_handling.get_image_filepath(name)
             with Image.open(path) as img:
                 w0, h0 = img.size
             scale = h / h0
@@ -1395,7 +1391,7 @@ class DividerDrawer(object):
     def drawSetIcon(self, setImage, x, y):
         # set image
         size = self.SET_ICON_SIZE
-        path = DividerDrawer.get_image_filepath(setImage)
+        path = resource_handling.get_image_filepath(setImage)
         self.canvas.drawImage(
             path, x, y, size, size, mask="auto", preserveAspectRatio=True
         )
@@ -1456,7 +1452,7 @@ class DividerDrawer(object):
         from io import BytesIO
 
         # Get the original image.
-        artwork = DividerDrawer.get_image_filepath(image)
+        artwork = resource_handling.get_image_filepath(image)
 
         # Make any optional adjustments.
         if resolution != 0 or opacity != 1.0:

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -8,7 +8,7 @@ from collections import Counter, defaultdict
 from loguru import logger
 from reportlab.lib.units import cm
 
-from . import config_options, db
+from . import config_options, db, resource_handling
 from .cards import Card
 from .draw import DividerDrawer
 
@@ -147,7 +147,7 @@ def add_card_text(cards, language="en_us"):
     card_text_filepath = os.path.join(
         "card_db", language, "cards_" + language.lower() + ".json.gz"
     )
-    with db.get_resource_stream(card_text_filepath) as card_text_file:
+    with resource_handling.get_resource_stream(card_text_filepath) as card_text_file:
         card_text = json.loads(card_text_file.read().decode("utf-8"))
     assert language, "Could not load card text for %r" % language
 
@@ -167,7 +167,7 @@ def add_set_text(options, sets, language="en_us"):
     language = language.lower()
     # Read in the set text and store for later
     set_text_filepath = os.path.join("card_db", language, f"sets_{language}.json.gz")
-    with db.get_resource_stream(set_text_filepath) as set_text_file:
+    with resource_handling.get_resource_stream(set_text_filepath) as set_text_file:
         set_text = json.loads(set_text_file.read().decode("utf-8"))
     assert set_text, "Could not load set text for %r" % language
 
@@ -185,7 +185,7 @@ def add_type_text(types=None, language="en_us"):
     language = language.lower()
     # Read in the type text and store for later
     type_text_filepath = os.path.join("card_db", language, f"types_{language}.json.gz")
-    with db.get_resource_stream(type_text_filepath) as type_text_file:
+    with resource_handling.get_resource_stream(type_text_filepath) as type_text_file:
         type_text = json.loads(type_text_file.read().decode("utf-8"))
     assert type_text, "Could not load type text for %r" % language
 
@@ -209,7 +209,9 @@ def add_bonus_regex(options, language="en_us"):
     bonus_regex_filepath = os.path.join(
         "card_db", language, f"bonuses_{language}.json.gz"
     )
-    with db.get_resource_stream(bonus_regex_filepath) as bonus_regex_file:
+    with resource_handling.get_resource_stream(
+        bonus_regex_filepath
+    ) as bonus_regex_file:
         bonus_regex = json.loads(bonus_regex_file.read().decode("utf-8"))
     assert bonus_regex, "Could not load bonus keywords for %r" % language
 

--- a/src/domdiv/resource_handling.py
+++ b/src/domdiv/resource_handling.py
@@ -5,6 +5,14 @@ import importlib.resources
 import os
 
 
+def iter_resource_dir(path):
+    return importlib.resources.files(f"domdiv").joinpath(path).iterdir()
+
+
+def is_resource_dir(path):
+    return importlib.resources.files(f"domdiv").joinpath(path).is_dir()
+
+
 @contextlib.contextmanager
 def get_resource_stream(path):
     ref = importlib.resources.files("domdiv").joinpath(path)

--- a/src/domdiv/resource_handling.py
+++ b/src/domdiv/resource_handling.py
@@ -1,0 +1,28 @@
+import atexit
+import contextlib
+import gzip
+import importlib.resources
+import os
+
+
+@contextlib.contextmanager
+def get_resource_stream(path):
+    ref = importlib.resources.files("domdiv").joinpath(path)
+    with ref.open("rb") as f:
+        yield gzip.GzipFile(fileobj=f)
+
+
+def get_resource_filepath(fpath):
+    file_manager = contextlib.ExitStack()
+    atexit.register(file_manager.close)
+    ref = importlib.resources.files("domdiv") / fpath
+    path = file_manager.enter_context(importlib.resources.as_file(ref))
+    return path
+
+
+def get_image_filepath(fname):
+    return get_resource_filepath(os.path.join("images", fname))
+
+
+def resource_exists(fpath):
+    return importlib.resources.files("domdiv").joinpath(fpath).is_file()


### PR DESCRIPTION
This has come up a couple of times, latest in #544.

pkg_resource from setuptools is deprecated and often not installed (we don't specify it as a runtime dependency anywhere, which is bad.

So, upgrade to use importlib.resources.

Fixes #325.