### PR TITLE
Keep arrows in card names for groups, but always render in Times Bold

### DIFF
--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -668,6 +668,13 @@ class DividerDrawer(object):
             "Monospaced": [
                 "Courier",
             ],
+            "Arrow": [  # The custom fonts don't have the → character used for e.g. traveller card groups
+                (
+                    "Times-Bold"
+                    if langlatin1 or timesTTF_not_found
+                    else "Times-Bold-TTF"
+                ),
+            ],
         }
         self.fontStyle = {
             # select the first matching preference for each font type
@@ -1435,7 +1442,10 @@ class DividerDrawer(object):
         for i, part in enumerate(name_parts):
             if i != 0:
                 w += pdfmetrics.stringWidth(" ", font, caps)
-            if small == caps:
+            # Render arrows in Times Bold, because the other Name fonts don't support it.
+            if part == "→":
+                w += pdfmetrics.stringWidth(part, self.fontStyle["Arrow"], fontSize)
+            elif small == caps:
                 w += pdfmetrics.stringWidth(part, font, caps)
             else:
                 w += pdfmetrics.stringWidth(part[0], font, caps)
@@ -1685,8 +1695,6 @@ class DividerDrawer(object):
         textWidth -= textInsetRight
 
         name = card.name
-        # arrows don't format properly in all fonts, so convert them to en dashes
-        name = name.replace("→", "–")
         style = "Expansion" if card.isExpansion() else "Name"
         width = self.nameWidth(name, fontSize, style)
         while width > textWidth and fontSize > minFontSize:
@@ -1789,10 +1797,14 @@ class DividerDrawer(object):
         # Print small caps text, simulating it if necessary
 
         def drawWordPiece(text, fontSize):
-            self.canvas.setFont(font, fontSize)
+            this_font = font
+            if text == "→":
+                this_font = self.fontStyle["Arrow"]
+            self.canvas.setFont(this_font, fontSize)
             if text != " ":
                 self.canvas.drawString(x, y, text)
-            return pdfmetrics.stringWidth(text, font, fontSize)
+            self.canvas.setFont(font, fontSize)
+            return pdfmetrics.stringWidth(text, this_font, fontSize)
 
         # Improve typography
         text = text.replace("'", "’")


### PR DESCRIPTION
I'm working on several unrelated improvements. I'm going to try to submit them as separate, small PRs, but if @sumpfork would prefer fewer, larger PRs, I'm happy to do that too.

This adds a workaround for the fact that the arrow character isn't present in the various custom fonts used on dominion cards, by always rendering it using Times Bold. I'm removing a different workaround that had instead replaced it with a dash.