### PR TITLE
Ungroup cards if the group only has one card in it

### DIFF
--- a/src/domdiv/config_options.py
+++ b/src/domdiv/config_options.py
@@ -390,6 +390,12 @@ def parse_opts(cmdline_args=None):
         "(e.g., Shelters, Tournament and Prizes, Urchin/Mercenary, etc.).",
     )
     group_select.add_argument(
+        "--no-single-card-groups",
+        action="store_true",
+        dest="no_single_card_groups",
+        help="If there are any groups of cards with only one card in them, ungroup them.",
+    )
+    group_select.add_argument(
         "--group-kingdom",
         action="store_true",
         dest="group_kingdom",

--- a/src/domdiv/db.py
+++ b/src/domdiv/db.py
@@ -140,7 +140,7 @@ def find_index_of_object(lst=None, attributes=None):
     return None
 
 
-def read_card_data(options):
+def read_card_data(options) -> list[Card]:
     # Read in the card types
     types_db_filepath = os.path.join("card_db", "types_db.json.gz")
     with resource_handling.get_resource_stream(types_db_filepath) as typefile:

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -246,7 +246,7 @@ def combine_cards(cards, old_card_type, new_card_tag, new_cardset_tag, new_type)
     return filteredCards
 
 
-def filter_sort_cards(cards, options):
+def filter_sort_cards(cards: list[Card], options) -> list[Card]:
     # Filter out cards by edition
     if options.edition and options.edition != "all":
         keep_sets = []

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -359,6 +359,16 @@ def filter_sort_cards(cards, options):
                     ].randomizer = card.randomizer
                     group_holders[(card.group_tag, card.cardset_tag)].image = card.image
 
+        # If there's only one card in the group (Summon is the only event in Promos), undo all of this and
+        # just keep the single card.
+        if options.no_single_card_groups:
+            for i, card in enumerate(keep_cards):
+                if (card.group_tag, card.cardset_tag) in group_holders:
+                    if len(cards_in_group[(card.group_tag, card.cardset_tag)]) == 1:
+                        keep_cards[i] = cards_in_group[
+                            (card.group_tag, card.cardset_tag)
+                        ][0]
+
         cards = keep_cards
 
     # Get the final type names in the requested language

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 import unicodedata
 from collections import Counter, defaultdict
+from copy import deepcopy
 
 from loguru import logger
 from reportlab.lib.units import cm
@@ -306,72 +307,59 @@ def filter_sort_cards(cards, options):
     # Group all the special cards together
     if options.group_special:
         keep_cards = []  # holds the cards that are to be kept
-        group_cards = {}  # holds the cards for each group
+        group_holders = {}  # map from (group_tag, cardset_tag) to the group holder card
+        cards_in_group = {}  # map from (group_tag, cardset_tag) to a list of the unmodified cards in that group
         for card in cards:
             if not card.group_tag:
                 keep_cards.append(card)  # not part of a group, so just keep the card
             else:
-                # have a card in a group
-                if (card.group_tag, card.cardset_tag) not in group_cards:
-                    # First card of a group
-                    group_cards[(card.group_tag, card.cardset_tag)] = (
-                        card  # save to update cost later
-                    )
-                    # this card becomes the card holder for the whole group.
-                    card.card_tag = card.group_tag
+                # this card is in a group
+                if (card.group_tag, card.cardset_tag) not in group_holders:
+                    # This is the first card in this group
+                    # clone the card to be the group holder, so that the original can remain unchanged.
+                    group_holder = deepcopy(card)
+                    group_holder.setCardCount(0)
+                    group_holder.card_tag = card.group_tag
                     # These text fields should be updated later if there is a translation for this group_tag.
                     error_msg = (
                         "ERROR: Missing language entry for group_tab '%s'."
                         % card.group_tag
                     )
-                    card.name = (
+                    group_holder.name = (
                         card.group_tag
                     )  # For now, change the name to the group_tab
-                    card.description = error_msg
-                    card.extra = error_msg
-                    if card.get_GroupCost():
-                        card.cost = card.get_GroupCost()
+                    group_holder.description = error_msg
+                    group_holder.extra = error_msg
+                    if group_holder.get_GroupCost():
+                        group_holder.cost = card.get_GroupCost()
+                        group_holder.debtcost = 0
+                        group_holder.potioncost = 0
                     # now save the card
-                    keep_cards.append(card)
-                else:
-                    # subsequent cards in the group. Update group info, but don't keep the card.
-                    if card.group_top:
-                        # this is a designated card to represent the group, so update important data
-                        group_cards[(card.group_tag, card.cardset_tag)].cost = card.cost
-                        group_cards[
-                            (card.group_tag, card.cardset_tag)
-                        ].potcost = card.potcost
-                        group_cards[
-                            (card.group_tag, card.cardset_tag)
-                        ].debtcost = card.debtcost
-                        group_cards[
-                            (card.group_tag, card.cardset_tag)
-                        ].types = card.types
-                        group_cards[
-                            (card.group_tag, card.cardset_tag)
-                        ].randomizer = card.randomizer
-                        group_cards[
-                            (card.group_tag, card.cardset_tag)
-                        ].image = card.image
-
-                    group_cards[(card.group_tag, card.cardset_tag)].addCardCount(
-                        card.count
-                    )  # increase the count
-                    # set holder to lowest cost of the two cards
-                    # group_cards[(card.group_tag, card.cardset_tag)].set_lowest_cost(card)
+                    group_holders[(card.group_tag, card.cardset_tag)] = group_holder
+                    keep_cards.append(group_holder)
+                # Regardless of whether this is the first card or not, update the group info and store a reference to this card
+                cards_in_group.setdefault(
+                    (card.group_tag, card.cardset_tag), []
+                ).append(card)
+                group_holders[(card.group_tag, card.cardset_tag)].addCardCount(
+                    card.count
+                )
+                if card.group_top:
+                    # this is a designated card to represent the group, so update important data
+                    group_holders[(card.group_tag, card.cardset_tag)].cost = card.cost
+                    group_holders[
+                        (card.group_tag, card.cardset_tag)
+                    ].potcost = card.potcost
+                    group_holders[
+                        (card.group_tag, card.cardset_tag)
+                    ].debtcost = card.debtcost
+                    group_holders[(card.group_tag, card.cardset_tag)].types = card.types
+                    group_holders[
+                        (card.group_tag, card.cardset_tag)
+                    ].randomizer = card.randomizer
+                    group_holders[(card.group_tag, card.cardset_tag)].image = card.image
 
         cards = keep_cards
-
-        # Now fix up card costs for groups by Type (Events, Landmarks, etc.)
-        for card in cards:
-            if (card.card_tag, card.cardset_tag) in group_cards and group_cards[
-                (card.group_tag, card.cardset_tag)
-            ].get_GroupCost():
-                group_cards[(card.group_tag, card.cardset_tag)].cost = group_cards[
-                    (card.group_tag, card.cardset_tag)
-                ].get_GroupCost()
-                group_cards[(card.group_tag, card.cardset_tag)].debtcost = 0
-                group_cards[(card.group_tag, card.cardset_tag)].potcost = 0
 
     # Get the final type names in the requested language
     Card.type_names = add_type_text(Card.type_names, db.LANGUAGE_DEFAULT)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+import argparse
+from copy import deepcopy
+
+from domdiv import config_options
+
+
+def parse_and_clean_args(opts) -> argparse.Namespace:
+    parsed = config_options.parse_opts(opts)
+    cleaned = config_options.clean_opts(parsed)
+    # TODO: Uncomment and ensure correctness after https://github.com/sumpfork/dominiontabs/pull/565 is merged
+    # expected_recleaned_opts = deepcopy(cleaned)
+    # cleaned_again = config_options.clean_opts(expected_recleaned_opts)
+    # assert cleaned_again == expected_recleaned_opts
+    # assert cleaned == expected_recleaned_opts
+    return cleaned

--- a/tests/selection_tests.py
+++ b/tests/selection_tests.py
@@ -1,0 +1,45 @@
+from domdiv import db, main
+from tests import parse_and_clean_args
+
+
+def test_group_special():
+    options = parse_and_clean_args(["--group-special"])
+    all_cards = db.read_card_data(options)
+    cards = main.filter_sort_cards(all_cards, options)
+
+    # Make assertions that a few specific cards are handled correctly
+    empires_event_cards = [
+        c for c in cards if c.isType("Event") and c.cardset_tag == "empires"
+    ]
+    assert len(empires_event_cards) == 1
+    empires_events = empires_event_cards[0]
+    assert empires_events.count == [1] * 13
+    assert empires_events.name == "Events: Empires"
+    assert empires_events.types == ["Event"]
+
+    # test some split piles
+    gladiator_matches = [c for c in cards if c.group_tag == "Gladiator - Fortune"]
+    assert len(gladiator_matches) == 1
+    gladiator_fortune = gladiator_matches[0]
+    gladiator_fortune.name.startswith("Gladiator")
+    assert "Fortune" in gladiator_fortune.name
+    assert gladiator_fortune.count == [5, 5]
+    assert gladiator_fortune.types == ["Action"]
+    assert gladiator_fortune.cost == "3"
+
+    joust_matches = [c for c in cards if c.group_tag == "Joust and Rewards"]
+    assert len(joust_matches) == 1
+    joust_rewards = joust_matches[0]
+    assert joust_rewards.name.startswith("Joust")
+    assert "Rewards" in joust_rewards.name
+    joust_rewards.count.sort()
+    assert joust_rewards.count == 6 * [2] + [10]
+    assert joust_rewards.types == ["Action"]
+
+    allies_ally_cards = [
+        c for c in cards if c.cardset_tag == "allies" and c.isType("Ally")
+    ]
+    assert len(allies_ally_cards) == 1
+    allies_allies = allies_ally_cards[0]
+    assert allies_allies.name == "Allies: Allies"
+    assert allies_allies.count == [1] * 23


### PR DESCRIPTION
It seems silly to me that when grouping is turned on, and the promo "expansion" is included, it generates a card called "Events - Promo" with a single card in it (Summon). 

This provides an option to make it not do that. I've also refactored the code that creates the groups to be more explicit about what it's doing. Rather than updating the first card it finds in the group to be the group holder (but also still kind of sometimes retain its original data for purposes like the card count), now I'm explicitly making a new card to be the holder, and tracking a list of the unmodified cards in the group that can be used for other purposes if necessary. 