### PR TITLE
Allow sorting non-kingdom cards to the end of the expansion

### DIFF
--- a/src/domdiv/config_options.py
+++ b/src/domdiv/config_options.py
@@ -30,7 +30,7 @@ SPINE_CHOICES = ["name", "types", "tab", "blank"]
 
 EDITION_CHOICES = ["1", "2", "latest", "upgrade", "removed", "all"]
 
-ORDER_CHOICES = ["expansion", "global", "colour", "cost"]
+ORDER_CHOICES = ["expansion", "global", "colour", "cost", "kingdom"]
 
 EXPANSION_GLOBAL_GROUP = "extras"
 
@@ -104,6 +104,7 @@ def parse_opts(cmdline_args=None):
         help="Sort order for the dividers: "
         " 'global' will sort by card name;"
         " 'expansion' will sort by expansion, then card name;"
+        " 'kingdom' will sort by expansion, then card name of all kingdom cards (with dividers), then card name of all non-kingdom cards;"
         " 'colour' will sort by card type, then card name;"
         " 'cost' will sort by expansion, then card cost, then name.",
     )

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -58,6 +58,8 @@ class CardSorter(object):
             self.sort_key = self.by_colour_sort_key
         elif order == "cost":
             self.sort_key = self.by_cost_sort_key
+        elif order == "kingdom":
+            self.sort_key = self.by_expansion_kingdom_sort_key
         else:
             self.sort_key = self.by_expansion_sort_key
 
@@ -109,6 +111,15 @@ class CardSorter(object):
             card.cardset,
             int(card.isExpansion()),
             self.baseIndex(card.name),
+            self.get_card_name_sort_key(card.name),
+        )
+
+    def by_expansion_kingdom_sort_key(self, card):
+        return (
+            card.cardset,
+            int(card.isExpansion()),
+            self.baseIndex(card.name),
+            card.randomizer * -1,
             self.get_card_name_sort_key(card.name),
         )
 


### PR DESCRIPTION
I want to be able to put my events, landmarks, etc at the end of the cards in an expansion, with alternating tabs. This lets me do that. 

I don't fully understand the purpose of the "extras" pseudo-expansions. Maybe they're for this same purpose? If there's another way to accomplish this, I'd be happy to close this PR and instead update the documentation to make it more clear.