### PR TITLE
[draft] Use card text from the dominion strategy wiki

### DIFF
--- a/src/domdiv/config_options.py
+++ b/src/domdiv/config_options.py
@@ -20,7 +20,13 @@ TAB_SIDE_CHOICES = [
     "centre",
     "full",
 ]
-TEXT_CHOICES = ["card", "rules", "blank"]
+TEXT_CHOICES = [
+    "card",
+    "rules",
+    "blank",
+    "image",
+    "wiki-text",
+]
 LINE_CHOICES = ["line", "dot", "cropmarks", "line-cropmarks", "dot-cropmarks"]
 
 HEAD_CHOICES = ["tab", "strap", "cover", "none"]

--- a/src/domdiv/db.py
+++ b/src/domdiv/db.py
@@ -169,6 +169,26 @@ def read_card_data(options) -> list[Card]:
         )
     assert cards, "Could not load any cards from database"
 
+    with open(
+        os.path.join("src", "domdiv", "tools", "merged_cards_en_us.json"),
+        "r",
+        encoding="utf-8",
+    ) as wiki_json:
+        wiki_cards = json.load(wiki_json)
+
+    for c in cards:
+        if c.name in wiki_cards:
+            c.wiki_text = wiki_cards[c.name].get("raw_wikitext")
+        else:
+            c.wiki_text = ""
+            print("Could not find card %r" % c.name)
+
+    for c in cards:
+        if not hasattr(c, "wiki_text"):
+            print(f"{c.name} has no wiki_text")
+        elif not c.wiki_text:
+            print(f"{c.name} has falsey wiki_text: [{c.wiki_text}]")
+
     set_db_filepath = os.path.join("card_db", "sets_db.json.gz")
     with resource_handling.get_resource_stream(set_db_filepath) as setfile:
         Card.sets = json.loads(setfile.read().decode("utf-8"))

--- a/src/domdiv/inline_images.py
+++ b/src/domdiv/inline_images.py
@@ -1,0 +1,272 @@
+import re
+
+from . import resource_handling
+
+
+def expand_wiki_nowrap_template(s: str) -> str:
+    return re.sub(r"{{nowrap\|([^{}]+)}}", r"<nobr>\1</nobr>", s)
+
+
+def nobr(s: str) -> str:
+    return f"<nobr>{s}</nobr>"
+
+
+def nobr_if_necessary(s: str, needed: bool) -> str:
+    if needed:
+        return nobr(s)
+    else:
+        return s
+
+
+class InlineImage(object):
+    def __init__(self, width, height, valign):
+        self.width = width
+        self.height = height
+        self.valign = valign
+
+
+class CoinInlineImage(InlineImage):
+    def __init__(self, width, height, valign, resolution):
+        super().__init__(width, height, valign)
+        if resolution == "low":
+            # TODO: unlike the other low-res images, the empty coin doesn't have extra whitespace on the right,
+            # so it looks squashed when rendered at the aspect ratio that works for the others. It would be good to
+            # clean them all up at some point.
+            self.blank_image = "coin_small_empty.png"
+            self.question_image = "coin_small_question.png"
+            self.x_image = "coin_small_x.png"
+            self.n_image = "coin_small_{n}.png"
+        elif resolution == "medium":
+            self.blank_image = "coin.png"
+            self.question_image = "coin_small_question.png"
+            self.x_image = "coin_small_x.png"
+            self.n_image = "coin_small_{n}.png"
+        elif resolution == "high":
+            self.blank_image = "highres/Coin.png"
+            self.question_image = "highres/CoinQ.png"
+            self.x_image = "highres/Coinx.png"
+            self.n_image = "highres/Coin{n}.png"
+        else:
+            raise Exception(f"CoinScale: Unsupported resolution: {resolution}")
+
+    def coin(self, coins, fontsize):
+        if coins and coins.isdigit():
+            coin_image = self.n_image.format(n=int(coins))
+        elif coins in {"x", "X"}:
+            coin_image = self.x_image
+        elif coins == "?":
+            coin_image = self.question_image
+        else:
+            coin_image = self.blank_image
+        image_path = str(resource_handling.get_image_filepath(coin_image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        return f'<img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+
+
+class DebtInlineImage(InlineImage):
+    def __init__(self, width, height, valign, resolution):
+        super().__init__(width, height, valign)
+        if resolution == "low":
+            self.blank_image = "debt.png"
+            self.n_image = "debt_{n}.png"
+        elif resolution in ["medium", "high"]:
+            self.blank_image = "highres/Debt.png"
+            self.n_image = "highres/Debt{n}.png"
+        else:
+            raise Exception(f"DebtScale: Unsupported resolution: {resolution}")
+
+    def debt(self, debt, fontsize):
+        if debt and debt.isdigit():
+            debt_image = self.n_image.format(n=int(debt))
+        else:
+            debt_image = self.blank_image
+        image_path = str(resource_handling.get_image_filepath(debt_image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        return f'<img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+
+
+class SimpleInlineImage(InlineImage):
+    def __init__(self, width, height, valign, image: str):
+        super().__init__(width, height, valign)
+        self.image = image
+
+
+class PotionInlineImage(SimpleInlineImage):
+    def potion(self, fontsize):
+        image_path = str(resource_handling.get_image_filepath(self.image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        return f'<img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+
+
+class VpInlineImage(SimpleInlineImage):
+    def __init__(self, width, height, valign, image: str, fontsize_multiplier):
+        SimpleInlineImage.__init__(self, width, height, valign, image)
+        self.fontsize_multiplier = fontsize_multiplier
+
+    def vp(self, vp, fontsize):
+        image_path = str(resource_handling.get_image_filepath(self.image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        img = f'<img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+        if vp:
+            return nobr(
+                f"<b><font size={fontsize * self.fontsize_multiplier}>{vp}</font></b>{img}"
+            )
+        return img
+
+
+class SunInlineImage(SimpleInlineImage):
+    def sun(self, fontsize):
+        image_path = str(resource_handling.get_image_filepath(self.image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        return f'<img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+
+    def sunplus(self, fontsize):
+        image_path = str(resource_handling.get_image_filepath(self.image))
+        width = self.width * fontsize
+        height = self.height * fontsize
+        return nobr(
+            f'<b>+1</b><img src="{image_path}" width="{width}" height="{height}" valign="{self.valign}" />'
+        )
+
+
+class InlineImages(object):
+    def __init__(
+        self,
+        coin: dict[str, CoinInlineImage],
+        potion: dict[str, PotionInlineImage],
+        vp: dict[str, VpInlineImage],
+        debt: dict[str, DebtInlineImage],
+        sun: dict[str, SunInlineImage],
+    ):
+        self.coin = coin
+        self.potion = potion
+        self.vp = vp
+        self.debt = debt
+        self.sun = sun
+
+
+IMAGES = InlineImages(
+    coin={
+        "m": CoinInlineImage(1.2, 1, valign="-28%", resolution="low"),
+        "l": CoinInlineImage(2.4, 2.2, valign="top", resolution="medium"),
+        "xl": CoinInlineImage(5, 5, valign="top", resolution="medium"),
+    },
+    potion={
+        "m": PotionInlineImage(1.2, 1, valign="middle", image="potion_small.png"),
+        "l": PotionInlineImage(2, 1.4, valign="top", image="potion_small.png"),
+        "xl": PotionInlineImage(3, 4, valign="top", image="highres/Potion.png"),
+    },
+    vp={
+        "m": VpInlineImage(
+            1.25, 1, valign="middle", image="victory_emblem.png", fontsize_multiplier=1
+        ),
+        "l": VpInlineImage(
+            2, 2.4, valign="middle", image="highres/VP.png", fontsize_multiplier=3
+        ),
+        "xl": VpInlineImage(
+            3.4, 4, valign="-10%", image="highres/VP.png", fontsize_multiplier=5
+        ),
+    },
+    debt={
+        "m": DebtInlineImage(1.2, 1.05, valign="-28%", resolution="low"),
+    },
+    sun={
+        "m": SunInlineImage(1.2, 1.2, valign="middle", image="sun.png"),
+    },
+)
+
+
+def replace_wiki_templates(text, fontsize):
+    def replace_cost_template(match: re.Match):
+        """
+        Handles the {{Cost}} and {{Costplus}} wiki templates, which each have up to four parameters:
+        {{Cost|coins|size|debt|potion}}
+        All parameters are optional.
+        If the template name is Costplus a bold plus sign is prepended with no line break between it and the image.
+        {{Cost}} means a single blank coin icon. Otherwise, the coin icon is omitted unless the coins parameter is
+        non-empty.
+        If debt or coins are a number, that number is put inside the icon.
+        If debt or coins are '-', then the blank debt/coin icon is rendered.
+        If coins is "x" or "?" then the special x or ? coins icon is rendered.
+        If the potion parameter is "P" then a single potion is added at the end.
+        If not specified, size defaults to "m", which is the regular size for embedded text in cards.
+        Size "l" is used for e.g. kingdom treasures that have a larger symbol and also other text, like Hoard.
+        Size "xl" is used for the base cards that have no other text, like Silver.
+        """
+        coin = None
+        size = None
+        debt = ""
+        potion = ""
+        prefix = ""
+        needs_nobr_tag = False
+        if match:
+            if match.group(2):
+                prefix = "+"
+                needs_nobr_tag = True
+            if match.group(3):
+                parts = match.group(3).split("|")
+                coin = parts[1] if len(parts) > 1 else ""
+                size = parts[2] if len(parts) > 2 else ""
+                debt = parts[3] if len(parts) > 3 else ""
+                potion = parts[4] if len(parts) > 4 else ""
+            else:
+                # A completely empty template is a blank coin
+                return nobr_if_necessary(
+                    f"{prefix}{IMAGES.coin['m'].coin('-', fontsize)}", needs_nobr_tag
+                )
+        size = size or "m"  # medium is the default size
+        if potion == "P":
+            potion = IMAGES.potion[size].potion(fontsize)
+        if debt:
+            debt = IMAGES.debt[size].debt(debt, fontsize)
+
+        if coin == "" and (potion or debt):
+            return nobr_if_necessary("".join([prefix, debt, potion]), needs_nobr_tag)
+        coin = IMAGES.coin[size].coin(coin, fontsize)
+        if debt or potion:
+            needs_nobr_tag = True
+        return nobr_if_necessary("".join([prefix, coin, debt, potion]), needs_nobr_tag)
+
+    def handle_match(match: re.Match):
+        prefix = ""
+        size = None
+        count = None
+        debt = ""
+        potion = ""
+        template = match.group(1)
+        if template.lower() == "cost":
+            return replace_cost_template(match)
+        if match.group(2):
+            prefix = "+"
+        if match.group(3):
+            parts = match.group(3).split("|")
+            count = parts[1] if len(parts) > 1 else ""
+            size = parts[2] if len(parts) > 2 else "m"
+            debt = parts[3] if len(parts) > 3 else ""
+            potion = parts[4] if len(parts) > 4 else ""
+
+        size = size or "m"
+        if template == "VP":
+            return IMAGES.vp[size].vp(count, fontsize)
+        if template.lower() == "debt":
+            debt_img = IMAGES.debt[size].debt(count, fontsize)
+            if prefix:
+                return nobr(f"<b>{prefix}</b>{debt_img}")
+            return debt_img
+        if template.lower() == "sun":
+            scale = IMAGES.sun[size]
+            if prefix == "+":
+                return scale.sunplus(fontsize)
+            else:
+                return scale.sun(fontsize)
+
+        raise ValueError("Unknown template")
+
+    return re.sub(
+        r"{{([Cc]ost|[Dd]ebt|VP|[Ss]un)(plus)?(\|[^}]*?)?}}", handle_match, text
+    )

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -491,7 +491,7 @@ def filter_sort_cards(cards: list[Card], options) -> list[Card]:
                 if s.lower() == e or Card.sets[s].get("set_name", "").lower() == e:
                     wantedSets.discard(s)
                     knownExpansions.add(e)
-        # Give indication if an imput did not match anything
+        # Give indication if an input did not match anything
         unknownExpansions = options.exclude_expansions - knownExpansions
         if unknownExpansions:
             logger.warning(

--- a/src/domdiv/tools/merged_cards_en_us.json
+++ b/src/domdiv/tools/merged_cards_en_us.json
@@ -1,0 +1,6192 @@
+{
+    "Abandoned Mine": {
+        "description": "+1 Coin",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Abandoned Mine",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Costplus|1}}",
+        "wikitext": "+1 Coin"
+    },
+    "Abundance": {
+        "description": "The next time you gain an Action card: +1 Buy and +3 Coin.",
+        "extra": "This triggers when you gain an Action card due to buying it, or gain one some other way.<br>If it happens during another player's turn, the +3 Coin and +1 Buy won't be useful.",
+        "name": "Abundance",
+        "raw_wikitext": "The next time you gain an Action card: '''+1&nbsp;Buy''' and {{Costplus|3}}.",
+        "wikitext": "The next time you gain an Action card: <b>+1&nbsp;Buy</b> and +3 Coins."
+    },
+    "Academy": {
+        "description": "When you gain an Action card, +1 Villager.",
+        "extra": "This happens whether you gain an Action card due to buying it, or some other way.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Academy",
+        "raw_wikitext": "When you gain an Action card, '''+1&nbsp;Villager'''.",
+        "wikitext": "When you gain an Action card, <b>+1&nbsp;Villager</b>."
+    },
+    "Acolyte": {
+        "description": "You may trash an Action or Victory card from your hand to gain a Gold.<br>You may trash this to gain an Augur.",
+        "extra": "Both abilities are optional; you may do either or both or neither.<n>You only gain a Gold if you actually trashed an Action or a Victory card from your hand; you only gain an Augur if you actually trashed Acolyte.<n>Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.",
+        "name": "Acolyte",
+        "raw_wikitext": "<p>You may trash an Action or Victory card from your hand to gain a Gold.</p><p>You may trash this to gain an Augur.</p>",
+        "wikitext": "You may trash an Action or Victory card from your hand to gain a Gold.<n>You may trash this to gain an Augur."
+    },
+    "Acting Troupe": {
+        "description": "+4 Villagers<n>Trash this.",
+        "extra": "If you do not manage to trash this (for example if you play it twice via Throne Room), you still get the +4 Villagers.",
+        "name": "Acting Troupe",
+        "raw_wikitext": "'''+4&nbsp;Villagers'''<p>Trash this.</p>",
+        "wikitext": "<b>+4&nbsp;Villagers</b><n>Trash this."
+    },
+    "Advance": {
+        "description": "You may trash an Action card from your hand. If you do, gain an Action card costing up to 6 Coins.",
+        "extra": "If you do not trash an Action, nothing else happens.",
+        "name": "Advance",
+        "raw_wikitext": "You may trash an Action card from your hand. If you do, gain an Action card costing up to {{Cost|6}}.",
+        "wikitext": "You may trash an Action card from your hand. If you do, gain an Action card costing up to 6 Coins."
+    },
+    "Adventurer": {
+        "description": "Reveal cards from your deck until you reveal 2 Treasure cards. Put those Treasure cards in your hand and discard the other revealed cards.",
+        "extra": "If you have to shuffle in the middle, shuffle. Don't shuffle in the revealed cards as these cards do not go to the Discard pile until you have finished revealing cards. If you run out of cards after shuffling and still only have one Treasure, you get just that one Treasure.",
+        "name": "Adventurer",
+        "raw_wikitext": "Reveal cards from your deck until you reveal 2&nbsp;Treasure cards. Put those Treasure cards into your hand and discard the other revealed cards.",
+        "wikitext": "Reveal cards from your deck until you reveal 2&nbsp;Treasure cards. Put those Treasure cards into your hand and discard the other revealed cards."
+    },
+    "Advisor": {
+        "description": "+1 Action<n>Reveal the top 3 cards of your deck. The player to your left chooses one of them. Discard that card. Put the other cards into your hand.",
+        "extra": "If there are not three cards in your deck, reveal what you can, then shuffle your discard pile into your deck to get the other cards. If there still are not enough, just reveal what you can. No matter how many you revealed, the player to your left chooses one for you to discard, and the remaining cards go into your hand.",
+        "name": "Advisor",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Reveal the top 3&nbsp;cards of your deck. The player to your left chooses one of them. Discard that card and put the rest into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Reveal the top 3&nbsp;cards of your deck. The player to your left chooses one of them. Discard that card and put the rest into your hand."
+    },
+    "Alchemist": {
+        "description": "+2 Cards<br>+1 Action<line>When you discard this from play, you may put this on top of your deck if you have a Potion in play.",
+        "extra": "When you play this, you draw two cards and may play an additional Action card this turn. In the Clean-up Phase, when you discard this, if you have at least one Potion card in play, you may put Alchemist on top of your deck. This is optional and happens before drawing your new hand. If you have no cards in your deck when you do this, Alchemist becomes the only card in your deck. If you have multiple Alchemists and a Potion, you can put any or all of the Alchemists on top of your deck. You don't have to have used the Potion to buy anything, you only need to have played it.",
+        "name": "Alchemist",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>At the start of Clean-up this turn, if you have a Potion in play, you may put this onto your deck.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>At the start of Clean-up this turn, if you have a Potion in play, you may put this onto your deck."
+    },
+    "Alley": {
+        "description": "+1 Card<br>+1 Action<br>Discard a card.<line>You can play this from your deck as if it is in your hand.",
+        "extra": "See the Shadows section. When you play Alley, you draw a card, get +1 Action, and discard a card.",
+        "name": "Alley",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Discard a card.</p>{{Divline}}You can play this from your deck as if in your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Discard a card.<n><line>You can play this from your deck as if in your hand."
+    },
+    "Alliance": {
+        "description": "Gain a Province, a Duchy, an Estate, a Gold, a Silver, and a Copper.",
+        "extra": "You gain each of those cards that is present in the Supply; you cannot choose not to gain one. You gain them in the order listed.",
+        "name": "Alliance",
+        "raw_wikitext": "Gain a Province, a Duchy, an Estate, a Gold, a Silver, and a Copper.",
+        "wikitext": "Gain a Province, a Duchy, an Estate, a Gold, a Silver, and a Copper."
+    },
+    "Alms": {
+        "description": "Once per turn: If you have no Treasures in play, gain a card costing up to 4 Coin.",
+        "extra": "You can only buy this once per turn. When you do, if you have no Treasures in play, you gain a card costing up to 4 Coins. The gained card comes from the Supply and is put into your discard pile.",
+        "name": "Alms",
+        "raw_wikitext": "Once per turn: If you have no Treasures in play, gain a card costing up to {{Cost|4}}.",
+        "wikitext": "Once per turn: If you have no Treasures in play, gain a card costing up to 4 Coins."
+    },
+    "Altar": {
+        "description": "Trash a card from your hand. Gain a card costing up to 5 Coins.",
+        "extra": "You trash a card from your hand if you can, and then gain a card whether or not you trashed one. The gained card comes from the Supply and is put into your discard pile.",
+        "name": "Altar",
+        "raw_wikitext": "Trash a card from your hand. Gain a card costing up to {{Cost|5}}.",
+        "wikitext": "Trash a card from your hand. Gain a card costing up to 5 Coins."
+    },
+    "Amass": {
+        "description": "If you have no Action cards in play, gain an Action card costing up to 5 Coins.",
+        "name": "Amass",
+        "raw_wikitext": "If you have no Action cards in play, gain an Action card costing up to {{Cost|5}}."
+    },
+    "Ambassador": {
+        "description": "Reveal a card from your hand. Return up to 2 copies of it from your hand to the Supply. Then each other player gains a copy of it.",
+        "extra": "First you choose and reveal a card from your hand. You may place up to 2 copies of that card from your hand back in the Supply. You may choose not to put any of them back in the Supply. Then the other players each gain a copy of it from the Supply. If the pile for the chosen card runs out, some players may not get one; cards are given out in turn order starting with the next player. If you have no other cards in hand when you play this, it does nothing.",
+        "name": "Ambassador",
+        "raw_wikitext": "Reveal a card from your hand. Return up to 2&nbsp;copies of it from your hand to the Supply. Then each other player gains a copy of it.",
+        "wikitext": "Reveal a card from your hand. Return up to 2&nbsp;copies of it from your hand to the Supply. Then each other player gains a copy of it."
+    },
+    "Amphora": {
+        "description": "Either now or at the start of your next turn:<br>+1 Buy and +3 Coin.",
+        "extra": "When playing Amphora, choose whether to get +3 Coin and +1 Buy immediately, or at the start of your next turn.<br>If you choose \"immediately,\" Amphora will be discarded in the same turn's Clean-up; if you choose \"next turn,\" Amphora will be discarded that turn.<br>If you play Amphora multiple times, such as with King's Cache, you choose each time whether to get the +3 Coin and +1 Buy now or next turn, and Amphora only stays in play if at least one of the plays was for next turn (in which case the King's Cache also stays in play).",
+        "name": "Amphora",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "Either now or at the start of your next turn: '''+1&nbsp;Buy''' and {{Costplus|3}}.",
+        "wikitext": "Either now or at the start of your next turn: <b>+1&nbsp;Buy</b> and +3 Coins."
+    },
+    "Amulet": {
+        "description": "Now and at the start of your next turn, choose one: +1 Coin; or trash a card from your hand; or gain a Silver.",
+        "extra": "You choose something when you play it, and again at the start of your next turn; the choices may be the same or different.",
+        "name": "Amulet",
+        "raw_wikitext": "Now and at the start of your next turn, choose one: {{Costplus|1}}; or trash a card from your hand; or gain a Silver.",
+        "wikitext": "Now and at the start of your next turn, choose one: +1 Coin; or trash a card from your hand; or gain a Silver."
+    },
+    "Animal Fair": {
+        "description": "+4 Coin<br>+1 Buy per empty supply pile.<line>Instead of paying this card's cost, you may trash an Action card from your hand.",
+        "extra": "This only checks how many piles are empty when you play it; how many +Buys you got does not change if a pile becomes empty later in the turn (or non-empty, such as due to Ambassador from Seaside).<n>This only counts Supply piles, not non-Supply piles like Horse.<n>When buying this card, you can trash an Action card from your hand instead of paying 7 Coin. You can only do this if you have an Action card in hand to trash. You can do this even if you do not have 7 Coin. When buying Animal Fair this way, you spend no _ Coin, but still use up a Buy.<n>Animal Fair still has a cost of 7 Coin, regardless of how you pay for it.<n>In games using Shelters, you can use an opening buy on Animal Fair by trashing Necropolis.",
+        "name": "Animal Fair",
+        "raw_wikitext": "{{Costplus|4}}<p>'''+1&nbsp;Buy''' per empty supply pile.</p>{{Divline}}Instead of paying this card's cost, you may trash an Action card from your hand.",
+        "wikitext": "+4 Coins<n><b>+1&nbsp;Buy</b> per empty supply pile.<n><line>Instead of paying this card's cost, you may trash an Action card from your hand."
+    },
+    "Annex": {
+        "description": "Look through your discard pile. Shuffle all but up to 5 cards from it into your deck. Gain a Duchy.",
+        "extra": "You can do this even if the Duchy pile is empty.<n>The chosen cards stay in your discard pile when the other cards are shuffled into your deck.",
+        "name": "Annex",
+        "raw_wikitext": "Look through your discard pile. Shuffle all but up to 5&nbsp;cards from it into your deck. Gain a Duchy.",
+        "wikitext": "Look through your discard pile. Shuffle all but up to 5&nbsp;cards from it into your deck. Gain a Duchy."
+    },
+    "Anvil": {
+        "description": "1 <*COIN*><n><n>You may discard a Treasure to gain a card costing up to 4 Coin.",
+        "extra": "Discarding a Treasure is optional. If you discard one, you gain a card costing up to 4 Coin which comes from the Supply and goes to your discard pile.",
+        "name": "Anvil",
+        "raw_wikitext": "{{Cost|1|l}}<p>You may discard a Treasure to gain a card costing up to {{Cost|4}}.</p>",
+        "wikitext": "1 <*COIN*><n>You may discard a Treasure to gain a card costing up to 4 Coins."
+    },
+    "Apothecary": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top 4 cards of your deck. Put the revealed Coppers and Potions into your hand. Put the other cards back on top in any order.",
+        "extra": "You draw a card first. Then reveal the top four cards, put the Coppers and Potions into your hand, and put the rest back on top of your deck. If there aren't four cards left in your deck, reveal what you can and shuffle to get the rest. If there still aren't enough cards, just reveal what there is. Any cards that are not Copper and are not Potion go back on top of your deck in an order your choose. You cannot choose not to take all of the Coppers and Potions. If after revealing four cards there are no cards left in your deck, the cards you put back will become the only cards in your deck.",
+        "name": "Apothecary",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top 4&nbsp;cards of your deck. Put the Coppers and Potions into your hand. Put the rest back in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top 4&nbsp;cards of your deck. Put the Coppers and Potions into your hand. Put the rest back in any order."
+    },
+    "Apprentice": {
+        "description": "+1 Action<n>Trash a card from your hand.<n>+1 Card per _ Coin it costs.<n>+2 Cards if it has {{Cost||||P}} in its cost.",
+        "extra": "If you do not have any cards left in hand to trash, you do not draw any cards. If you trash a card costing 0 coins, such as Curse or Copper, you do not draw any cards. Otherwise you draw a card per _ Coin the card you trashed cost, and another two cards if it had {{Cost||||P}} in its cost. For example, if you trash a Golem, which costs {{Cost|4|||P}}, you draw 6 cards.",
+        "name": "Apprentice",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Trash a card from your hand.<br>'''+1&nbsp;Card''' per {{Cost|1}} it costs.<br>'''+2&nbsp;Cards''' if it has {{Cost||||P}} in its cost.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Trash a card from your hand.<br><b>+1&nbsp;Card</b> per 1 Coin it costs.<br><b>+2&nbsp;Cards</b> if it has Potion in its cost."
+    },
+    "Approaching Army": {
+        "description": "After you play an Attack card, +1 Coin.<line><b>Setup:</b> Add an Attack kingdom card pile to the Supply.",
+        "extra": "The Attack card added in setup is in addition to the usual 10 Kingdom cards, even if those already included an Attack card. For split piles (from Allies and Empires), a pile is an Attack pile if the randomizer card for it is an Attack. The added pile is a regular Kingdom card pile, and can be gained from like other piles. This setup occurs at the start of the game, and so affects the game even if the Prophecy never happens. Once the Prophecy has happened, you get +1 Coin from each Attack card you play; for Duration Attacks, this applies only on the turn the Duration Attack was played. The +1 Coin is the last thing the Attack card does when it's played. You get the +1 Coin even if you didn't follow the instructions on the Attack card; for example if you used a Way (from Menagerie).",
+        "name": "Approaching Army",
+        "raw_wikitext": "After you play an Attack card, {{Costplus|1}}.{{Divline}}'''Setup:''' Add an Attack kingdom card pile to the Supply.",
+        "wikitext": "After you play an Attack card, +1 Coin.<line><b>Setup:</b> Add an Attack kingdom card pile to the Supply."
+    },
+    "Aqueduct": {
+        "description": "When you gain a Treasure, move 1 <VP> from its pile to this. When you gain a Victory card, take the <VP> from this.<line>Setup: Put 8 <VP> on the Silver and Gold piles.",
+        "extra": "If you gain a card that is both a Treasure and a Victory card, such as Humble Castle, you can resolve the abilities in either order.",
+        "name": "Aqueduct",
+        "raw_wikitext": "When you gain a Treasure, move {{VP|'''1'''}} from its pile to this. When you gain a Victory card, take the {{VP}} from this.{{Divline}}Setup: Put {{VP|'''8'''}} on the Silver and Gold piles.",
+        "wikitext": "When you gain a Treasure, move 1 <VP> from its pile to this. When you gain a Victory card, take the {{VP}} from this.<line>Setup: Put 8 <VP> on the Silver and Gold piles."
+    },
+    "Archer": {
+        "description": "+2 Coins<n>Each other player with 5 or more cards in hand reveals all but one, and discards one of those you choose.",
+        "extra": "The players go in turn order if they care.<n>Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe and reveals the rest.<n>You choose one of the revealed cards for them to discard.",
+        "name": "Archer",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player with 5&nbsp;or more cards in hand reveals all but one, and discards one of those you choose.</p>",
+        "wikitext": "+2 Coins<n>Each other player with 5&nbsp;or more cards in hand reveals all but one, and discards one of those you choose."
+    },
+    "Architects' Guild": {
+        "description": "When you gain a card, you may spend 2 Favors to gain a cheaper non-Victory card.",
+        "extra": "",
+        "name": "Architects' Guild",
+        "raw_wikitext": "When you gain a card, you may spend '''2&nbsp;Favors''' to gain a cheaper non-Victory card.",
+        "wikitext": "When you gain a card, you may spend <b>2&nbsp;Favors</b> to gain a cheaper non-Victory card."
+    },
+    "Archive": {
+        "description": "+1 Action<n>Set aside the top 3 cards of your deck face down (you may look at them). Now and at the start of your next two turns, put one into your hand.",
+        "extra": "You look at three cards, and get one now, one next turn, and one the turn after that. Put the set-aside cards under Archive. If you play two Archives, they get separate sets of cards. If you Throne Room an Archive, keep the sets of cards separate; you get one from each turn. If there are fewer than three cards, just set aside what you can, and Archive will run out of cards faster and still be discarded the turn it has no cards left.",
+        "name": "Archive",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Set aside the top 3&nbsp;cards of your deck face down (you may look at them). Now and at the start of your next two turns, put one into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Set aside the top 3&nbsp;cards of your deck face down (you may look at them). Now and at the start of your next two turns, put one into your hand."
+    },
+    "Arena": {
+        "description": "At the start of your Buy phase, you may discard an Action card. If you do, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "With Villa it is possible for your Buy phase to start twice or more in a turn; you can make use of Arena each time.",
+        "name": "Arena",
+        "raw_wikitext": "At the start of your Buy phase, you may discard an Action card. If you do, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "At the start of your Buy phase, you may discard an Action card. If you do, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Aristocrat": {
+        "description": "If the number of Aristocrats you have in play is:<br><br>1 or 5: +3 Actions;<br>2 or 6: +3 Cards;<br>3 or 7: +3 Coin;<br>4 or 8: +3 Buys.",
+        "extra": "What matters is how many Aristocrats you have in play, not how many you played that turn. For example if you play Daimyo and then Aristocrat, you'll get +3 Actions for each play. If you have zero or 9 or 10 Aristocrats in play, it doesn't do anything.",
+        "name": "Aristocrat",
+        "raw_wikitext": "<p>If the number of Aristocrats you have in play is:</p>1 or 5: '''+3&nbsp;Actions''';<br>2 or 6: '''+3&nbsp;Cards''';<br>3 or 7: {{Costplus|3}};<br>4 or 8: '''+3&nbsp;Buys'''.",
+        "wikitext": "If the number of Aristocrats you have in play is:<n>1 or 5: <b>+3&nbsp;Actions</b>;<br>2 or 6: <b>+3&nbsp;Cards</b>;<br>3 or 7: +3 Coins;<br>4 or 8: <b>+3&nbsp;Buys</b>."
+    },
+    "Armory": {
+        "description": "Gain a card costing up to 4 Coins, putting it on top of your deck.",
+        "extra": "The card you gain comes from the Supply and is put on top of your deck.",
+        "name": "Armory",
+        "raw_wikitext": "Gain a card onto your deck costing up to {{Cost|4}}.",
+        "wikitext": "Gain a card onto your deck costing up to 4 Coins."
+    },
+    "Artificer": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>Discard any number of cards. You may gain a card costing exactly 1 Coin per card discarded, putting it on top of your deck.",
+        "extra": "First you get +1 Card, +1 Action, and +1 Coin. Then you discard any number of cards. You may choose not to discard any cards. Then you may gain a card costing exactly 1 per card discarded. For example if you discarded two cards; you may gain a card costing 2; if you discard no cards, you may gain a card costing 0. The gained card comes from the Supply and is put on top of your deck. You may choose not to gain a card, even if you discard cards.",
+        "name": "Artificer",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>Discard any number of cards. You may gain a card onto your deck, costing exactly {{Cost|1}} per card discarded.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>Discard any number of cards. You may gain a card onto your deck, costing exactly 1 Coin per card discarded."
+    },
+    "Artisan": {
+        "description": "Gain a card to your hand costing up to 5 Coins.<n>Put a card from your hand onto your deck.",
+        "extra": "The card you gain comes from the Supply and is put into your hand.<n>You cannot use _ Coin&nbsp;to increase how expensive of a card you gain; it always costs from 0 Coins to 5 Coins.<n>After gaining the card, you put a card from your hand onto your deck; that can be the card you just gained, or a different card.",
+        "name": "Artisan",
+        "raw_wikitext": "<p>Gain a card to your hand costing up to {{cost|5}}.</p>Put a card from your hand onto your deck.",
+        "wikitext": "Gain a card to your hand costing up to 5 Coins.<n>Put a card from your hand onto your deck."
+    },
+    "Artist": {
+        "description": "+1 Action<br><br>+1 Card per card you have exactly one of in play.",
+        "extra": "This costs 8 Debt; see the Debt section. This counts itself, if you have exactly one Artist in play. This counts cards played on other turns that are still in play, such as a Samurai from a previous turn.",
+        "name": "Artist",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>'''+1&nbsp;Card''' per card you have exactly one copy of in play.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n><b>+1&nbsp;Card</b> per card you have exactly one copy of in play."
+    },
+    "Asceticism": {
+        "description": "Pay any amount of {{Cost}} to trash that many cards from your hand.",
+        "name": "Asceticism",
+        "raw_wikitext": "Pay any amount of {{Cost}} to trash that many cards from your hand."
+    },
+    "Astrolabe": {
+        "description": "Now and at the start of your next turn:<br><br>1 <*COIN*><br><br>+1 Buy",
+        "extra": "This gives you +1 Buy and +1 Coin on the turn you play it, and +1 Buy and +1 Coin on your next turn too.",
+        "name": "Astrolabe",
+        "raw_wikitext": "Now and at the start of your next turn:<br>{{Cost|1|l}}<br>'''+1&nbsp;Buy'''",
+        "wikitext": "Now and at the start of your next turn:<br>1 <*COIN*><br><b>+1&nbsp;Buy</b>"
+    },
+    "Augurs": {
+        "description": "This pile starts the game with 4 copies each of Herb Gatherer, Acolyte, Sorceress, and Sibyl, in that order. Only the top card can be gained or bought.",
+        "extra": "Herb Gatherer: Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's. Playing a Treasure from your discard pile is optional, as is rotating the Augurs.<n>Acolyte: Both abilities are optional; you may do either or both or neither. You only gain a Gold if you actually trashed an Action or Victory card from your hand; you only gain an Augur if you actually trashed Acolyte. Gaining an Augur will give you whichever Augur is on top of the pile currently, even if that's another Acolyte.<n>Sorceress: Name a card; if the top card of your deck has that name, each other player gains a Curse. You put the card into your hand whether or not it had the name you chose.<n>Sibyl: If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Augurs"
+    },
+    "Avanto": {
+        "description": "+3 Cards<br>You may play a Sauna from your hand.",
+        "extra": "Avanto is a promotional Action card. It's a terminal draw card that can potentially become non-terminal if you have a Sauna in your hand to play. It is a split pile card, with five copies of Avanto sitting under five copies of Sauna.",
+        "name": "Avanto",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>You may play a Sauna from your hand.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>You may play a Sauna from your hand."
+    },
+    "Avoid": {
+        "description": "+1 Buy<br>The next time you shuffle this turn, pick up to 3 of those cards to put into your discard pile.",
+        "extra": "If you don't end up shuffling this turn, this does nothing.<br>If you do shuffle, you first look through the cards and pick up to 3 to put into your discard pile. Shuffle the other cards normally, but don't shuffle those 3 in.<br>Avoid is cumulative; if you Avoid 3 times, you will pick up to 9 cards to not shuffle in.<br>You might leave so many cards in your discard pile that you don't have enough to draw; this does not trigger another shuffle, you just draw what you can.",
+        "name": "Avoid",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>The next time you shuffle this turn, pick up to 3&nbsp;of those cards to put into your discard pile.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>The next time you shuffle this turn, pick up to 3&nbsp;of those cards to put into your discard pile."
+    },
+    "Bad Omens": {
+        "description": "Put your deck into your discard pile. Look through it and put 2 Coppers from it onto your deck (or reveal you can't.)",
+        "extra": "Normally you will end up with a deck consisting of two Coppers, and a discard pile with the rest of your cards. Sometimes you will only have one or no Coppers; in those cases reveal your deck to demonstrate this.",
+        "name": "Bad Omens",
+        "raw_wikitext": "Put your deck into your discard pile. Look through it and put 2&nbsp;Coppers from it onto your deck (or reveal you can't).",
+        "wikitext": "Put your deck into your discard pile. Look through it and put 2&nbsp;Coppers from it onto your deck (or reveal you can't)."
+    },
+    "Bag of Gold": {
+        "description": "+1 Action<n>Gain a Gold, putting it on top of your deck.<n><i>(This is not in the Supply.)</i>",
+        "extra": "The Gold you gain comes from the Supply and is put on top of your deck. If your deck has no cards in it, it becomes the only card in your deck. If there are no Golds left in the Supply, you do not gain one. This is a Prize; see the Additional Rules.",
+        "name": "Bag of Gold",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Gain a Gold onto your deck.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Gain a Gold onto your deck.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Baker": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coffers (take a Coin token).<line>Setup: Each player takes a Coin token.",
+        "extra": "When you play this, you draw a card, get +1 Action, and +1 Coffers (take a Coin token). In games using this card, each player starts the game with a Coin token. This includes games using the promo card Black Market in which Baker is in the Black Market deck.",
+        "name": "Baker",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Coffers'''{{Divline}}'''Setup:''' Each player gets '''+1&nbsp;Coffers'''.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Coffers</b><line><b>Setup:</b> Each player gets <b>+1&nbsp;Coffers</b>."
+    },
+    "Ball": {
+        "description": "Take your - 1 Coin token. Gain 2 cards each costing up to 4 Coin.",
+        "extra": "When you buy this, you take your - 1 Coin token, which will cause you to get 1 Coin less the next time you get Coins. Then you gain 2 cards, each costing up 4 Coins. They can be 2 copies of the same card or 2 different cards.",
+        "name": "Ball",
+        "raw_wikitext": "Take your –{{Cost|1}} token. Gain 2&nbsp;cards each costing up to {{Cost|4}}.",
+        "wikitext": "Take your –1 Coin token. Gain 2&nbsp;cards each costing up to 4 Coins."
+    },
+    "Band of Misfits": {
+        "description": "Play a non-Command Action card from the Supply that costs less than this, leaving it there.",
+        "extra": "When you play this, you pick an Action card from the Supply that costs less than it, and treat this card as if it were the card you chose. Normally this will just mean that you follow the instructions on the card you picked. So, if you play Band of Misfits and Fortress is in the Supply, you could pick that and then you would draw a card and get +2 Actions, since that is what Fortress does when you play it. Band of Misfits also gets the chosen card's cost, name, and types. If you use Band of Misfits as a card that trashes itself, such as Death Cart, you will trash the Band of Misfits (at which point it will just be a Band of Misfits card in the trash). If you use Band of Misfits as a duration card (from Seaside), Band of Misfits will stay in play until next turn, just like the duration card would. If you use Band of Misfits as a Throne Room (from Dominion), King's Court (from Prosperity), or Procession, and use that effect to play a duration card, Band of Misfits will similarly stay in play. If you use Throne Room, King's Court, or Procession to play a Band of Misfits card multiple times, you only pick what to play it as the first time; the other times it is still copying the same card. For example, if you use Procession to play Band of Misfits twice and choose Fortress the first time, you will automatically replay it as Fortress, then trash the Band of Misfits, return it to your hand (it is a Fortress when it's trashed, and Fortress has a when-trashed ability that returns it to your hand), and gain an Action card costing exactly 6 Coins(1 Coin more than Band of Misfits, which has left play and so is no longer copying Fortress). If you use Band of Misfits as a card that does something during Clean-up, such as Hermit, it will do that thing during Clean-up. When you play Horn of Plenty (from Cornucopia), it counts Band of Misfits as whatever Band of Misfits was played as; for example if you play a Band of Misfits as a Fortress, and then play another Band of Misfits as a Scavenger, and then play Horn of Plenty, you will gain a card costing up to 3 Coins. Band of Misfits can only be played as a card that is visible in the Supply; it cannot be played as a card after its pile runs out, and cannot be played as a non-Supply card like Mercenary; it can be played as the top card of the Ruins pile, but no other Ruins, and can only be played as Sir Martin when that is the top card of the Knights pile",
+        "name": "Band of Misfits",
+        "raw_wikitext": "Play a non-Command non-Duration Action card from the Supply that costs less than this, leaving it there.",
+        "wikitext": "Play a non-Command non-Duration Action card from the Supply that costs less than this, leaving it there."
+    },
+    "Band of Nomads": {
+        "description": "When you gain a card costing 3 Coins or more, you may spend a Favor, for +1 Card, or +1 Action, or +1 Buy.",
+        "extra": "",
+        "name": "Band of Nomads",
+        "raw_wikitext": "When you gain a card costing {{Cost|3}} or more, you may spend a '''Favor''', for '''+1&nbsp;Card''', or '''+1&nbsp;Action''', or '''+1&nbsp;Buy'''.",
+        "wikitext": "When you gain a card costing 3 Coins or more, you may spend a <b>Favor</b>, for <b>+1&nbsp;Card</b>, or <b>+1&nbsp;Action</b>, or <b>+1&nbsp;Buy</b>."
+    },
+    "Bandit": {
+        "description": "Gain a Gold. Each other player reveals the top 2 cards of their deck, trashes a revealed Treasure other than Copper, and discards the rest.",
+        "extra": "First you gain a Gold from the Supply, putting it into your discard pile.<n>Then each other player, in turn order, reveals their top 2 cards, trashes one they choose that is a Treasure other than Copper (e.g. Silver or Gold), and discards the other revealed cards.<n>A player who did not reveal a Treasure card other than Copper simply discards both cards.",
+        "name": "Bandit",
+        "raw_wikitext": "Gain a Gold. Each other player reveals the top 2&nbsp;cards of their deck, trashes a revealed Treasure other than Copper, and discards the rest.",
+        "wikitext": "Gain a Gold. Each other player reveals the top 2&nbsp;cards of their deck, trashes a revealed Treasure other than Copper, and discards the rest."
+    },
+    "Bandit Camp": {
+        "description": "+1 Card<br>+2 Actions<n>Gain a Spoils from the Spoils pile.",
+        "extra": "Draw a card before gaining a Spoils. The Spoils comes from the Spoils pile, which is not part of the Supply, and is put into your discard pile. If there are no Spoils cards left, you do not get one.",
+        "name": "Bandit Camp",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>Gain a Spoils.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>Gain a Spoils."
+    },
+    "Bandit Fort": {
+        "description": "When scoring, -2 <VP> for each Silver and each Gold you have.",
+        "extra": "For example with 3 Silvers and 1 Gold, you would get -8 <VP>.<n>Scores can go negative.",
+        "name": "Bandit Fort",
+        "raw_wikitext": "When scoring, {{VP|'''-2'''}} for each Silver and each Gold you have.",
+        "wikitext": "When scoring, -2 <VP> for each Silver and each Gold you have."
+    },
+    "Banish": {
+        "description": "Exile any number of cards with the same name from your hand.",
+        "extra": "For example, you could Exile three Estates from your hand.",
+        "name": "Banish",
+        "raw_wikitext": "Exile any number of cards with the same name from your hand.",
+        "wikitext": "Exile any number of cards with the same name from your hand."
+    },
+    "Bank": {
+        "description": "? Coins<n>+1 Coin per Treasure card you have in play (counting this).",
+        "extra": "This is a Treasure worth a variable amount. When you play Bank, it is worth 1 coin per Treasure you have in play, counting itself. Remember, you choose what order to play Treasure cards. If you play Bank with no other Treasures in play, it is worth 1 coin. If you play two copies of Bank in a row, the one you play second will be worth 1 coin more than the first one. Bank produces money right when you play it; things that happen later in the turn will not change how much money you got from it.",
+        "name": "Bank",
+        "raw_wikitext": "{{Costplus|1}} per Treasure card you have in play (counting this).",
+        "wikitext": "+1 Coin per Treasure card you have in play (counting this)."
+    },
+    "Banquet": {
+        "description": "Gain 2 Coppers and a non-Victory card costing up to 5 Coins.",
+        "extra": "You can do this even if the Copper pile is empty.",
+        "name": "Banquet",
+        "raw_wikitext": "Gain 2&nbsp;Coppers and a non-Victory card costing up to {{Cost|5}}.",
+        "wikitext": "Gain 2&nbsp;Coppers and a non-Victory card costing up to 5 Coins."
+    },
+    "Barbarian": {
+        "description": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.",
+        "extra": "For example, if a player trashes Contract to this, they could gain a Royal Galley, as they share the Duration type, or a Silver, as they share the Treasure type, or a Sycophant, as they share the Liaison type.<n>If the trashed card costs 3 Coins or more, they have to gain a cheaper card if they can; if there are no cheaper cards that share a type, they simply fail to gain a card.<n>The attack hits each other player in turn order, starting with the player to your left; this can be important.",
+        "name": "Barbarian",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player trashes the top card of their deck. If it costs {{Cost|3}} or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse.</p>",
+        "wikitext": "+2 Coins<n>Each other player trashes the top card of their deck. If it costs 3 Coins or more they gain a cheaper card sharing a type with it; otherwise they gain a Curse."
+    },
+    "Bard": {
+        "description": "+2 Coins<br>Receive a Boon.",
+        "extra": "You get +2 Coins and receive a Boon.",
+        "name": "Bard",
+        "raw_wikitext": "{{Costplus|2}}<p>Receive a Boon.</p>",
+        "wikitext": "+2 Coins<n>Receive a Boon."
+    },
+    "Bargain": {
+        "description": "Gain a non-Victory card costing up to 5 coin. Each other player gains a Horse.",
+        "extra": "The other players gain their Horses in turn order.<n>They cannot decline to gain one.",
+        "name": "Bargain",
+        "raw_wikitext": "Gain a non-Victory card costing up to {{Cost|5}}. Each other player gains a Horse.",
+        "wikitext": "Gain a non-Victory card costing up to 5 Coins. Each other player gains a Horse."
+    },
+    "Barge": {
+        "description": "Either now or at the start of your next turn,<n>+3 Cards and +1 Buy.",
+        "extra": "When playing Barge, choose whether to take +3 Cards and +1 Buy immediately, or at the start of your next turn.<n>If you choose \"immediately,\" Barge will be discarded in the same turn's Clean-up; if you choose \"next turn,\" Barge will be discarded that turn.<n>If you play a Barge multiple times, such as with Mastermind, you choose each time whether to take +3 Cards and +1 Buy immediately or next turn, and the Barge only stays in play until next turn if at least one of the plays was for next turn (in which case the Mastermind also stays in play).",
+        "name": "Barge",
+        "raw_wikitext": "Either now or at the start of your next turn, '''+3&nbsp;Cards''' and '''+1&nbsp;Buy'''.",
+        "wikitext": "Either now or at the start of your next turn, <b>+3&nbsp;Cards</b> and <b>+1&nbsp;Buy</b>."
+    },
+    "Baron": {
+        "description": "+1 Buy<n>You may discard an Estate card. If you do, +4 Coins. Otherwise, gain an Estate card.",
+        "extra": "You are never obligated to discard an Estate, even if you have one in your hand. However, if you do not discard an Estate, you must gain an Estate (if there are any left); you cannot choose to just get +1 Buy from this Card.",
+        "name": "Baron",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>You may discard an Estate for {{Costplus|4}}. If you don't, gain an Estate.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>You may discard an Estate for +4 Coins. If you don't, gain an Estate."
+    },
+    "Barracks": {
+        "description": "At the start of your turn, +1 Action.",
+        "extra": "You simply have +1 Action on each of your turns.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Barracks",
+        "raw_wikitext": "At the start of your turn, '''+1&nbsp;Action'''.",
+        "wikitext": "At the start of your turn, <b>+1&nbsp;Action</b>."
+    },
+    "Basilica": {
+        "description": "When you buy a card, if you have 2 Coins or more left, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "This happens each time you buy a card.<n>For example with 4 Coin and 3 Buys, you could buy Copper, then Copper, then Silver, taking 2 <VP>, then 2 <VP>, then none.",
+        "name": "Basilica",
+        "raw_wikitext": "When you gain a card in your Buy phase, if you have {{Cost|2}} or more, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "When you gain a card in your Buy phase, if you have 2 Coins or more, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Bat": {
+        "description": "Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": "The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
+        "name": "Bat",
+        "raw_wikitext": "<p>Trash up to 2&nbsp;cards from your hand. If you trashed at least one, exchange this for a Vampire.</p>''(This is not in the Supply.)''",
+        "wikitext": "Trash up to 2&nbsp;cards from your hand. If you trashed at least one, exchange this for a Vampire.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Baths": {
+        "description": "When you end your turn without having gained a card, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "Any way you gain a card will stop you from getting <VP> from this that turn.",
+        "name": "Baths",
+        "raw_wikitext": "When you end your turn without having gained a card, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "When you end your turn without having gained a card, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Battle Plan": {
+        "description": "+1 Card<br>+1 Action<n>You man reveal an Attack card from your hand for +1 Card.<br>You may rotate any Supply pile.",
+        "extra": "First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, for the Castles from Empires, or for the Knights or Ruins from Dark Ages.",
+        "name": "Battle Plan",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may reveal an Attack card from your hand for '''+1&nbsp;Card'''.</p>You may rotate any Supply pile.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may reveal an Attack card from your hand for <b>+1&nbsp;Card</b>.<n>You may rotate any Supply pile."
+    },
+    "Battlefield": {
+        "description": "When you gain a Victory card, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "You take the <VP> whether you bought the Victory card or gained it another way.",
+        "name": "Battlefield",
+        "raw_wikitext": "When you gain a Victory card, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "When you gain a Victory card, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Bauble": {
+        "description": "Choose two different options: +1 Buy; +1 Coin; +1 Favor; this turn, when you gain a card, you may put it onto your deck.",
+        "extra": "Choose two of the four options; the first three options are simple +1's and the last is everything else. So, for example, you could choose to take +1 Buy and \"this turn, when you gain a card, you may put it onto your deck.\"",
+        "name": "Bauble",
+        "raw_wikitext": "Choose two different options: '''+1&nbsp;Buy'''; {{Costplus|1}}; '''+1&nbsp;Favor'''; this turn, when you gain a card, you may put it onto your deck.",
+        "wikitext": "Choose two different options: <b>+1&nbsp;Buy</b>; +1 Coin; <b>+1&nbsp;Favor</b>; this turn, when you gain a card, you may put it onto your deck."
+    },
+    "Bazaar": {
+        "description": "+1 Card<br>+2 Actions<br>+1 Coin",
+        "extra": "You draw a card, get 2 more Actions to use, and get 1 more coin to spend this turn.",
+        "name": "Bazaar",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<br>{{Costplus|1}}",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><br>+1 Coin"
+    },
+    "Beggar": {
+        "description": "Gain 3 Coppers, putting them into your hand.<line>When another player plays an Attack card, you may discard this.<n>If you do, gain two Silvers, putting one on top of your deck.",
+        "extra": "When you play this, you gain three Coppers from the Supply, putting them into your hand. If there are not three Coppers left, just gain as many as you can. When another player plays an Attack card, you may discard this from your hand. If you do, you gain two Silvers from the Supply, putting one on your deck and the other into your discard pile. If there is only one Silver left, put it on your deck; if there are no Silvers left, you do not gain any.",
+        "name": "Beggar",
+        "raw_wikitext": "Gain 3 Coppers to your hand.{{Divline}}When another player plays an Attack card, you may first discard this to gain 2&nbsp;Silvers, putting one onto your deck.",
+        "wikitext": "Gain 3 Coppers to your hand.<line>When another player plays an Attack card, you may first discard this to gain 2&nbsp;Silvers, putting one onto your deck."
+    },
+    "Berserker": {
+        "description": "Gain a card costing less than this. Each other player discards down to 3 cards in hand.<line>When you gain this, if you have an Action in play, play this.",
+        "extra": "When you gain a Berserker, if you have an Action card in play, you play the Berserker; this means it will go into play, and you'll gain a cheaper card and then the other players will discard down to 3 cards in hand. They can still use cards like Moat then. If you gain a Berserker with no Actions in play, however, you don't play it. If you gain and play this with Innovation, Berserker loses track of itself, so Berserker telling you to play it will fail. If you gain this on another player's turn (e.g. their Barbarian trashes your Border Village), and you have an Action in play (most likely a Duration card), you can play the Berserker and attack them during their own turn. You'll discard the Berserker from play during their Clean-up. If you played 5 Highways, Berserker will cost 0 Coin, so it'll fail to gain a card.",
+        "name": "Berserker",
+        "raw_wikitext": "Gain a card costing less than this. Each other player discards down to 3&nbsp;cards in hand.{{Divline}}When you gain this, if you have an Action in play, play this.",
+        "wikitext": "Gain a card costing less than this. Each other player discards down to 3&nbsp;cards in hand.<line>When you gain this, if you have an Action in play, play this."
+    },
+    "Biding Time": {
+        "description": "At the start of your Clean-up, set aside your hand face down. At the start of your next turn, put those cards into your hand.",
+        "extra": "Instead of discarding unplayed cards in Clean-up, you set them aside, and put them back into your hand at the start of your next turn.",
+        "name": "Biding Time",
+        "raw_wikitext": "At the start of your Clean-up, set aside your hand face down. At the start of your next turn, put those cards into your hand.",
+        "wikitext": "At the start of your Clean-up, set aside your hand face down. At the start of your next turn, put those cards into your hand."
+    },
+    "Bishop": {
+        "description": "+1 Coin<br>+1 <VP><n>Trash a card from your hand. +<VP> equal to half its cost in coins, rounded down.<n>Each other player may trash a card from his hand.",
+        "extra": "[When a player takes <VP> tokens, he takes a player mat to put them on. <VP> tokens are not private and anyone can count them. <VP> tokens come in 1 <VP> and 5 <VP> denominations and players can make change as needed. Tokens are unlimited and if they run out, use something else to track any further tokens. At the end of the game, players add the total value of their <VP> tokens to their score.] Trashing a card is optional for the other players but mandatory for you. You trash a card, then each other player may trash a card, in turn order. Only the player who played Bishop can get <VP> tokens from it. Potion in costs is ignored, for example if you trash Golem (from Alchemy) which costs 4 coins Potion, you get 3 <VP> tokens total (counting the 1 <VP> you always get from Bishop). If you have no cards left in your hand to trash, you still get the 1 coin and 1 <VP> token.",
+        "name": "Bishop",
+        "raw_wikitext": "{{Costplus|1}}<br>{{VP|'''+1'''}}<p>Trash a card from your hand. {{VP|'''+1'''}} per {{Cost|2}} it costs (round down). Each other player may trash a card from their hand.</p>",
+        "wikitext": "+1 Coin<br>{{VP|<b>+1</b>}}<n>Trash a card from your hand. {{VP|<b>+1</b>}} per 2 Coins it costs (round down). Each other player may trash a card from their hand."
+    },
+    "Black Cat": {
+        "description": "+2 Cards<n>If it isn't your turn, each other player gains a Curse.<line>When another player gains a Victory card, you may play this from your hand.",
+        "extra": "When you play this on your turn, you draw 2 cards.<n>When you play it on another player's turn - normally only possible via its reaction - you draw 2 cards, and then everyone else gains a Curse, in turn order starting with the player whose turn it is.<n>When anyone else gains a Victory card - whether or not it is your turn - you may play this from your hand.",
+        "name": "Black Cat",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>If it isn't your turn, each other player gains a Curse.</p>{{Divline}}When another player gains a Victory card, you may play this from your hand.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>If it isn't your turn, each other player gains a Curse.<n><line>When another player gains a Victory card, you may play this from your hand."
+    },
+    "Black Market": {
+        "description": "+2 Coins<n>Reveal the top 3 cards of the Black Market deck. You may buy one of them immediately. Put the unbought cards on the bottom of the Black Market deck in any order.<n><i>(Before the game, make a Black Market deck out of one copy of each Kingdom card not in the supply.)</i>",
+        "extra": "Black Market allows you to Buy a card during the Action phase. You can use coins provided by other Action cards played earlier in the Action phase and you can also play Treasure cards from your hand to pay the cost of the bought card. The Treasure cards are played to the table in your play area, just as you would during the Buy phase. You may play more Treasure cards than are required for the purchase; the extra coins from Action cards and Treasure cards are available to use during your Buy phase. You may even play Treasure cards without Buying a card. You may not reuse coins already spent during a turn. A card bought during the Action phase does not count as a card bought in your Buy phase, so you do not need an action card giving you +1 Buy to still buy a card during your normal Buy phase. The Black Market deck, created before game start, is made up of Kingdom cards that are not in the Supply of the current game. The players should agree before the game which cards will be used to create the Black Market deck (for example, you could agree to use one of every Kingdom card you own that is not a part of the Supply). It is recommended that the Black Market deck contain at least 15 Kingdom cards, with no duplicates. All players can see which cards are placed in the Black Market deck before the game begins, at which point the deck is shuffled. This deck is not a Supply pile and if it is emptied, it does not count towards the end game conditions. If you play Black Market and the Black Market deck is empty, you cannot buy a card but you still get +2 Coins. If you play Black Market and choose not to buy one of the three cards from the Black Market deck, you still get +2 Coins.",
+        "name": "Black Market",
+        "raw_wikitext": "{{Costplus|2}}<p>Reveal the top 3&nbsp;cards of the Black Market deck. Play any number of Treasures from your hand. You may buy one of the revealed cards. Put the rest on the bottom of the Black Market deck in any order.</p>{{Divline}}Setup: Make a Black Market deck out of different unused Kingdom cards.",
+        "wikitext": "+2 Coins<n>Reveal the top 3&nbsp;cards of the Black Market deck. Play any number of Treasures from your hand. You may buy one of the revealed cards. Put the rest on the bottom of the Black Market deck in any order.<n><line>Setup: Make a Black Market deck out of different unused Kingdom cards."
+    },
+    "Blacksmith": {
+        "description": "Choose one: Draw until you have 6 cards in hand; or +2 Cards; or +1 Card and +1 Action.",
+        "extra": "You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.",
+        "name": "Blacksmith",
+        "raw_wikitext": "Choose one: Draw until you have 6&nbsp;cards in hand; or '''+2&nbsp;Cards'''; or '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.",
+        "wikitext": "Choose one: Draw until you have 6&nbsp;cards in hand; or <b>+2&nbsp;Cards</b>; or <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Blessed Village": {
+        "description": "+1 Card<br>+2 Actions<line>When you gain this, take a Boon. Receive it now or at the start of your next turn.",
+        "extra": "You see the Boon before deciding to resolve it immediately or at the start of your next turn. If you save it for next turn, it sits in front of you until then (or until the end of that turn if it says to keep it out until Clean-up).",
+        "name": "Blessed Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, take a Boon. Receive it now or at the start of your next turn.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, take a Boon. Receive it now or at the start of your next turn."
+    },
+    "Blockade": {
+        "description": "Gain a card costing up to 4 Coin, setting it aside.<br>At the start of your next turn, put it into your hand. While it's set aside, when another player gains a copy of it on their turn, they gain a Curse.",
+        "extra": "The gained card comes from the Supply and is set aside; put it on the <i>Blockade</i> to remember which card goes with <i>Blockade</i>.<br>If the gained card somehow doesn't end up set aside (for example if you trash it with <i>Watchtower</i> from Prosperity), nothing further happens; if the card is set aside, then you put it into your hand on your next turn, and until then, when other players gain the card on their own turns, they also gain a Curse.<br>Like all Duration attacks, you have to reveal your <i>Moat</i> as soon as an opponent plays a <i>Blockade</i>.<br>Unlike <i>Summon</i>, the card you gain is set aside immediately, but it can still get moved (with e.g. <i>Gatekeeper</i>). If it gets moved, you'll discard <i>Blockade</i> during Clean-up.<br>Because you don't gain the card to your discard pile, that means that the abilities on <i>Nomad Camp</i> and <i>Ghost Town</i> do not matter.<br>If you <i>Blockade</i> a Curse, then if another player on their turn gains a Curse, they will gain all the Curses. If they have a <i>Trader</i> in hand, they can get any and all Silvers in the Supply, but they'll still gain all the Curses.<br>This only Curses another player if they gain a copy of a <i>Blockaded</i> card during their turn. If you make them gain a copy when it's not their turn (e.g. you buy a <i>Messenger</i> and give them a copy), they won't gain a Curse.<br>During a <i>Possession</i> turn, no one will get Cursed from <i>Blockade</i>.",
+        "name": "Blockade",
+        "raw_wikitext": "<p>Gain a card costing up to {{Cost|4}}, setting it aside.</p>At the start of your next turn, put it into your hand. While it's set aside, when another player gains a copy of it on their turn, they gain a Curse.",
+        "wikitext": "Gain a card costing up to 4 Coins, setting it aside.<n>At the start of your next turn, put it into your hand. While it's set aside, when another player gains a copy of it on their turn, they gain a Curse."
+    },
+    "Bonfire": {
+        "description": "Trash up to 2 cards you have in play.",
+        "extra": "This only trashes cards you have in play, not cards from your hand. You can trash zero, one, or two cards. If you trash Treasures with this, this does not remove the 1 Coin you got from playing those Treasures this turn. For example, with 5 Coppers in play and two Buys, you could pay 3 Coins for a Bonfire to trash two of the Coppers, then spend the other 2 Coins on a Peasant.",
+        "name": "Bonfire",
+        "raw_wikitext": "Trash up to 2&nbsp;Coppers you have in play.",
+        "wikitext": "Trash up to 2&nbsp;Coppers you have in play."
+    },
+    "Border Guard": {
+        "description": "+1 Action<br><br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.",
+        "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.",
+        "name": "Border Guard",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Reveal the top 2&nbsp;cards of your deck. Put one into your hand and discard the other. If both were Actions, take the Lantern or Horn.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Reveal the top 2&nbsp;cards of your deck. Put one into your hand and discard the other. If both were Actions, take the Lantern or Horn."
+    },
+    "Border Guard - LanternHorn": {
+        "description": "<left><u>Border Guard</u>:</left><n>+1 Action<br>Reveal the top 2 cards of your deck.  Put one into your hand and discard the other.  If both were Actions, take the Lantern or Horn.<n><left><u>Horn</u>:</left><n>Once per turn, when you discard a Border Guard from play, you may put it onto your deck.<n><left><u>Lantern</u>:</left><n>Your Border Guards reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
+        "extra": "When you play a Border Guard and do not have the Lantern, you reveal the top 2 cards of your deck, choose one and put it into your hand, and discard the other; then if they were both Action cards, you take the Lantern or the Horn.  When you play a Border Guard and have the Lantern, you reveal the top 3 cards of your deck, choose one and put it into your hand, and discard the rest; then if all three were Action cards, you may take the Horn.  If you reveal fewer than 2 cards, or fewer than 3 cards when you have the Lantern, you don't take an Artifact.  Both the Horn and the Lantern function the turn you get them.<n><n>Horn and Lantern are Artifacts. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Border Guard / Horn / Lantern"
+    },
+    "Border Village": {
+        "description": "+1 Card<br>+2 Actions<line>When you gain this, gain a card costing less than this.",
+        "extra": "When you play this, you draw a card and can play two more Actions this turn. When you gain this, you also gain a card from the Supply that costs less than Border Village. Normally that will be a card costing up to 5 coins, but if Border Village costs less than normal, such as due to Highway, then the card you gain will have a lower maximum cost. You only gain a card when you gain Border Village, not when you play it. You gain a card whether you gained Border Village due to buying it, or gained it some other way.",
+        "name": "Border Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, gain a cheaper card.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, gain a cheaper card."
+    },
+    "Borrow": {
+        "description": "+1 Buy<n>Once per turn:<br>If your -1 Card token isn't on your deck, put it there and +1 Coin.",
+        "extra": "You can only buy this once per turn. When you do, if your -1 Card token is not on your deck, you put it on your deck and get +1 Coin. The -1 Card token will cause you to draw one less card the next time you draw cards; see the Tokens section.",
+        "name": "Borrow",
+        "raw_wikitext": "Once per turn: '''+1&nbsp;Buy'''. If your –1&nbsp;Card token isn't on your deck, put it there and {{Costplus|1}}.",
+        "wikitext": "Once per turn: <b>+1&nbsp;Buy</b>. If your –1&nbsp;Card token isn't on your deck, put it there and +1 Coin."
+    },
+    "Bounty Hunter": {
+        "description": "+1 Action<br>Exile a card from your hand.<n>If you didn't have a copy of it in Exile, +3 Coin.",
+        "extra": "First you get +1 Action and Exile a card from your hand; this is not optional.<n>Then if that is the only copy of that card that you have in Exile, you get +3 Coin.<n>If you can't Exile a card, you don't get +3 Coin.",
+        "name": "Bounty Hunter",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Exile a card from your hand. If you didn't have a copy of it in Exile, {{Costplus|3}}.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Exile a card from your hand. If you didn't have a copy of it in Exile, +3 Coins."
+    },
+    "Bridge": {
+        "description": "+1 Buy<br>+1 Coin<n>All cards (including cards in players' hands) cost 1 Coin less this turn, but not less than 0 Coins.",
+        "extra": "Costs are 1 coin lower for all purposes. For example, if you played Village, then Bridge, then Workshop, you could use Workshop to gain a Duchy (because Duchy now costs 4 Coins due to the Bridge). Then if you played 3 Coins, you could buy a Silver (for 2 Coins) and an Estate (for 1 coin). Cards in players' decks are also affected. The effect is cumulative; if you Throne Room a Bridge, all cards will cost 2 Coins less this turn. Costs never go below 0 Coins. For this reason, if you play Bridge and then play Upgrade, you could trash a Copper (which still costs zero, even though you played Bridge) and gain a Pawn (which costs 1 after Bridge is played).",
+        "name": "Bridge",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}<p>This turn, cards (everywhere) cost {{Cost|1}} less.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<n>This turn, cards (everywhere) cost 1 Coin less."
+    },
+    "Bridge Troll": {
+        "description": "Each other player takes his -1 Coin token. Now and at the start of your next turn:<n>+1 Buy<line>While this is in play, cards cost 1 Coin less on your turn, but not less than 0 Coins.",
+        "extra": "This gives each other player his - 1 Coin token, which will cause those players to get 1 Coin less the next time they get treasure; see the Tokens section. It also gives you +1 Buy both on the turn you play it and on your next turn. While Bridge Troll is in play, on your turns only, cards cost 1 Coin less, but not less than 0 Coins. This applies to all cards everywhere, including cards in the Supply, cards in hand, and cards in Decks. For example if you have Bridge Troll in play and play Raze, trashing Estate, Estate will only cost 1 Coin, so you'll only look at one card rather than two. This is cumulative; if you have two Bridge Trolls in play from last turn and play another Bridge Troll this turn, all cards will cost 3 Coins less this turn (to a minimum of 0 Coins).",
+        "name": "Bridge Troll",
+        "raw_wikitext": "Each other player takes their {{nowrap|–{{Cost|1}} token.}} On this turn and your next turn, cards cost {{Cost|1}} less. Now and at the start of your next turn: '''+1&nbsp;Buy'''.",
+        "wikitext": "Each other player takes their –1 Coin token. On this turn and your next turn, cards cost 1 Coin less. Now and at the start of your next turn: <b>+1&nbsp;Buy</b>."
+    },
+    "Broker": {
+        "description": "Trash a card from your hand and choose one: +1 Card per 1 Coin it costs; or +1 Action per 1 Coin it costs; or +1 Coin per 1 Coin it costs; or +1 Favor per 1 Coin it costs.",
+        "extra": "For example, if you trash an Estate, which costs 2 Coins, you could choose to get +2 Cards, or +2 Actions, or +2 Coins, or +2 Favors.<n>If you trash a card with Debt or Potions in the cost, you get nothing for those symbols.",
+        "name": "Broker",
+        "raw_wikitext": "Trash a card from your hand and choose one:<br>'''+1&nbsp;Card''' per {{Cost|1}} it costs;<br>or '''+1&nbsp;Action''' per {{Cost|1}} it costs; <br>or {{Costplus|1}} per {{Cost|1}} it costs; <br>or '''+1&nbsp;Favor''' per {{Cost|1}} it costs.",
+        "wikitext": "Trash a card from your hand and choose one:<br><b>+1&nbsp;Card</b> per 1 Coin it costs;<br>or <b>+1&nbsp;Action</b> per 1 Coin it costs; <br>or +1 Coin per 1 Coin it costs; <br>or <b>+1&nbsp;Favor</b> per 1 Coin it costs."
+    },
+    "Bureaucracy": {
+        "description": "When you gain a card that doesn't cost 0 Coins, gain a Copper.",
+        "name": "Bureaucracy",
+        "raw_wikitext": "When you gain a card that doesn't cost {{Cost|0}}, gain a Copper."
+    },
+    "Bureaucrat": {
+        "description": "Gain a silver card; put it on top of your deck. Each other player reveals a Victory card from his hand and puts it on his deck (or reveals a hand with no Victory cards).",
+        "extra": "If you have no cards left in your Deck when you play this card, the Silver you gain will become the only card in your Deck. Similarly, if another players has no cards in his Deck, the Victory card he puts on top will become the only card in his Deck.",
+        "name": "Bureaucrat",
+        "raw_wikitext": "Gain a Silver onto your deck. Each other player reveals a Victory card from their hand and puts it onto their deck (or reveals a hand with no Victory cards).",
+        "wikitext": "Gain a Silver onto your deck. Each other player reveals a Victory card from their hand and puts it onto their deck (or reveals a hand with no Victory cards)."
+    },
+    "Buried Treasure": {
+        "description": "At the start of your next turn, +1 Buy and +3 Coin.<line>When you gain this, play it.",
+        "extra": "When you gain this, you have to play it; it's not optional.",
+        "name": "Buried Treasure",
+        "raw_wikitext": "At the start of your next turn, '''+1&nbsp;Buy''' and {{Costplus|3}}.{{Divline}}When you gain this, play it.",
+        "wikitext": "At the start of your next turn, <b>+1&nbsp;Buy</b> and +3 Coins.<line>When you gain this, play it."
+    },
+    "Bury": {
+        "description": "+1 Buy<br>Put any card from your discard pile on the bottom of your deck.",
+        "extra": "Once you buy this, the ability is mandatory.",
+        "name": "Bury",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Put any card from your discard pile on the bottom of your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Put any card from your discard pile on the bottom of your deck."
+    },
+    "Bustling Village": {
+        "description": "+1 Card<br>+3 Actions<n>Look through your discard pile. You may reveal a Settlers from it and put it into your hand.",
+        "extra": "You can look through your discard pile even if you know there are no Settlers in it.",
+        "name": "Bustling Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+3&nbsp;Actions'''<p>You may reveal a Settlers from your discard pile and put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+3&nbsp;Actions</b><n>You may reveal a Settlers from your discard pile and put it into your hand."
+    },
+    "Butcher": {
+        "description": "+2 Coffers (take two Coin tokens)<br>You may trash a card from your hand and then pay any number of Coin tokens. If you did trash a card, gain a card with a cost of up to the cost of the trashed card plus the number of Coin tokens you paid.",
+        "extra": "First add two Coin tokens to your Coffers mat. Then you may trash a card from your hand and pay any number of Coin tokens (returning them to the pile). The number of Coin tokens you pay can be zero. Butcher itself is no longer in your hand and so cannot trash itself (though it can trash another copy of Butcher). If you trashed a card, you gain a card costing up to the cost of the trashed card plus the number of Coin tokens you paid. For example, you could trash an Estate and pay six Coin tokens to gain a Province, or you could trash another Butcher and pay zero Coin tokens to gain a Duchy. You can pay the Coin tokens you just got. Paying Coin tokens for this ability does not get you coins to spend, it just changes what cards you can gain with this ability.",
+        "name": "Butcher",
+        "raw_wikitext": "'''+2&nbsp;Coffers'''<p>You may trash a card from your hand, to gain a card, costing up to {{Cost|1}} more than it per Coffers you spend.</p>",
+        "wikitext": "<b>+2&nbsp;Coffers</b><n>You may trash a card from your hand, to gain a card, costing up to 1 Coin more than it per Coffers you spend."
+    },
+    "Cabin Boy": {
+        "description": "+1 Card<br>+1 Action<br>At the start of your next turn, choose one: +2 Coin; or trash this to gain a Duration card.",
+        "extra": "You can trash a Cabin Boy to gain another Cabin Boy.",
+        "name": "Cabin Boy",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>At the start of your next turn, choose one: {{Costplus|2}}; or trash this to gain a Duration card.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>At the start of your next turn, choose one: +2 Coins; or trash this to gain a Duration card."
+    },
+    "Cache": {
+        "description": "3 <*COIN*><line>When you gain this, gain two Coppers.",
+        "extra": "This is a treasure worth 3 coins, like Gold. When you gain it, you also gain two Coppers from the Supply. if there are not two Coppers left, just gain as many as you can. You only gain Coppers when you gain Cache, not when you play it. You gain Coppers whether you gained Cache due to buying it, or gained it some other way.",
+        "name": "Cache",
+        "raw_wikitext": "{{Cost|3|l}}{{Divline}}When you gain this, gain 2&nbsp;Coppers.",
+        "wikitext": "3 <*COIN*><line>When you gain this, gain 2&nbsp;Coppers."
+    },
+    "Cage": {
+        "description": "Set aside up to 4 cards from your hand face down (on this). The next time you gain a Victory card, trash this, and put the set aside cards into your hand at end of turn.",
+        "extra": "The cards go to your hand after drawing your regular hand of 5 cards for next turn.<br>For example you might set aside two Estate and two Copper on a Cage on an early turn; then on a late turn, buy a Province, trash the Cage, and add the two Estates and two Coppers to your hand at end of turn.",
+        "name": "Cage",
+        "raw_wikitext": "Set aside up to 4&nbsp;cards from your hand face down (on this). The next time you gain a Victory card, trash this, and put the set aside cards into your hand at end of turn.",
+        "wikitext": "Set aside up to 4&nbsp;cards from your hand face down (on this). The next time you gain a Victory card, trash this, and put the set aside cards into your hand at end of turn."
+    },
+    "Camel Train": {
+        "description": "Exile a non-Victory card from the Supply.<line>When you gain this, Exile a Gold from the Supply.",
+        "extra": "When you play this, you Exile a non-Victory card from the Supply; when you gain this, you Exile a Gold from the Supply.<n>The Exiled cards are not available for use until discarded from the Exile mat.",
+        "name": "Camel Train",
+        "raw_wikitext": "Exile a non-Victory card from the Supply.{{Divline}}When you gain this, Exile a Gold from the Supply.",
+        "wikitext": "Exile a non-Victory card from the Supply.<line>When you gain this, Exile a Gold from the Supply."
+    },
+    "Canal": {
+        "description": "During your turns, cards cost 1 Coin less, but not less than 0 Coin.",
+        "extra": "During your turns, all cards, including cards in the Supply, in hands, and in Decks, cost 1 Coin less, but not less than 0 Coin. For example if you have Canal and play Villain, other players discard a card costing at least 2 Coin, which could not be Estate, as Estate only costs 1 Coin on your turns.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Canal",
+        "raw_wikitext": "During your turns, cards cost {{Cost|1}} less.",
+        "wikitext": "During your turns, cards cost 1 Coin less."
+    },
+    "Candlestick Maker": {
+        "description": "+1 Action<br>+1 Buy<br>+1 Coffers (take a Coin token).",
+        "extra": "You get +1 Action and +1 Buy, and +1 Coffers (take a Coin token).",
+        "name": "Candlestick Maker",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<br>'''+1&nbsp;Coffers'''",
+        "wikitext": "<b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><br><b>+1&nbsp;Coffers</b>"
+    },
+    "Capital": {
+        "description": "6 Coins<br>+1 Buy<line>When you discard this from play, take 6 Debt, and then you may pay off Debt.",
+        "extra": "When you discard this from play (normally, in the Clean-up phase of the turn you played it), you get 6 Debt, and then get an extra opportunity to pay off Debt with Coins, right then. You do not get the Debt if you did not discard it from play - for example, if you trash it due to Counterfeit (from Dark Ages). You only get Debt per copy of Capital discarded; for example if you use Crown to play Capital twice, you still only get 6 Debt when you discard it from play.",
+        "name": "Capital",
+        "raw_wikitext": "{{Cost|6|l}}<br>'''+1&nbsp;Buy'''{{Divline}}When you discard this from play, {{Debtplus|6}}.",
+        "wikitext": "6 <*COIN*><br><b>+1&nbsp;Buy</b><line>When you discard this from play, {{Debtplus|6}}."
+    },
+    "Capital City": {
+        "description": "+1 Card<br>+2 Actions<n>You may discard 2 cards for +2 Coins.<br>You may pay 2 Coins for +2 Cards.",
+        "extra": "First draw a card and get +2 Actions.<n>Then decide if you want to discard 2 cards for +2 Coins. You may choose to do this even with fewer than 2 cards in hand and will discard what you can, but you only get +2 Coins if you actually discarded 2 cards.<n>Then decide if you want to spend 2 Coins for +2 Cards. The 2 Coins can come from discarding to Capital City or some other source, e.g. a Barbarian you played earlier in the turn. You don't get to play Treasures here to make the 2 Coins, though.<n>If you play this with Way of the Chameleon, you may discard 2 cards for +2 Cards. You can also pay 2 Coins for +2 Coins, although this isn't useful.",
+        "name": "Capital City",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>You may discard 2&nbsp;cards for {{Costplus|2}}.</p>You may pay {{Cost|2}} for '''+2&nbsp;Cards'''.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>You may discard 2&nbsp;cards for +2 Coins.<n>You may pay 2 Coins for <b>+2&nbsp;Cards</b>."
+    },
+    "Capitalism": {
+        "description": "During your turns, Actions with +_ Coin amounts in their text are also Treasures.",
+        "extra": "To be affected, a card must have a +_ Coin amount in its text, not just a _ Coin amount - for example, Capitalism turns Improve into a Treasure, but does not affect Inventor. Having Capitalism means you can play any number of Action cards with +_ Coin amounts in your Buy phase (without using up Action plays). It also means that things that interact with Treasure cards also interact with those cards; for example, if you have Capitalism, you can use Treasurer to gain an Improve from the trash, since Improve is a Treasure on your turns. Any time you play an Action - Treasure card, it is both an Action and a Treasure, regardless of which phase it is. Getting +1 Action in your Buy phase does not let you play other Action cards then. Capitalism work on your turn, but affects cards everywhere; for example if you have Capitalism and play Bandit, you could trash another player's Improve, and it is not relevant if that player has Capitalism or not.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Capitalism",
+        "raw_wikitext": "During your turns, Actions with {{Costplus}} amounts in their text are also Treasures.",
+        "wikitext": "During your turns, Actions with {{Costplus}} amounts in their text are also Treasures."
+    },
+    "Captain": {
+        "description": "Now and at the start of your next turn: Play a non-Duration non-Command Action card from the Supply costing up to 4 Coin, leaving it there.",
+        "extra": "On the second turn, you can choose to play a different card, or the same card if there is still a copy of it in the Supply.<n>Captain can only play a visible card in the Supply, and the top card of a pile; it cannot play a card from an empty pile, or a card that has not been uncovered from a split pile, or a card from a split pile that has been bought out, or a non-Supply card (such as Mercenary).<n>The Action card stays in the Supply; if an effect tries to move it (such as Island putting itself on your Island Mat) it will fail to move it.<n>Captain can play a card that trashes itself when played; if the card checks to see if it was trashed (such as Mining Village), it was not, but if the card does not check (such as Acting Troupe), it will function normally.<n>Cards that normally move other cards from the Supply can move themselves when played via Captain; for example playing Workshop can gain itself, and playing Lurker can trash itself.<n>Since the played card is not in play, 'while this is in play' abilities (such as Goons's) will not do anything.<n>If there are no non-Duration Action cards in the Supply that cost up to 4 Coins the turn you play Captain, Captain still stays in play and tries to play a card at the start of your next turn.<n>If Captain plays a card that plays a Duration card, that does not affect which turn Captain is discarded from play.<n>You can enter an infinite loop with Captain, Band of Misfits, Ferry, and cost reduction: With your –2 Coins cost token on the Captain Supply pile, Band of Misfits can be played as Captain, and with cost reduction, Captain can play Band of Misfits. Since this results in Captain being played arbitrarily many times, at the start of your next turn you can play arbitrarily many Actions costing up to 4 Coins.",
+        "name": "Captain",
+        "raw_wikitext": "Now and at the start of your next turn: Play a non-Duration, non-Command Action card from the Supply costing up to {{Cost|4}}, leaving it there.",
+        "wikitext": "Now and at the start of your next turn: Play a non-Duration, non-Command Action card from the Supply costing up to 4 Coins, leaving it there."
+    },
+    "Caravan": {
+        "description": "+1 Card<br>+1 Action<br>At the start of your next turn, +1 Card.",
+        "extra": "Draw a card at the start of your next turn (not before); Caravan itself is discarded during the Cleanup phase of that subsequent turn.",
+        "name": "Caravan",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>At the start of your next turn, '''+1&nbsp;Card'''.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>At the start of your next turn, <b>+1&nbsp;Card</b>."
+    },
+    "Caravan Guard": {
+        "description": "+1 Card<br>+1 Action<n>At the start of your next turn, +1 Coin<line>When another player plays an Attack card, you may play this from your hand. (<i>+1 Action has no effect if it's not your turn.</i>)",
+        "extra": "This gives you +1 Card and +1 Action when you play it, and then +1 Coin at the start of your next turn after that. This card has a Reaction ability that lets you play it when another player plays an Attack card. Playing this during another player's turn is similar to playing it during your own turn - you put Caravan Guard into play, get +1 Card and +1 Action, and will get +1 Coin at the start of your next turn - the very next turn you take. However getting +1 Action during someone else's turn does not do anything for you; it does not let you play other Action cards during that player's turn. Similarly if a token gives you +1 Coin or +1 Buy during another player's turn, that still does not let you buy cards during that player's turn (although +1 Coin can cancel the - token given out by Bridge Troll). The +1 Action (or potential other +'s) does not carry over to your next turn either. After reacting with a Caravan Guard, you can use another one, even one you just drew, and also can use other Reactions, even ones you just drew; you keep going until you have no more Reactions you wish to respond to the Attack with.",
+        "name": "Caravan Guard",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>At the start of your next turn, {{Costplus|1}}.</p>{{Divline}}When another player plays an Attack card, you may first play this from your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>At the start of your next turn, +1 Coin.<n><line>When another player plays an Attack card, you may first play this from your hand."
+    },
+    "Cardinal": {
+        "description": "+2 Coin<br>Each other player reveals the top 2 cards of their deck, Exiles one costing from 3 Coin to 6 Coin, and discards the rest.",
+        "extra": "If an attacked player reveals two cards each costing from 3 Coin to 6 Coin, that player chooses which card they Exile.",
+        "name": "Cardinal",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player reveals the top 2&nbsp;cards of their deck, Exiles one costing from {{Cost|3}} to {{Cost|6}}, and discards the rest.</p>",
+        "wikitext": "+2 Coins<n>Each other player reveals the top 2&nbsp;cards of their deck, Exiles one costing from 3 Coins to 6 Coins, and discards the rest."
+    },
+    "Cargo Ship": {
+        "description": "+2 Coin<br><br>Once this turn, when you gain a card, you may set it aside face up (on this). At the start of your next turn, put it into your hand.",
+        "extra": "The card you set aside doesn't have to be the next card you gain; you could gain multiple cards and then gain one where you decided to set it aside. If you don't set a card aside at all, Cargo Ship is discarded that turn.",
+        "name": "Cargo Ship",
+        "raw_wikitext": "{{Costplus|2}}<p>Once this turn, when you gain a card, you may set it aside face up (on this). At the start of your next turn, put it into your hand.</p>",
+        "wikitext": "+2 Coins<n>Once this turn, when you gain a card, you may set it aside face up (on this). At the start of your next turn, put it into your hand."
+    },
+    "Carnival": {
+        "description": "Reveal the top 4 cards of your deck. Put one of each differently named card into your hand and discard the rest.",
+        "extra": "For example if you revealed 3 Coppers and a Farmhands, you'd put one Copper and the Farmhands into your hand, and discard the other two Coppers. Shuffle if necessary to get 4 cards to reveal; if there still aren't 4 cards, reveal what you can.",
+        "name": "Carnival",
+        "raw_wikitext": "Reveal the top 4&nbsp;cards of your deck. Put one of each differently named card into your hand and discard the rest.",
+        "wikitext": "Reveal the top 4&nbsp;cards of your deck. Put one of each differently named card into your hand and discard the rest."
+    },
+    "Carpenter": {
+        "description": "If no Supply piles are empty, +1 Action and gain a card costing up to 4 Coins.<br>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it.",
+        "extra": "First see if there are any empty Supply piles.<n>If there are none, you get +1 Action and gain a card costing up to 4 Coins; if there are one or more empty piles, instead you trash a card from your hand and gain a card costing up to 2 Coins more than the card you trashed.",
+        "name": "Carpenter",
+        "raw_wikitext": "<p>If no Supply piles are empty, '''+1&nbsp;Action''' and gain a card costing up to {{Cost|4}}.</p>Otherwise, trash a card from your hand and gain a card costing up to {{Cost|2}} more than it.",
+        "wikitext": "If no Supply piles are empty, <b>+1&nbsp;Action</b> and gain a card costing up to 4 Coins.<n>Otherwise, trash a card from your hand and gain a card costing up to 2 Coins more than it."
+    },
+    "Cartographer": {
+        "description": "+1 Card<br>+1 Action<n>Look at the top 4 cards of your deck. Discard any number of them. Put the rest back on top in any order.",
+        "extra": "You draw a card first, then look at the top 4 cards of your deck. If there are fewer than 4 cards left in your deck, look at the remaining cards, and shuffle your discard pile (which does not include those cards) to get the remainder needed to look at. If there are still not enough cards, just look at as many as you can. Discard any number of the cards you looked at - none, all four, or something in-between - and put the rest back on top of your deck in any order. if there were no cards left in your deck, these become the only cards in your deck. You do not reveal the cards you put back.",
+        "name": "Cartographer",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Look at the top 4&nbsp;cards of your deck. Discard any number of them, then put the rest back in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Look at the top 4&nbsp;cards of your deck. Discard any number of them, then put the rest back in any order."
+    },
+    "Castles": {
+        "description": "Sort the Castle pile by cost, putting the more expensive Castles on the bottom. For a 2-player game, use only one of each Castle. Only the top card of the pile can be gained or bought.",
+        "extra": "Humble Castle and King's Castle count themselves. Small Castle gains you the top Castle, whichever one that is. Haunted Castle works whether you buy it or gain it some other way, provided that it is your turn. You can pick either option on Sprawling Castle regardless of how many Duchies and Estates are left in the piles. Grand Castle counts both Victory cards in play - such as an Opulent Castle - and Victory cards in your hand.",
+        "name": "Castles"
+    },
+    "Catacombs": {
+        "description": "Look at the top 3 cards of your deck.<n>Choose one: Put them into your hand;<n>or discard them and +3 Cards.<line>When you trash this, gain a cheaper card.",
+        "extra": "When you play this, you look at the top 3 cards of your deck, and either put all 3 into your hand, or discard all 3 and draw the next 3 cards. If you discard them and have to shuffle to draw 3 cards, you will shuffle in the cards you discarded and may end up drawing some of them. When you trash Catacombs, you gain a card costing less than it. This happens whether Catacombs is trashed on your turn or someone else's, and no matter who has the card that trashed it. The gained card comes from the Supply and is put into your discard pile.",
+        "name": "Catacombs",
+        "raw_wikitext": "Look at the top 3&nbsp;cards of your deck. Choose one: Put them into your hand; or discard them and '''+3&nbsp;Cards'''.{{Divline}}When you trash this, gain a cheaper card.",
+        "wikitext": "Look at the top 3&nbsp;cards of your deck. Choose one: Put them into your hand; or discard them and <b>+3&nbsp;Cards</b>.<line>When you trash this, gain a cheaper card."
+    },
+    "Catapult": {
+        "description": "+1 Coin<n>Trash a card from your hand. If it costs 3 Coins or more, each other player gains a Curse. If it's a Treasure, each other player discards down to 3 cards in hand.",
+        "extra": "If the card you trash is a treasure, each other player discards down to 3 cards in hand; if the card you trash costs 3 Coins or more, each other player gains a Curse; if it is both (e.g. Silver), both things happen; if it is neither, neither thing happens. If you have no cards in hand left to trash, neither thing happens.",
+        "name": "Catapult",
+        "raw_wikitext": "{{Costplus|1}}<p>Trash a card from your hand. If it costs {{Cost|3}} or more, each other player gains a Curse. If it's a Treasure, each other player discards down to 3&nbsp;cards in hand.</p>",
+        "wikitext": "+1 Coin<n>Trash a card from your hand. If it costs 3 Coins or more, each other player gains a Curse. If it's a Treasure, each other player discards down to 3&nbsp;cards in hand."
+    },
+    "Catapult - Rocks": {
+        "description": "<left><u>Catapult</u>:</left><n>+1 Coin<n>Trash a card from your hand. If it costs 3 Coins or more, each other player gains a Curse. If it's a Treasure, each other player discards down to 3 cards in hand.<n><left><u>Rocks</u>:</left><n>+1 Coin<line>When you gain or trash this, gain a Silver; if it is your Buy phase, put the Silver on your deck, otherwise put it into your hand.",
+        "extra": "If the card you trash is a treasure, each other player discards down to 3 cards in hand; if the card you trash costs 3 Coins or more, each other player gains a Curse; if it is both (e.g. Silver), both things happen; if it is neither, neither thing happens. Rocks: If you have no cards in hand left to trash, neither thing happens. If it is another player's turn, then it is not your Buy phase, so the Silver goes to your hand.",
+        "name": "Catapult / Rocks"
+    },
+    "Cathedral": {
+        "description": "At the start of your turn, trash a card from your hand.",
+        "extra": "Once you have claimed this ability, it is not optional. There is no way to remove your cube.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Cathedral",
+        "raw_wikitext": "At the start of your turn, trash a card from your hand.",
+        "wikitext": "At the start of your turn, trash a card from your hand."
+    },
+    "Cauldron": {
+        "description": "2 <*COIN*><br><br>+1 Buy<br><br>The third time you gain an Action this turn, each other player gains a Curse.",
+        "extra": "If you gain three Actions before playing Cauldron that turn, then it won't give out a Curse. It doesn't matter how many non-Action cards you gained; the third time you gain an Action, each other player gains a Curse. This is cumulative if you play multiple Cauldrons. This a Treasure, so you play it in your Buy phase, but also an Attack, so cards like Guard Dog and Moat can be used in response to it.",
+        "name": "Cauldron",
+        "raw_wikitext": "{{Cost|2|l}}<br>'''+1&nbsp;Buy'''<p>The third time you gain an Action this turn, each other player gains a Curse.</p>",
+        "wikitext": "2 <*COIN*><br><b>+1&nbsp;Buy</b><n>The third time you gain an Action this turn, each other player gains a Curse."
+    },
+    "Cavalry": {
+        "description": "Gain 2 Horses.<line>When you gain this, +2 Cards, +1 Buy, and if it's your Buy phase return to your Action phase.",
+        "extra": "When you gain Cavalry in your Buy phase, you get +2 Cards, +1 Buy, and return to your Action phase.<n>When you gain Cavalry in a different phase or during another player's turn, you get +2 Cards and +1 Buy.<n>+1 Buy is not useful if it is not your turn.<n>This ability of Cavalry is not playing the Cavalry, and does not put Cavalry into play.<n>Returning to your Action phase does not cause \"start of turn\" abilities to repeat; however when your Buy phase happens again after that, \"start of your Buy phase\" abilities can repeat.<n>Returning to your Action phase does not give you any +Actions; you have left however many you already had left.",
+        "name": "Cavalry",
+        "raw_wikitext": "Gain 2&nbsp;Horses.{{Divline}}When you gain this, '''+2&nbsp;Cards''', '''+1&nbsp;Buy''', and if it's your Buy phase return to your Action phase.",
+        "wikitext": "Gain 2&nbsp;Horses.<line>When you gain this, <b>+2&nbsp;Cards</b>, <b>+1&nbsp;Buy</b>, and if it's your Buy phase return to your Action phase."
+    },
+    "Cave Dwellers": {
+        "description": "At the start of your turn, you may spend a Favor, to discard a card then draw a card. Repeat as desired.",
+        "extra": "",
+        "name": "Cave Dwellers",
+        "raw_wikitext": "At the start of your turn, you may spend a '''Favor''', to discard a card then draw a card. Repeat as desired.",
+        "wikitext": "At the start of your turn, you may spend a <b>Favor</b>, to discard a card then draw a card. Repeat as desired."
+    },
+    "Cellar": {
+        "description": "+1 Action<n>Discard any number of cards. +1 Card per card discarded.",
+        "extra": "You can't discard Cellar to itself, since it isn't in your hand any longer when you resolve it. You choose what cards to discard and discard them all at once. You only draw cards after you have discarded. If you have to shuffle to do the drawing, the discarded cards will end up shuffled into your new Deck.",
+        "name": "Cellar",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Discard any number of cards. '''+1&nbsp;Card''' per card discarded.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Discard any number of cards. <b>+1&nbsp;Card</b> per card discarded."
+    },
+    "Cemetery": {
+        "description": "2 <*VP*><line>When you gain this, trash up to 4 cards from your hand.<br><br><i>Heirloom: Haunted Mirror</i>",
+        "extra": "In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.",
+        "name": "Cemetery",
+        "raw_wikitext": "{{VP|2|l}}{{Divline}}<p>When you gain this, trash up to 4&nbsp;cards from your hand.</p>''Heirloom: Haunted Mirror''",
+        "wikitext": "2 <*VP*><line><n>When you gain this, trash up to 4&nbsp;cards from your hand.<n><i>Heirloom: Haunted Mirror</i>"
+    },
+    "Cemetery - Haunted Mirror": {
+        "description": "<left><u>Cemetery</u>:</left><center>2 <*VP*></center><line>When you gain this, trash up to 4 cards from your hand.<br><i>Heirloom: Haunted Mirror</i><left><u>Haunted Mirror</u>:</left><center>1 <*COIN*></center><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
+        "extra": "<u>Cemetery</u>:In games using this, replace one of your starting Coppers with a Haunted Mirror. When you gain a Cemetery, trash from zero to four cards from your hand.\n<u>Haunted Mirror</u>: Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
+        "name": "Cemetery / Haunted Mirror"
+    },
+    "Champion": {
+        "description": "+1 Action<n>For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action.<n><i>(This stays in play. This is not in the Supply.)</i>",
+        "extra": "Champion stays in play for the rest of the game once played. For the rest of the game, it provides you with an additional +1 Action each time you play an Action, which means you will always be able to play all of your Actions; and it protects you from all further Attacks played (whether you want the protection or not). Champion only protects you from Attacks played after it; for example it does not stop a previously played Swamp Hag from giving you Curses that turn.",
+        "name": "Champion",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action card, you first get '''+1&nbsp;Action'''.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Action</b><n>For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action card, you first get <b>+1&nbsp;Action</b>.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Chancellor": {
+        "description": "+2 Coins<n>You may immediately put your deck into your discard pile.",
+        "extra": "You must resolve the Chancellor (decide whether or not to discard your Deck by flipping it into your Discard pile) before doing other things on your turn, like deciding what to buy or playing another Action card. You may not look through your Deck as you discard it.",
+        "name": "Chancellor",
+        "raw_wikitext": "{{Costplus|2}}<p>You may immediately put your deck into your discard pile.</p>",
+        "wikitext": "+2 Coins<n>You may immediately put your deck into your discard pile."
+    },
+    "Change": {
+        "description": "If you have any Debt, +3 Coin. Otherwise, trash a card from you hand, gain a card costing more Coin than it. +Debt equal to the difference in Coin.",
+        "extra": "Remember you can repay Debt at any point during your turn, which can sometimes let you choose which thing Change will do. If you have any Debt, Change gives you +3 Coin; otherwise you trash a card from your hand, gain any card costing more Coins, and take Debt equal to the difference. For example you could trash a Copper, gain a Province, and take 8 Debt. You can't gain a card costing the same amount of Coins or less Coins. This ignores other special aspects of cost; for example you could trash an Estate and gain an Alchemist, from Alchemy, which costs 3 Coins and 1 Potion.",
+        "name": "Change",
+        "raw_wikitext": "If you have any {{Debt}}, {{Costplus|3}}. Otherwise, trash a card from your hand, and gain a card costing more {{Cost}} than it. {{Debtplus}} equal to the difference in {{Cost}}.",
+        "wikitext": "If you have any {{Debt}}, +3 Coins. Otherwise, trash a card from your hand, and gain a card costing more {{Cost}} than it. {{Debtplus}} equal to the difference in {{Cost}}."
+    },
+    "Changeling": {
+        "description": "Trash this. Gain a copy of a card you have in play.<line>In games using this, when you gain a card costing 3 Coins or more, you may exchange it for a Changeling.",
+        "extra": "When Changeling is in the Supply, any time you gain a card costing at least 3 Coins, you may exchange it for a Changeling from the Supply. You can only do this if you can actually return the card you gained, and there is at least one Changeling in the Supply. The Changeling goes to your discard pile, no matter where the gained card went. Things that happen due to gaining the gained card still happen. So for example you could gain Skulk, exchange it for a Changeling (returning Skulk to the Supply and putting Changeling into your discard pile), and still gain a Gold from Skulk's ability. Exchanging for a Changeling is optional. You cannot do it if the gained card costs less than 3 Coins, even if it normally costs 3 Coins or more, and you cannot do it if the cost is neither more or less than 3 Coins (such as Transmute from Alchemy). When you play Changeling, you trash it and gain a copy of a card you have in play; that can be any card you have in play, including Actions, Treasures, and Night cards, and including Duration cards you played on a previous turn that are still in play.",
+        "name": "Changeling",
+        "raw_wikitext": "Trash this. Gain a copy of a card you have in play.{{Divline}}In games using this, when you gain a card costing {{Cost|3}} or more, you may exchange it for a Changeling.",
+        "wikitext": "Trash this. Gain a copy of a card you have in play.<line>In games using this, when you gain a card costing 3 Coins or more, you may exchange it for a Changeling."
+    },
+    "Chapel": {
+        "description": "Trash up to 4 cards from your hand.",
+        "extra": "You can't trash the Chapel itself since it isn't in your hand when you resolve it. You could trash a different Chapel card if that card were in your hand.",
+        "name": "Chapel",
+        "raw_wikitext": "Trash up to 4&nbsp;cards from your hand.",
+        "wikitext": "Trash up to 4&nbsp;cards from your hand."
+    },
+    "Chariot Race": {
+        "description": "+1 Action<n>Reveal the top card of your deck and put it into your hand. The player to your left reveals the top card of their deck. If your card costs more, +1 Coin and +1 <VP>.",
+        "extra": "You and the player to your left reveal your top cards; yours goes into your hand, theirs goes back on their deck. If your card cost more you get +1 Coin and +1 <VP>; you can put the token on the Chariot Race to remind you that it made +1 Coin this turn. If it is a tie, your card did not cost more. With Debt, your card costs more only if both Coin and Debt amounts are larger, or one is larger and the other the same. For example Fortune (8 Coins 8 Debt) costs more than Overlord (5 Debt), but Overlord does not cost more than Silver, and Silver does not cost more than Overlord. If either player has no card to reveal, your card does not cost more.",
+        "name": "Chariot Race",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>'''+1&nbsp;Card''', revealing it. The player to your left reveals the top card of their deck. If your card costs more, {{Costplus|1}} and {{VP|'''+1'''}}.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n><b>+1&nbsp;Card</b>, revealing it. The player to your left reveals the top card of their deck. If your card costs more, +1 Coin and {{VP|<b>+1</b>}}."
+    },
+    "Charlatan": {
+        "description": "+3 Coin<n><n>Each other player gains a Curse.<line>In games using this, Curse is also a Treasure worth 1 Coin.",
+        "extra": "This turns Curses into Treasures for the entire game and in all situations; it's just like the bottom bar says \"Curse - Treasure.\" They may be played for +1 Coin in the Buy phase. They are trashed from play when gaining Mint, Magnate counts them in your hand, Courtier (from Intrigue) gives you two choices when revealing one, and so on. They are still Curses and still worth –1 <VP> at the end of the game. Unlike Capitalism, Charlatan makes Curses stay as Treasures during scoring, so they will count for Keep. Curses will be Treasures if Charlatan is in the Black Market deck, even if no one actually gains it.",
+        "name": "Charlatan",
+        "raw_wikitext": "{{Costplus|3}}<p>Each other player gains a Curse.</p>{{divline}}In games using this, Curse is also a Treasure worth {{Cost|1}}.",
+        "wikitext": "+3 Coins<n>Each other player gains a Curse.<n><line>In games using this, Curse is also a Treasure worth 1 Coin."
+    },
+    "Charm": {
+        "description": "When you play this, choose one: +1 Buy and +2 Coin; or the next time you gain a card this turn, you may also gain a differently named card with the same cost.",
+        "extra": "These are cumulative, and each Charm does not have to gain a different card, just a different card from the one bought. For example if you play two Charms and buy a Forum, you could gain two Duchies. The card gained from Charm is gained before gaining the card you bought, which may matter when cards do things when gained. For example if you buy Villa and gain Rocks via Charm, you will first gain a Silver to your deck due to Rocks, then get +1 Action and return to your Action phase due to Villa. The costs have to be identical; for example if you play Charm and buy Overlord, you can gain City Quarter, which also costs 8 Debt, but not Fortune, which costs 8 Coin 8 Debt.",
+        "name": "Charm",
+        "raw_wikitext": "Choose one: '''+1&nbsp;Buy''' and {{Costplus|2}}; or the next time you gain a card this turn, you may also gain a differently named card with the same cost.",
+        "wikitext": "Choose one: <b>+1&nbsp;Buy</b> and +2 Coins; or the next time you gain a card this turn, you may also gain a differently named card with the same cost."
+    },
+    "Cheap": {
+        "description": "Cheap cards cost 1 Coin less.",
+        "extra": "This lowers the cost of a pile for the entire game (including when scoring).<br>Costs can't go below 0 Coin.<br>This doesn't reduce non-_ Coin like Potion and Debt, for example this does nothing on the Engineer pile (from Empires).<br>This does not apply during setup; it can't for example cause a 4 Coin to be used as Young Witch Bane (from Cornucopia).",
+        "name": "Cheap",
+        "raw_wikitext": "Cheap cards cost {{Cost|1}} less.",
+        "wikitext": "Cheap cards cost 1 Coin less."
+    },
+    "Church": {
+        "description": "+1 Action<br>Set aside up to 3 cards from your hand face down. At the start of your next turn, put them into your hand, then you may trash a card from your hand.",
+        "extra": "You may set aside zero, one, two, or three cards from your hand. Put them face down; you may look at them.<n>No matter how many cards you set aside, you may trash a card at the start of your next turn and Church is discarded at the end of that turn.<n>The card you trash can be a card you had set aside, or a card that was already in your hand.<n>If you play multiple Churches (or one Church multiple times such as via Throne Room), you may set aside multiple batches of up to three cards. What happens on your next turn is this: you put one batch of set-aside cards in hand, then trash, then put the next batch of set-aside cards in hand, then trash. You can choose which batch of set-aside cards you put in hand first.",
+        "name": "Church",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Set aside up to 3&nbsp;cards from your hand face down. At the start of your next turn, put them into your hand, then you may trash a card from your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Set aside up to 3&nbsp;cards from your hand face down. At the start of your next turn, put them into your hand, then you may trash a card from your hand."
+    },
+    "Circle of Witches": {
+        "description": "After playing a Liaison, you may spend 3 Favors to have each other player gain a Curse.",
+        "extra": "",
+        "name": "Circle of Witches",
+        "raw_wikitext": "After playing a Liaison, you may spend '''3&nbsp;Favors''' to have each other player gain a Curse.",
+        "wikitext": "After playing a Liaison, you may spend <b>3&nbsp;Favors</b> to have each other player gain a Curse."
+    },
+    "Citadel": {
+        "description": "The first time you play an Action card during each of your turns, play it again afterwards.",
+        "extra": "Once you've claimed this ability, it is not optional. This can affect an Action card played outside of the Action phase, if it is your first Action card played that turn; for example if you also had Capitalism, you could opt to play a Flag Bearer in your Buy phase as your first play of the turn, and it would still be played twice. Citadel can cause a Duration card to be played twice; you will have to remember that on your next turn.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Citadel",
+        "raw_wikitext": "The first time you play an Action card during each of your turns, replay it afterwards.",
+        "wikitext": "The first time you play an Action card during each of your turns, replay it afterwards."
+    },
+    "City": {
+        "description": "+1 Card<br>+2 Actions<n>If there are one or more empty Supply piles, +1 Card. If there are two or more, +1 Coin and +1 Buy.",
+        "extra": "You draw a card and can play two more Actions no matter what. If there is just one empty pile in the Supply, you also draw another card. If there are two or more empty piles, you both draw another card, and get 1 coin to spend and an extra Buy to use in the Buy phase. There are no further bonuses if three or more piles are empty. This only checks how many piles are empty when you play it; if piles become empty later in the turn, you do not go back and get the bonuses. If a pile stops being empty due to cards being returned to it, such as with the Seaside card Ambassador, Cities played after that will not count that pile as empty. An empty trash pile does not count for this.",
+        "name": "City",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>If there are one or more empty Supply piles, '''+1&nbsp;Card'''. If there are two or more, '''+1&nbsp;Buy''' and {{Costplus|1}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>If there are one or more empty Supply piles, <b>+1&nbsp;Card</b>. If there are two or more, <b>+1&nbsp;Buy</b> and +1 Coin."
+    },
+    "City Gate": {
+        "description": "At the start of your turn, +1 Card, then put a card from your hand onto you deck.",
+        "extra": "First you draw a card; then you put any card from your hand onto your deck.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "City Gate",
+        "raw_wikitext": "At the start of your turn, '''+1&nbsp;Card''', then put a card from your hand onto your deck.",
+        "wikitext": "At the start of your turn, <b>+1&nbsp;Card</b>, then put a card from your hand onto your deck."
+    },
+    "City Quarter": {
+        "description": "+2 Actions<n>Reveal your hand. +1 Card per Action card revealed.",
+        "extra": "Cards with multiple types that include Action, such as Crown, are Actions.",
+        "name": "City Quarter",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Reveal your hand. '''+1&nbsp;Card''' per Action card revealed.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Reveal your hand. <b>+1&nbsp;Card</b> per Action card revealed."
+    },
+    "City-state": {
+        "description": "When you gain an Action card during your turn, you may spend 2 Favors to play it.",
+        "extra": "",
+        "name": "City-state",
+        "raw_wikitext": "When you gain an Action card during your turn, you may spend '''2&nbsp;Favors''' to play it.",
+        "wikitext": "When you gain an Action card during your turn, you may spend <b>2&nbsp;Favors</b> to play it."
+    },
+    "Clashes": {
+        "description": "This pile starts the game with 4 copies each of Battle Plan, Archer, Warlord, and Territory, in that order. Only the top card can be gained or bought.",
+        "extra": "Battle Plan: First you get +1 Card and +1 Action, then you may reveal an Attack card from your hand to draw a card, and finally you may rotate any Supply pile.<n>Many piles won't do anything meaningful if you do this. It can be relevant though for split piles, or for the Castles, for the Knights, or for Ruins.<n>Archer: The players go in turn order if they care. Each other player, if they have 5 or more cards in hand, chooses one to keep secret and safe, and reveals the rest. You choose one of the revealed cards for them to discard.<n>Warlord: This doesn't stop players from playing cards that aren't in their hands. With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but it can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play. This only affects Action cards.<n>Territory: For example, if your deck has 3 Estate, a Province, and a Territory, Territory is worth 3 <VP>. If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Clashes"
+    },
+    "Clerk": {
+        "description": "+2 Coin<n>Each other player with 5 or more cards in hand puts one onto their deck.<line>At the start of your turn, you may play this from your hand.",
+        "extra": "A player with no cards in their deck will have the card they put on top become the only card in their deck. At the start of your turn, you may play any number of Clerk cards from your hand, one at a time, without using up your regular Action play. You may use Clerk's self-playing start-of-turn ability before, between, or after other start-of-turn effects. For instance, if you draw Clerk due to the effect of Den of Sin, it's not too late to use Clerk's Reaction ability.",
+        "name": "Clerk",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player with 5 or more cards in hand puts one onto their deck.</p>{{divline}}At the start of your turn, you may play this from your hand.",
+        "wikitext": "+2 Coins<n>Each other player with 5 or more cards in hand puts one onto their deck.<n><line>At the start of your turn, you may play this from your hand."
+    },
+    "Coastal Haven": {
+        "description": "When discarding your hand in Clean-up, you may spend any number of Favors to keep that many cards in hand for next turn (you still draw 5).",
+        "extra": "",
+        "name": "Coastal Haven",
+        "raw_wikitext": "When discarding your hand in Clean-up, you may spend any number of '''Favors''' to keep that many cards in hand for next turn (you still draw&nbsp;5).",
+        "wikitext": "When discarding your hand in Clean-up, you may spend any number of <b>Favors</b> to keep that many cards in hand for next turn (you still draw&nbsp;5)."
+    },
+    "Cobbler": {
+        "description": "At the start of your next turn, gain a card to hand costing up to 4 Coins.",
+        "extra": "If you gain a Nomad Camp (from Hinterlands) with this, it goes to your hand.",
+        "name": "Cobbler",
+        "raw_wikitext": "At the start of your next turn, gain a card to your hand costing up to {{Cost|4}}.",
+        "wikitext": "At the start of your next turn, gain a card to your hand costing up to 4 Coins."
+    },
+    "Coin of the Realm": {
+        "description": "1 <*COIN*><n>When you play this, put it on your Tavern mat.<line>Directly after resolving an Action, you may call this for +2 Actions.",
+        "extra": "This is a Treasure worth 1 Coin. You play it in your Buy phase, like other Treasures. When you play it, it goes on your Tavern mat. It produces 1 Coin that turn but is no longer in play. It stays on the mat until you call it. You can call it after resolving playing an Action card, for +2 Actions (which will let you play further Action cards). Move the Coin of the Realm into play when you call it, but it does not give you 1 Coin that turn, it just gives +2 Actions. It is discarded that turn with your other cards in play.",
+        "name": "Coin of the Realm",
+        "raw_wikitext": "{{Cost|1|l}}<p>Put this on your Tavern mat.{{Divline}}After you play an Action card, you may call this, for '''+2&nbsp;Actions'''.</p>",
+        "wikitext": "1 <*COIN*><n>Put this on your Tavern mat.<line>After you play an Action card, you may call this, for <b>+2&nbsp;Actions</b>."
+    },
+    "Collection": {
+        "description": "2 <*COIN*><n><n>+1 Buy<n><n>This turn, when you gain an Action card, +1 <VP>.",
+        "extra": "You get +1 <VP> for each Action card you gain, whether bought, or gained some other way.<n>Multiple copies of this are cumulative; if you have two Collections in play and buy a Village, you'll get +2 <VP>. You only get <VP> for Actions you gain after you play the Collection; it doesn't retroactively give you points for cards you gained earlier in the turn. If the Collection leaves play (for instance, because you trashed it with Counterfeit), you still get <VP> from it for the rest of the turn.",
+        "name": "Collection",
+        "raw_wikitext": "{{Cost|2|l}}<br>'''+1&nbsp;Buy'''<p>This turn, when you gain an Action card, {{VP|'''+1'''}}.</p>",
+        "wikitext": "2 <*COIN*><br><b>+1&nbsp;Buy</b><n>This turn, when you gain an Action card, {{VP|<b>+1</b>}}."
+    },
+    "Colonnade": {
+        "description": "When you buy an Action card, if you have a copy of it in play, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "For example with Settlers in play, buying another Settlers gets you 2 <VP> from here.<n>Cards from the same pile are not necessarily copies of each other; for example Bustling Village is not a copy of Settlers.",
+        "name": "Colonnade",
+        "raw_wikitext": "When you gain an Action card in your Buy phase, if you have a copy of it in play, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "When you gain an Action card in your Buy phase, if you have a copy of it in play, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Colony": {
+        "description": "10 <*VP*>",
+        "extra": "This is not a Kingdom card. You do not use it every game. It is a Victory card worth 10 VP. If only Kingdom cards from Prosperity are being used this game, then the Platinum and Colony piles are added to the Basic cards in the Supply for the game. If a mix of Kingdom cards from Prosperity and other sets are being used, then the inclusion of Platinum and Colony in the Supply should be determined randomly, based on the proportion of Prosperity and non-Prosperity cards in use. For example, choose a random Kingdom card being used - such as the first card dealt out from the Randomizer deck [this is equivalent to rolling a d10 or choosing a card at random after all 10 have been selected] - and if it is from Prosperity, add Platinum and Colony to the Supply. Platinum and Colony are not Kingdom cards; when those are included, there are 10 Kingdom cards, plus Copper, Silver, Gold, Platinum, Estate, Duchy, Province, Colony, and Curse, in the Supply. Use 8 Colonies for a 2-player game, or 12 Colonies for a game with 3 or more players. [Use all 12 Platinum regardless of the number of players. Platinum and Colony are meant to be used together and both or neither should be used, not one or the other.]",
+        "name": "Colony",
+        "raw_wikitext": "{{VP|10|xl}}",
+        "wikitext": "10 <*VP*>"
+    },
+    "Commerce": {
+        "description": "Gain a Gold per differently named card you've gained this turn.",
+        "extra": "First count how many differently named cards you have gained this turn, then gain that many Golds. For example, if you have gained two Province, a Silver, and a Horse, you would gain three Golds.",
+        "name": "Commerce",
+        "raw_wikitext": "Gain a Gold per differently named card you've gained this turn.",
+        "wikitext": "Gain a Gold per differently named card you've gained this turn."
+    },
+    "Conclave": {
+        "description": "+2 Coins<n>You may play an Action card from your hand that you don’t have a copy of in play. If you do, +1 Action.",
+        "extra": " When you play this, you can play an Action card from your hand, provided that you do not have a copy of that card in play. It does not matter if you played the Action card this turn, only that it is not in play when you play Conclave; you can use Conclave to play a card that you played but trashed and so do not have in play, like a Pixie you trashed, but cannot use it to play a card you did not play this turn that is still in play, such as a Secret Cave from your previous turn. Conclave normally cannot play a Conclave, as that is a card you have in play. If you do play a card with Conclave, then Conclave gives you +1 Action, which has no special limitations, and so can for example be used to play another Conclave.",
+        "name": "Conclave",
+        "raw_wikitext": "{{Costplus|2}}<p>You may play an Action card from your hand that you don't have a copy of in play. If you do, '''+1&nbsp;Action'''.</p>",
+        "wikitext": "+2 Coins<n>You may play an Action card from your hand that you don't have a copy of in play. If you do, <b>+1&nbsp;Action</b>."
+    },
+    "Conjurer": {
+        "description": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand.",
+        "extra": "This will keep returning to your hand each turn as long as you keep playing it.<n>If you play this with a card like Band of Misfits, Band of Misfits will stay in play through the end of your next turn. Neither the Band of Misfits nor any Conjurer will move to your hand at the beginning of the next turn; it will try but fail to do so because of the stop-moving rule.",
+        "name": "Conjurer",
+        "raw_wikitext": "<p>Gain a card costing up to {{Cost|4}}.</p>At the start of your next turn, put this into your hand.",
+        "wikitext": "Gain a card costing up to 4 Coins.<n>At the start of your next turn, put this into your hand."
+    },
+    "Conquest": {
+        "description": "Gain 2 Silvers. +1 <VP> per Silver you've gained this turn.",
+        "extra": "This counts the two Silvers it gives you (provided that there were Silvers left to gain).<n>For example, with 12 Coin and 2 Buys and having gained no Silvers earlier in the turn, you could buy Conquest twice, getting two Silvers, then +2 <VP>, then two more Silvers, then +4 <VP>.",
+        "name": "Conquest",
+        "raw_wikitext": "Gain 2&nbsp;Silvers. {{VP|'''+1'''}} per Silver you've gained this turn.",
+        "wikitext": "Gain 2&nbsp;Silvers. {{VP|<b>+1</b>}} per Silver you've gained this turn."
+    },
+    "Conspirator": {
+        "description": "+2 Coins<n>If you've played 3 or more Actions this turn (counting this), +1 Card and +1 Action.",
+        "extra": "You evaluate whether or not Conspirator gives you +1 Card and +1 Action when you play it. Action cards played later in the turn do not change this evaluation. For the purposes of counting actions, if you Throne Room an Action, that's one Action of the Throne Room, one for the selected Action played the first time, and one for the selected Action played the second time. For example, if you play Throne Room on Conspirator, the first conspirator will be your second Action, and won't give you +1 Card or +1 Action, but the second Conspirator will be your third Action, and you will get +1 Card and +1 Action for that second Conspirator. Action - Victory cards are Actions.",
+        "name": "Conspirator",
+        "raw_wikitext": "{{Costplus|2}}<p>If you've played 3&nbsp;or more Actions this turn (counting this), '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.</p>",
+        "wikitext": "+2 Coins<n>If you've played 3&nbsp;or more Actions this turn (counting this), <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Continue": {
+        "description": "Once per turn: Gain a non-Attack Action card costing up to 4 Coins. Return to your Action phase and play it. <b>+1&nbsp;Action</b> and <b>+1&nbsp;Buy</b>.",
+        "name": "Continue",
+        "raw_wikitext": "Once per turn: Gain a non-Attack Action card costing up to {{Cost|4}}. Return to your Action phase and play it. '''+1&nbsp;Action''' and '''+1&nbsp;Buy'''."
+    },
+    "Contraband": {
+        "description": "3 <*COIN*><br><br>+1 Buy<n>The player to your left names a card. You can’t buy that card this turn.",
+        "extra": "This is a Treasure worth 3 coins, like Gold. When you play it, you get +1 Buy, the player to your left names a card, and you cannot buy the named card this turn. This does not stop you from gaining the card in ways other than buying it (such as via Hoard). He does not have to name a card in the Supply. If you play multiple Contrabands in one turn, the player to your left names a card each time; if he names different cards, you cannot buy any of the named cards this turn. You can play Treasures in any order, and you resolve this ability right when you play it, before playing any further Treasure cards. Note that once you buy a card in the Buy phase, you cannot play more Treasures. The number of cards left in a player's hand is public information; you can ask whenever you want to know it (for example, when that player plays Contraband).",
+        "name": "Contraband",
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>The player to your left names a card. You can't buy that card this turn.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>The player to your left names a card. You can't buy that card this turn."
+    },
+    "Contract": {
+        "description": "2 <*COIN*><br>+1 Favor<n>You may set aside an Action from your hand to play it at the start of your next turn.",
+        "extra": "If you set aside a card, then Contract stays in play until the Clean-up of your next turn; if you don't set aside a card, Contract is discarded the same turn in Clean-up.<n>If you set aside a card, you have to play it at the start of your next turn.<n>The set-aside card is face up.",
+        "name": "Contract",
+        "raw_wikitext": "{{Cost|2|l}}<br>'''+1&nbsp;Favor'''<p>You may set aside an Action from your hand to play it at the start of your next turn.</p>",
+        "wikitext": "2 <*COIN*><br><b>+1&nbsp;Favor</b><n>You may set aside an Action from your hand to play it at the start of your next turn."
+    },
+    "Copper": {
+        "description": "1 <*COIN*>",
+        "extra": "60 cards per game.",
+        "name": "Copper",
+        "raw_wikitext": "{{Cost|1|xl}}",
+        "wikitext": "1 <*COIN*>"
+    },
+    "Coppersmith": {
+        "description": "Copper produces an extra 1 Coin this turn.",
+        "extra": "This just changes how much money you get when playing Copper. The effect is cumulative; if you use Throne Room on Coppersmith, each Copper that you play that turn will produce 3 coins.",
+        "name": "Coppersmith",
+        "raw_wikitext": "Copper produces an extra {{Cost|1}} this turn.",
+        "wikitext": "Copper produces an extra 1 Coin this turn."
+    },
+    "Coronet": {
+        "description": "You may play a non-Reward Action from your hand twice.<br><br>You may play a non-Reward Treasure from your hand twice.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": " Playing either type of card is optional; you can play an Action twice, play a Treasure twice, do both, or do neither. If you do both, you play the Action first. This can't play Rewards. Playing a card twice with this means playing the card, resolving that completely, then playing the same card again. Playing cards with this doesn't use up Action plays for the turn. For example you could Coronet a Village and a Silver; you'd get +2 Cards and +4 Actions from the Village plays, and +4 coin from the Silver plays.",
+        "name": "Coronet",
+        "raw_wikitext": "<p>You may play a non-Reward Action from your hand twice.</p><p>You may play a non-Reward Treasure from your hand twice.</p>''(This is not in the Supply.)''",
+        "wikitext": "You may play a non-Reward Action from your hand twice.<n>You may play a non-Reward Treasure from your hand twice.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Corsair": {
+        "description": "+2 Coin<br><br>At the start of your next turn, +1 Card. Until then, each other player trashes the first Silver or Gold they play each turn.",
+        "extra": "The trashed Silver or Gold still made _ Coin for the player to spend that turn.<br>If you're under multiple <i>Corsair</i> attacks, you'll only trash 1 Silver and/or Gold.",
+        "name": "Corsair",
+        "raw_wikitext": "{{Costplus|2}}<p>At the start of your next turn, '''+1&nbsp;Card'''. Until then, each other player trashes the first Silver or Gold they play each turn.</p>",
+        "wikitext": "+2 Coins<n>At the start of your next turn, <b>+1&nbsp;Card</b>. Until then, each other player trashes the first Silver or Gold they play each turn."
+    },
+    "Council Room": {
+        "description": "+4 Cards<br>+1 Buy<n>Each other player draws a card.",
+        "extra": "The other players must draw a card whether they want to or not. All players should shuffle as necessary.",
+        "name": "Council Room",
+        "raw_wikitext": "'''+4&nbsp;Cards'''<br>'''+1&nbsp;Buy'''<p>Each other player draws a card.</p>",
+        "wikitext": "<b>+4&nbsp;Cards</b><br><b>+1&nbsp;Buy</b><n>Each other player draws a card."
+    },
+    "Count": {
+        "description": "Choose one: Discard 2 cards; or put a card from your hand on top of your deck; or gain a Copper.<n><n>Choose one: +3 Coins; or trash your hand; or gain a Duchy.",
+        "extra": "This card gives you two separate choices: first you either discard 2 cards, put a card from your hand on top of your deck, or gain a Copper; after resolving that, you either get +3 Coins, trash your hand, or gain a Duchy. For example, you might choose to discard 2 cards, then gain a Duchy. Gained cards come from the Supply and are put into your discard pile. You can choose an option even if you cannot do it. If you trash multiple cards that do something when trashed at once, trash them all, then choose an order to resolve the things that happen due to them being trashed.",
+        "name": "Count",
+        "raw_wikitext": "<p>Choose one: Discard 2&nbsp;cards; or put a card from your hand onto your deck; or gain a Copper.</p>Choose one: {{Costplus|3}}; or trash your hand; or gain a Duchy.",
+        "wikitext": "Choose one: Discard 2&nbsp;cards; or put a card from your hand onto your deck; or gain a Copper.<n>Choose one: +3 Coins; or trash your hand; or gain a Duchy."
+    },
+    "Counterfeit": {
+        "description": "1 <*COIN*><br><br>+1 Buy<n>When you play this, you may play a Treasure from your hand twice. If you do, trash that Treasure",
+        "extra": "This is a Treasure worth 1 Coin. You play it in your Buy phase, like other Treasures. When you play it, you also get +1 Buy, and you may play an additional Treasure card from your hand twice. If you choose to do that, you trash that Treasure. You still get any coins that Treasure gave you from playing it, despite trashing it. If you use Counterfeit to play Spoils twice, you will get +6 Coins, (in addition to the 1 Coin, from Counterfeit) and return Spoils to the Spoils pile; you will be unable to trash it. If you use Counterfeit to play a Treasure that does something special when you play it, you will do that thing twice. Cards with two types, one of which is Treasure (such as Harem from Intrigue) are Treasures and so can be played via Counterfeit.",
+        "name": "Counterfeit",
+        "raw_wikitext": "{{Cost|1|l}}<br>'''+1&nbsp;Buy'''<p>You may play a non-Duration Treasure from your hand twice. Trash it.</p>",
+        "wikitext": "1 <*COIN*><br><b>+1&nbsp;Buy</b><n>You may play a non-Duration Treasure from your hand twice. Trash it."
+    },
+    "Counting House": {
+        "description": "Look through your discard pile, reveal any number of Copper cards from it, and put them into your hand.",
+        "extra": "This card lets you look through your discard pile, something you normally are not allowed to do. You only get to look through your discard pile when you play this. You do not have to show the other players your entire discard pile, just the Coppers you take out. After you take out the Coppers, you can leave the cards in your discard pile in any order.",
+        "name": "Counting House",
+        "raw_wikitext": "Look through your discard pile, reveal any number of Coppers from it, and put them into your hand.",
+        "wikitext": "Look through your discard pile, reveal any number of Coppers from it, and put them into your hand."
+    },
+    "Courier": {
+        "description": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.",
+        "extra": "First discard your top card, shuffling if needed. Then look through your discard pile, and you may play an Action or Treasure from it.<n>You resolve any effects from discarding the top card of your deck before you look through your discard pile. So if this discards a Tunnel, you can play the Gold that you gained from it.<n>If you have an empty discard pile after discarding the top card of your deck, you can't play any card.",
+        "name": "Courier",
+        "raw_wikitext": "{{Costplus|1}}<p>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it.</p>",
+        "wikitext": "+1 Coin<n>Discard the top card of your deck. Look through your discard pile; you may play an Action or Treasure from it."
+    },
+    "Courser": {
+        "description": "Choose two different options:<br>+2 Cards; +2 Actions;<br>+2 coin; gain 4 Silvers.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": "First choose any two of the four options, then do those options in the order listed. So if you choose both +2 Cards and \"Gain 4 Silvers,\" you will draw cards before you gain the Silvers.",
+        "name": "Courser",
+        "raw_wikitext": "<p>Choose two different options: '''+2&nbsp;Cards'''; '''+2&nbsp;Actions'''; {{Costplus|2}}; gain 4 Silvers.</p>''(This is not in the Supply.)''",
+        "wikitext": "Choose two different options: <b>+2&nbsp;Cards</b>; <b>+2&nbsp;Actions</b>; +2 Coins; gain 4 Silvers.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Courtier": {
+        "description": "Reveal a card from your hand. For each type it has (Action, Attack, etc.), choose one: +1 Action; or +1 Buy; or +3 Coin; or gain a Gold. The choices must be different.",
+        "extra": "First reveal a card from your hand, then count the types.<n>The types are the words on the bottom line including Action, Attack, Curse, Reaction, Treasure, and Victory (with more in expansions).<n>Then choose one different thing per type the card had; if you revealed a card with two types, you pick two things.<n>For example you could reveal a Copper and choose \"gain a Gold,\" or reveal a Mill and choose \"+1 Action\" and \"+3 Coin\".<n>If you gain a Gold, put the Gold into your discard pile.",
+        "name": "Courtier",
+        "raw_wikitext": "Reveal a card from your hand. For each type it has (Action, Attack, etc.), choose one: '''+1&nbsp;Action'''; or '''+1&nbsp;Buy'''; or {{Costplus|3}}; or gain a Gold. The choices must be different.",
+        "wikitext": "Reveal a card from your hand. For each type it has (Action, Attack, etc.), choose one: <b>+1&nbsp;Action</b>; or <b>+1&nbsp;Buy</b>; or +3 Coins; or gain a Gold. The choices must be different."
+    },
+    "Courtyard": {
+        "description": "+3 Card<br>Put a card from your hand on top of your deck.",
+        "extra": "You draw cards and add them to your hand before putting one back. The card you put on top of your deck can be any card in your new hand and doesn't have to be one of the 3 you just drew.",
+        "name": "Courtyard",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>Put a card from your hand onto your deck.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>Put a card from your hand onto your deck."
+    },
+    "Coven": {
+        "description": "+1 Action<br>+2 Coin<br>Each other player Exiles a Curse from the Supply. If they can't, they discard their Exiled Curses.",
+        "extra": "Curses are Exiled in turn order; it may be that one player Exiles a Curse while another discards the Curses from their mat.",
+        "name": "Coven",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|2}}<p>Each other player Exiles a Curse from the Supply. If they can't, they discard their Exiled Curses.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+2 Coins<n>Each other player Exiles a Curse from the Supply. If they can't, they discard their Exiled Curses."
+    },
+    "Crafters' Guild": {
+        "description": "At the start of your turn, you may spend 2 Favors to gain a card costing up to 4 Coins onto your deck.",
+        "extra": "",
+        "name": "Crafters' Guild",
+        "raw_wikitext": "At the start of your turn, you may spend '''2 Favors''' to gain a card costing up to {{Cost|4}} onto your deck.",
+        "wikitext": "At the start of your turn, you may spend <b>2 Favors</b> to gain a card costing up to 4 Coins onto your deck."
+    },
+    "Craftsman": {
+        "description": "+2 Debt<br><br>Gain a card costing up to 5 Coin.",
+        "extra": "You gain a card even if you already had Debt; see the Debt section.",
+        "name": "Craftsman",
+        "raw_wikitext": "{{Debtplus|2}}<p>Gain a card costing up to {{Cost|5}}.</p>",
+        "wikitext": "{{Debtplus|2}}<n>Gain a card costing up to 5 Coins."
+    },
+    "Credit": {
+        "description": "Gain an Action or Treasure costing up to 8 Coins. {{Debtplus}} equal to its cost.",
+        "name": "Credit",
+        "raw_wikitext": "Gain an Action or Treasure costing up to {{Cost|8}}. {{Debtplus}} equal to its cost."
+    },
+    "Crew": {
+        "description": "+3 Cards<br>At the start of your next turn, put this onto your deck.",
+        "extra": "Putting this onto your deck isn't optional.",
+        "name": "Crew",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>At the start of your next turn, put this onto your deck.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>At the start of your next turn, put this onto your deck."
+    },
+    "Crop Rotation": {
+        "description": "At the start of your turn, you may discard a Victory card for +2 Cards.",
+        "extra": "If drawing causes you to shuffle, you will shuffle in the discarded Victory card.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Crop Rotation",
+        "raw_wikitext": "At the start of your turn, you may discard a Victory card for '''+2&nbsp;Cards'''.",
+        "wikitext": "At the start of your turn, you may discard a Victory card for <b>+2&nbsp;Cards</b>."
+    },
+    "Crossroads": {
+        "description": "Reveal your hand.<n>+1 Card per Victory card revealed. If this is the first time you played a Crossroads this turn, +3 Actions.",
+        "extra": "First reveal your hand, and draw a card for each Victory card you revealed, if any. The revealed cards all stay in your hand. Cards with two types, one of which is Victory, are Victory cards. Then, if this is the first time you played a Crossroads this turn, you get +3 Actions. Subsequent Crossroads this turn will give you cards but not Actions. Using a card that lets you play a card several times (like Throne Room from Dominion) on Crossroads, you will play Crossroads multiple times, getting +3 Actions the first time but not the others.",
+        "name": "Crossroads",
+        "raw_wikitext": "Reveal your hand. '''+1&nbsp;Card''' per Victory card revealed. If this is the first time you played a Crossroads this turn, '''+3&nbsp;Actions'''.",
+        "wikitext": "Reveal your hand. <b>+1&nbsp;Card</b> per Victory card revealed. If this is the first time you played a Crossroads this turn, <b>+3&nbsp;Actions</b>."
+    },
+    "Crown": {
+        "description": "If it's your Action phase, you may play an Action from your hand twice. If it's your Buy phase, you may play a Treasure from your hand twice.",
+        "extra": "If you play this in your Action phase, you play an Action card from your hand, then play the same card again; this does not use up any extra Actions you have. If you play this in your Buy phase, you play a Treasure from your hand, then play it again; this does not use up any Actions at all. Crown can be used to play another Crown in either your Action or Buy phase, causing you to either play two more Actions twice each, or two more Treasures twice each. If you play Crown in your Action phase via something that lets you play Treasures (like Storyteller from Adventures), Crown will still play an Action card twice.",
+        "name": "Crown",
+        "raw_wikitext": "<p>If it's your Action phase, you may play an Action from your hand twice.</p>If it's your Buy phase, you may play a Treasure from your hand twice.",
+        "wikitext": "If it's your Action phase, you may play an Action from your hand twice.<n>If it's your Buy phase, you may play a Treasure from your hand twice."
+    },
+    "Crucible": {
+        "description": "Trash a card from your hand. +1 Coin per 1 Coin it costs.",
+        "extra": "For example if you trash an Estate, which costs 2 Coin you get +2 Coin.<br>If you trash a card with Debt or Potion in its cost (from other expansions), you get nothing for those symbols.",
+        "name": "Crucible",
+        "raw_wikitext": "Trash a card from your hand. {{Costplus|1}} per {{Cost|1}} it costs.",
+        "wikitext": "Trash a card from your hand. +1 Coin per 1 Coin it costs."
+    },
+    "Crumbling Castle": {
+        "description": "1 <*VP*><line>When you gain or trash this, {{VP|<b>+1</b>}} and gain a Silver.",
+        "name": "Crumbling Castle",
+        "raw_wikitext": "{{VP|1|l}}{{Divline}}When you gain or trash this, {{VP|'''+1'''}} and gain a Silver."
+    },
+    "Crypt": {
+        "description": "Set aside any number of Treasures you have in play, face down (under this). While any remain, at the start of each of your turns, put one of them into your hand.",
+        "extra": "For example if you set aside three Treasures, then at the start of each of your next three turns you will put one of them into your hand, and at the end of the last of those turns you will discard Crypt from play. The Treasures are facedown; you can look at them at any time, but other players may not.",
+        "name": "Crypt",
+        "raw_wikitext": "Set aside any number of non-Duration Treasures you have in play, face down (under this). While any remain, at the start of each of your turns, put one of them into your hand.",
+        "wikitext": "Set aside any number of non-Duration Treasures you have in play, face down (under this). While any remain, at the start of each of your turns, put one of them into your hand."
+    },
+    "Crystal Ball": {
+        "description": "1 <*COIN*><n><n>Look at the top card of your deck. You may trash it, discard it, or, if it's an Action or Treasure, play it.",
+        "extra": "If you don't choose to do any of those things, you leave the card on your deck. If this plays an Action during your Buy phase that gives you +Actions, that doesn't let you play more Action cards in your Buy phase; if it draws Treasure cards, you can still play them.",
+        "name": "Crystal Ball",
+        "raw_wikitext": "{{Cost|1|l}}<p>Look at the top card of your deck. You may trash it, discard it, or, if it's an Action or Treasure, play it.</p>",
+        "wikitext": "1 <*COIN*><n>Look at the top card of your deck. You may trash it, discard it, or, if it's an Action or Treasure, play it."
+    },
+    "Cultist": {
+        "description": "+2 Cards<n>Each other player gains a Ruins. You may play a Cultist from your hand.<line>When you trash this, +3 Cards.",
+        "extra": "When you play this, you draw two cards, then each other player gains a Ruins. These come from the Ruins pile in the Supply, and are put into discard piles. Go in turn order starting to your left; each player takes the top Ruins, revealing the next one each time. If the Ruins pile runs out, players stop gaining them at that point. After giving out Ruins, you may play another Cultist from your hand. It can be one you just drew from playing Cultist, or one you already had in your hand. Playing a Cultist this way does not use up any extra Actions you were allowed to play due to cards like Fortress - the original Cultist uses up one Action and that is it. When you trash a Cultist of yours, you draw three cards. This happens whether or not it is your turn, and whether or not the card that causes Cultist to be trashed was yours. If you trash a Cultist while revealing cards, such as to a Knight attack, you do not draw the revealed cards that are about to be discarded.",
+        "name": "Cultist",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each other player gains a Ruins. You may play a Cultist from your hand.</p>{{Divline}}When you trash this, '''+3&nbsp;Cards'''.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Each other player gains a Ruins. You may play a Cultist from your hand.<n><line>When you trash this, <b>+3&nbsp;Cards</b>."
+    },
+    "Curse": {
+        "description": "-1 <*VP*>",
+        "extra": "Curses are an available pile in the Supply regardless of what other cards are in the Supply. With 2 players, place 10 Curses in the Supply. With 3 players, place 20 Curses in the Supply. With 4 players, place 30 Curses in the Supply. With 5 players, place 40 Curses in the Supply. With 6 players, place 50 Curses in the Supply.",
+        "name": "Curse",
+        "raw_wikitext": "{{VP|-1|xl}}",
+        "wikitext": "-1 <*VP*>"
+    },
+    "Cursed": {
+        "description": "When you gain a Cursed card, gain a Loot and a Curse.",
+        "extra": "When you gain a card from the Cursed pile, you also gain a Loot and a Curse.<br>If there are no Curses left, you still gain a Loot.",
+        "name": "Cursed",
+        "raw_wikitext": "When you gain a Cursed card, gain a Loot and a Curse.",
+        "wikitext": "When you gain a Cursed card, gain a Loot and a Curse."
+    },
+    "Cursed Gold": {
+        "description": "3 <*COIN*><br><br>When you play this, gain a Curse.",
+        "extra": "You can choose not to play Cursed Gold, and thus not gain a Curse.",
+        "name": "Cursed Gold",
+        "raw_wikitext": "{{Cost|3|l}}<p>Gain a Curse.</p>",
+        "wikitext": "3 <*COIN*><n>Gain a Curse."
+    },
+    "Cursed Village": {
+        "description": "+2 Actions<br>Draw until you have 6 cards in hand.<line>When you gain this, receive a Hex.",
+        "extra": " If you already have six or more cards in hand, you do not draw any cards. When you gain Cursed Village, you receive a Hex; since that will often be in your Buy phase, some of the Hexes may not do anything to you. Shuffle the Hexes before receiving the Hex.",
+        "name": "Cursed Village",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Draw until you have 6&nbsp;cards in hand.</p>{{Divline}}When you gain this, receive a Hex.",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Draw until you have 6&nbsp;cards in hand.<n><line>When you gain this, receive a Hex."
+    },
+    "Cutpurse": {
+        "description": "+2 Coins<n>Each other player discards a Copper card (or reveals a hand with no Copper).",
+        "extra": "Other players must discard one and only one Copper. If they do not have a Copper, they must reveal their hand for all players to see.",
+        "name": "Cutpurse",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player discards a Copper (or reveals a hand with no Copper).</p>",
+        "wikitext": "+2 Coins<n>Each other player discards a Copper (or reveals a hand with no Copper)."
+    },
+    "Cutthroat": {
+        "description": "Each other player discards down to 3 cards in hand.<br>The next time anyone gains a Treasure costing 5 Coin or more, gain a Loot.",
+        "extra": "Loot itself is a Treasure costing 5 Coin or more, so a player gaining one will trigger Cutthroats.",
+        "name": "Cutthroat",
+        "raw_wikitext": "<p>Each other player discards down to 3&nbsp;cards in hand.</p>The next time anyone gains a Treasure costing {{Cost|5}} or more, gain a Loot.",
+        "wikitext": "Each other player discards down to 3&nbsp;cards in hand.<n>The next time anyone gains a Treasure costing 5 Coins or more, gain a Loot."
+    },
+    "Daimyo": {
+        "description": "+1 Card<br>+1 Action<br><br>The next time you play a non-Command Action card this turn, replay it afterwards.",
+        "extra": "This isn't optional; whatever that next non-Command Action card is, Daimyo replays it. It replays it even if the card trashed itself. Command cards, such as Daimyo itself, are not replayed; Daimyo waits for a non-Command Action card (or fails to do anything more if the turn ends before you play one). If you play two Daimyos and then e.g. a Craftsman, you'll play the Craftsman three times total - once normally and once for each Daimyo. Daimyo costs 6 Debt; see the Debt section.",
+        "name": "Daimyo",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>The next time you play a non-Command Action card this turn, replay it afterwards.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>The next time you play a non-Command Action card this turn, replay it afterwards."
+    },
+    "Dame Anna": {
+        "description": "You may trash up to 2&nbsp;cards from your hand. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Dame Anna",
+        "raw_wikitext": "You may trash up to 2&nbsp;cards from your hand. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this."
+    },
+    "Dame Josephine": {
+        "description": "Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.<line>2 <*VP*>",
+        "name": "Dame Josephine",
+        "raw_wikitext": "Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{nowrap|{{Cost|6}},}} and discards the rest. If a Knight is trashed by this, trash this.{{Divline}}{{VP|2|l}}"
+    },
+    "Dame Molly": {
+        "description": "<b>+2&nbsp;Actions</b><n>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Dame Molly",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this.</p>"
+    },
+    "Dame Natalie": {
+        "description": "You may gain a card costing up to 3 Coins. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Dame Natalie",
+        "raw_wikitext": "You may gain a card costing up to {{Cost|3}}. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this."
+    },
+    "Dame Sylvia": {
+        "description": "+2 Coins<n>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Dame Sylvia",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this.</p>"
+    },
+    "Death Cart": {
+        "description": "You may trash this or an Action card from your hand, for +5 Coin.<line>When you gain this, gain 2 Ruins.",
+        "extra": "When you play Death Cart, you either trash an Action card from your hand, or trash the Death Cart, and get +5 Coins,. If you have no Action card in your hand, you will have to trash the Death Cart, but you can trash the Death Cart whether or not you have an Action card in hand. A card with multiple types, one of which is Action, is an Action card. When you gain a Death Cart, either from buying it or from gaining it some other way, you also gain 2 Ruins. You just take the top 2, whatever they are. If there are not enough Ruins left, take as many as you can. The Ruins come from the Supply and are put into your discard pile. The other players get to see which ones you got. The player gaining Death Cart is the one who gains Ruins; if Possession (from Alchemy) is used to make another player buy Death Cart, the player actually gaining the Death Cart (the one who played Possession) gains the Ruins. If you use Trader (from Hinterlands) to take a Silver instead of a Death Cart, you do not gain any Ruins. It doesn't matter whose turn it is; if you use Ambassador (from Seaside) to give Death Carts to each other player, those players also gain Ruins. Passing cards with Masquerade (from Intrigue) does not count as gaining them.",
+        "name": "Death Cart",
+        "raw_wikitext": "You may trash this or an Action card from your hand, for {{Costplus|5}}.{{Divline}}When you gain this, gain 2&nbsp;Ruins.",
+        "wikitext": "You may trash this or an Action card from your hand, for +5 Coins.<line>When you gain this, gain 2&nbsp;Ruins."
+    },
+    "Defiled Shrine": {
+        "description": "When you gain an Action, move 1 <VP> from its pile to this. When you buy a Curse, take the <VP> from this.<line>Setup: Put 2 <VP> on each non-Gathering Action Supply pile.",
+        "extra": "Note that this triggers on gaining an Action, whether bought or otherwise gained, but only on buying Curse, not on gaining Curse other ways.<n><VP> tokens will go on Ruins (from Dark Ages) when used, but not on Farmers' Market, Temple, or Wild Hunt (the three Action - Gathering cards).",
+        "name": "Defiled Shrine",
+        "raw_wikitext": "When you gain an Action, move {{VP|'''1'''}} from its pile to this. When you gain a Curse in your Buy phase, take the {{VP}} from this.{{Divline}}Setup: Put {{VP|'''2'''}} on each non-Gathering Action Supply pile.",
+        "wikitext": "When you gain an Action, move 1 <VP> from its pile to this. When you gain a Curse in your Buy phase, take the {{VP}} from this.<line>Setup: Put 2 <VP> on each non-Gathering Action Supply pile."
+    },
+    "Delay": {
+        "description": "You may set aside an Action card from your hand. At the start of your next turn, play it.",
+        "extra": "Once you set aside the Action card, you have to play it at the start of your next turn.<n>If you do multiple things at the start of your turn, you can order them.<n>Playing the Action card at the start of your next turn does not use up an Action.",
+        "name": "Delay",
+        "raw_wikitext": "You may set aside an Action card from your hand. At the start of your next turn, play it.",
+        "wikitext": "You may set aside an Action card from your hand. At the start of your next turn, play it."
+    },
+    "Deliver": {
+        "description": "+1 Buy<br>This turn, each time you gain a card, set it aside, and put it into your hand at end of turn.",
+        "extra": "Buying this more than once doesn't do anything extra.<br>The set aside cards go into your hand after drawing your usual 5 cards.",
+        "name": "Deliver",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>This turn, each time you gain a card, set it aside, and put it into your hand at end of turn.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>This turn, each time you gain a card, set it aside, and put it into your hand at end of turn."
+    },
+    "Deluded": {
+        "description": "At the start of your Buy phase, return this, and you can't buy Actions this turn.",
+        "name": "Deluded",
+        "raw_wikitext": "At the start of your Buy phase, return this, and you can't buy Actions this turn."
+    },
+    "Delusion": {
+        "description": "If you don't have Deluded or Envious, take Deluded.",
+        "extra": "",
+        "name": "Delusion",
+        "raw_wikitext": "If you don't have Deluded or Envious, take Deluded.",
+        "wikitext": "If you don't have Deluded or Envious, take Deluded."
+    },
+    "Delve": {
+        "description": "+1 Buy<br>Gain a Silver.",
+        "extra": "Each purchase of Delve gives you back the Buy you used on it.<n>For example, if you have 7 Coins, you can Delve, then Delve, then buy a card for 3 Coins.",
+        "name": "Delve",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Gain a Silver.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Gain a Silver."
+    },
+    "Demand": {
+        "description": "Gain a Horse and a card costing up to 4 coin, both onto your deck.",
+        "extra": "The Horse goes on top first, then the card costing up to 4 coin does.",
+        "name": "Demand",
+        "raw_wikitext": "Gain a Horse and a card costing up to {{Cost|4}}, both onto your deck.",
+        "wikitext": "Gain a Horse and a card costing up to 4 Coins, both onto your deck."
+    },
+    "Demesne": {
+        "description": "+2 Actions<br>+2 Buys<br>Gain a Gold.<line>Worth 1 <VP> per Gold you have.<br><br><i>(This is not in the supply.)</i>",
+        "extra": "When you play this, you get +2 Actions, +2 Buys, and gain a Gold. When scoring, this is worth 1 <VP> per Gold you have then.",
+        "name": "Demesne",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<br>'''+2&nbsp;Buys'''<p>Gain a Gold.</p>{{Divline}}<p>Worth {{VP|'''1'''}} per Gold you have.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Actions</b><br><b>+2&nbsp;Buys</b><n>Gain a Gold.<n><line><n>Worth 1 <VP> per Gold you have.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Den of Sin": {
+        "description": "At the start of your next turn,<n>+2 Cards.<line>This is gained to your hand (instead of your discard pile).",
+        "extra": "Since Night is after the Buy phase, normally you can play this the turn you buy it.",
+        "name": "Den of Sin",
+        "raw_wikitext": "At the start of your next turn, '''+2&nbsp;Cards.'''{{Divline}}This is gained to your hand (instead of your discard pile).",
+        "wikitext": "At the start of your next turn, <b>+2&nbsp;Cards.</b><line>This is gained to your hand (instead of your discard pile)."
+    },
+    "Desert Guides": {
+        "description": "At the start of your turn, you may spend a Favor to discard your hand and draw 5 cards. Repeat as desired.",
+        "extra": "",
+        "name": "Desert Guides",
+        "raw_wikitext": "At the start of your turn, you may spend a '''Favor''' to discard your hand and draw 5&nbsp;cards. Repeat as desired.",
+        "wikitext": "At the start of your turn, you may spend a <b>Favor</b> to discard your hand and draw 5&nbsp;cards. Repeat as desired."
+    },
+    "Desperation": {
+        "description": "Once per turn: You may gain a Curse. If you do, +1 Buy and +2  Coin",
+        "extra": "If the Curse pile is empty, you fail to gain one and do not get +1 Buy and +2 Coin.",
+        "name": "Desperation",
+        "raw_wikitext": "Once per turn: You may gain a Curse. If you do, '''+1 Buy''' and {{Costplus|2}}.",
+        "wikitext": "Once per turn: You may gain a Curse. If you do, <b>+1 Buy</b> and +2 Coins."
+    },
+    "Destrier": {
+        "description": "+2 Cards<br>+1 Action<line>During your turns, this costs 1 Coin less per card you've gained this turn.",
+        "extra": "Destrier costs 1 Coin less per card the player whose turn it is has gained that turn.<n>For example, you could play a Sleigh to gain two Horses, then use Workshop to gain a Destrier, as it would cost 4 Coin.<n>Destrier only cares about cards gained by the player whose turn it is; for example, playing Witch to give other players Curses will not lower its cost.",
+        "name": "Destrier",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''{{Divline}}During your turns, this costs {{Cost|1}} less per card you've gained this turn.",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><line>During your turns, this costs 1 Coin less per card you've gained this turn."
+    },
+    "Develop": {
+        "description": "Trash a card from your hand. Gain a card costing exactly 1 coin more than it and a card costing exactly 1 less than it, in either order, putting them on top of your deck.",
+        "extra": "First trash a card from your hand, if you have any cards in hand. Develop itself is no longer in your hand and so cannot trash itself (though it can trash other copies of Develop). If you trashed a card, gain two cards, one costing exactly 1 coin more than the trashed card, and one costing exactly 1 coin less than the trashed card. The gained cards come from the Supply; gain them in either order. If there is no card in the Supply at one of the costs, you still gain the other card if you can. Put the gained cards on top of your deck rather than into your discard pile. If you trash a Copper with Develop, which costs 0 coins, you will try and fail to gain a card costing -1 coins (and also try to gain a card costing 1 coin).",
+        "name": "Develop",
+        "raw_wikitext": "Trash a card from your hand. Gain two cards onto your deck, with one costing exactly {{Cost|1}} more than it, and one costing exactly {{Cost|1}} less than it, in either order.",
+        "wikitext": "Trash a card from your hand. Gain two cards onto your deck, with one costing exactly 1 Coin more than it, and one costing exactly 1 Coin less than it, in either order."
+    },
+    "Devil's Workshop": {
+        "description": "If the number of cards you've gained this turn is:<br>2+, gain an Imp from its pile;<br>1, gain a card costing up to 4 Coin;<br>0, gain a Gold.",
+        "extra": "This counts all cards you have gained this turn, including cards gained at Night prior to playing it. You cannot choose a different benefit; if you have gained two or more cards, you have to gain an Imp, you cannot take a card costing up to 4 Coins or a Gold instead. Normally, bought cards are then gained, but cards exchanged for (such as Vampire exchanging for Bat) are not gained.<br><br>Setup: Put the Imp pile near the Supply.",
+        "name": "Devil's Workshop",
+        "raw_wikitext": "<p>If the number of cards you've gained this turn is:</p>2+, gain an Imp;<br>1, gain a card costing up to {{Cost|4}};<br>0, gain a Gold.",
+        "wikitext": "If the number of cards you've gained this turn is:<n>2+, gain an Imp;<br>1, gain a card costing up to 4 Coins;<br>0, gain a Gold."
+    },
+    "Diadem": {
+        "description": "2 <*COIN*><n>When you play this, +1 Coins per unused Action you have (Action, not Action card).<n><i>(This is not in the Supply.)</i>",
+        "extra": "This is a Treasure worth 2 coins, like Silver. You play it in your Buy phase, like other Treasures. When you play it, you get an extra +1 coin per unused Action you have. This means Actions, not Action cards. So for example if you play Farming Village (which gives you +2 Actions), then Diadem, Diadem will give you an extra +2 coins, for 4 coins total. If you play no Action cards at all on your turn, you will have one unused Action, so you will get total from Diadem. This is a Prize; see the Additional Rules.",
+        "name": "Diadem",
+        "raw_wikitext": "{{Cost|2|l}}<p>{{Costplus|1}} per unused Action you have (Action, not Action card).</p>''(This is not in the Supply.)''",
+        "wikitext": "2 <*COIN*><n>+1 Coin per unused Action you have (Action, not Action card).<n><i>(This is not in the Supply.)</i>"
+    },
+    "Diplomat": {
+        "description": "+2 Cards<br>If you have 5 or fewer cards in hand (after drawing), +2 Actions.<line>When another player plays an Attack card, you may first reveal this from a hand of 5 or more cards, to draw 2 cards then discard 3.",
+        "extra": "When playing this, you get +2 Cards, then count your cards in hand, and if you have 5 cards or fewer, you get +2 Actions.<n>So, for example if you play this from a hand of 5 cards, you will put it into play, going down to 4 cards, then draw 2 cards, going up to 6 cards, and that is more than 5 cards so you would not get the +2 Actions.<n>Diplomat can also be used when another player plays an Attack card, if you have at least 5 cards in hand.<n>Before the Attack card does anything, you can reveal a Diplomat from your hand; if you do, you draw 2 cards, then discard 3 cards (which can include the Diplomat).<n>If you still have at least 5 cards in hand after doing that (such as due to Council Rooms), you can reveal Diplomat again and do it again.<n>You reveal Reactions one at a time; you cannot reveal two Diplomats simultaneously.<n>You can reveal a Moat from your hand (to be unaffected by an Attack) either before or after revealing and resolving a Diplomat (even if the Moat was not in your hand until after resolving Diplomat).",
+        "name": "Diplomat",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>If you have 5&nbsp;or fewer cards in hand (after drawing), '''+2&nbsp;Actions'''.</p>{{Divline}}When another player plays an Attack card, you may first reveal this from a hand of 5&nbsp;or more cards, to draw 2&nbsp;cards then discard&nbsp;3.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>If you have 5&nbsp;or fewer cards in hand (after drawing), <b>+2&nbsp;Actions</b>.<n><line>When another player plays an Attack card, you may first reveal this from a hand of 5&nbsp;or more cards, to draw 2&nbsp;cards then discard&nbsp;3."
+    },
+    "Disciple": {
+        "description": "You may play an Action card from your hand twice. Gain a copy of it.<line>When you discard this from play, you may exchange it for a Teacher.<n><i>(This is not in the Supply.)</i>",
+        "extra": "Playing an Action card from your hand is optional. If you do play one, you play it twice, then gain a copy of it if possible; gaining the copy is not optional once you have played it. The copy comes from the Supply and is put into your discard pile; if the Action is a non-Supply card, such as Fugitive, you can play it twice, but do not gain a copy of it. This does not use up any extra Actions you were allowed to play due to cards like Port - Disciple itself uses up one Action and that is it. You cannot play any other cards in between resolving the Discipled Action card multiple times, unless that Action card specifically tells you to (such as Disciple itself does). If you Disciple a card that gives you +1 Action, such as Artificer, you will end up with 2 Actions to use afterwards, rather than the one you would have left if you just played two Artificers. If you use Disciple on a Duration card, Disciple will stay in play until the Duration card is discarded.",
+        "name": "Disciple",
+        "raw_wikitext": "You may play an Action card from your hand twice. Gain a copy of it.{{Divline}}<p>When you discard this from play, you may exchange it for a Teacher.</p>''(This is not in the Supply.)''",
+        "wikitext": "You may play an Action card from your hand twice. Gain a copy of it.<line><n>When you discard this from play, you may exchange it for a Teacher.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Dismantle": {
+        "description": "Trash a card from your hand. If it costs 1 coin or more, gain a cheaper card and a Gold.",
+        "extra": "Trashing is not optional. If you trash a card costing 0 Coin, or if you have no cards left in hand to trash, nothing else happens. If you trash a card costing 1 Coin or more, you gain a cheaper card and a Gold. Both come from the Supply, and are put into your discard pile. The cheaper card goes into your discard pile first. For example, if you trash a Silver (costing 3 Coin), you could gain an Estate (costing 2 Coin). There will almost always be a cheaper card in the Supply, since Copper and Curse cost 0 Coin, but if there aren't any, you still gain a Gold. If there aren't any Gold left in the Supply, you still gain the cheaper card. Cards that cost only Potion (like Transmute from Alchemy) or only Debt (like Engineer from Empires) do not cost 1 Coin or more.",
+        "name": "Dismantle",
+        "raw_wikitext": "Trash a card from your hand. If it costs {{Cost|1}} or more, gain a cheaper card and a Gold.",
+        "wikitext": "Trash a card from your hand. If it costs 1 Coin or more, gain a cheaper card and a Gold."
+    },
+    "Displace": {
+        "description": "Exile a card from your hand. Gain a differently named card costing up to 2 Coin more than it.",
+        "extra": "The card you gain does not have to cost more than the card you Exiled.<n>For example, you could Exile a Province and gain a Gold.",
+        "name": "Displace",
+        "raw_wikitext": "Exile a card from your hand. Gain a differently named card costing up to {{Cost|2}} more than it.",
+        "wikitext": "Exile a card from your hand. Gain a differently named card costing up to 2 Coins more than it."
+    },
+    "Distant Lands": {
+        "description": "Put this on your Tavern mat.<line>Worth 4 <VP> if on your Tavern mat at the end of the Game (otherwise worth 0 <VP>).",
+        "extra": "This is a Victory card. Use 8 for games with 2 players, or 12 for games with 3 or more players. This is also an Action card; when you play it, you put it on your Tavern mat. It will stay there the rest of the game; there is no way to call it. At the end of the game, Distant Lands is worth 4 <VP> if it is on your mat, or 0 <VP> if it is not. It counts as part of your deck either way (for example it can contribute to how many <VP> a Gardens is worth).",
+        "name": "Distant Lands",
+        "raw_wikitext": "Put this on your Tavern mat.{{Divline}}Worth {{VP|'''4'''}} if on your Tavern mat at the end of the game (otherwise worth {{VP|'''0'''}}).",
+        "wikitext": "Put this on your Tavern mat.<line>Worth 4 <VP> if on your Tavern mat at the end of the game (otherwise worth 0 <VP>)."
+    },
+    "Distant Shore": {
+        "description": "+2 Cards<br>+1 Action<n>Gain an Estate.<line>2 <*VP*>",
+        "extra": "Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Distant Shore",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Gain an Estate.</p>{{Divline}}{{VP|2|l}}",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Gain an Estate.<n><line>2 <*VP*>"
+    },
+    "Divine Wind": {
+        "description": "When you remove the last {{Sun}}, remove all Kingdom card piles from the Supply, and set up 10&nbsp;new random piles.",
+        "name": "Divine Wind",
+        "raw_wikitext": "When you remove the last {{Sun}}, remove all Kingdom card piles from the Supply, and set up 10&nbsp;new random piles."
+    },
+    "Doctor": {
+        "description": "Name a card. Reveal the top 3 cards of your deck. Trash the matches. Put the rest back on top in any order.<line>When you buy this, you may overpay for it. For each 1 Coin you overpaid, look at the top card of your deck; trash it, discard it, or put it back.",
+        "extra": "When you play this, you name a card, reveal the top three cards of your deck, trash each of those cards that has that name, and put the other cards back on your deck in any order. You do not have to name a card being used this game. If there are fewer than three cards left in your deck, reveal the remaining cards, and shuffle your discard pile (which does not include those cards) to get the remainder needed to reveal. If there are still not enough cards, just reveal as many as you can. When you buy this, for each extra 1 Coin you pay over the cost, you look at the top card of your deck, and either trash it, discard it, or put it back on top. If there are no cards left in your deck, shuffle your discard pile into your deck (including any cards already discarded to this overpay ability this turn), and if there still are no cards in it, you do not look at one. If you overpay more than 1 Coin, you may do different things for each card you look at, and you will look at the same card again if you put it back on top. For example if you bought Doctor for 7 Coins, you would look at the top card four times; you might end up first trashing a Copper, then discarding a Province, then putting a Silver back on top, then putting that Silver back on top again.",
+        "name": "Doctor",
+        "raw_wikitext": "Name a card. Reveal the top 3&nbsp;cards of your deck. Trash the matches. Put the rest back in any order.{{Divline}}Overpay: Per {{Cost|1}} overpaid, look at the top card of your deck; trash it, discard it, or put it back.",
+        "wikitext": "Name a card. Reveal the top 3&nbsp;cards of your deck. Trash the matches. Put the rest back in any order.<line>Overpay: Per 1 Coin overpaid, look at the top card of your deck; trash it, discard it, or put it back."
+    },
+    "Dominate": {
+        "description": "Gain a Province. If you do, +9 <VP>.",
+        "extra": "This does nothing once the Province pile is empty.",
+        "name": "Dominate",
+        "raw_wikitext": "Gain a Province. If you do, {{VP|'''+9'''}}.",
+        "wikitext": "Gain a Province. If you do, {{VP|<b>+9</b>}}."
+    },
+    "Donate": {
+        "description": "After this turn, put all cards from your deck and discard pile into your hand, trash any number, shuffle your hand into your deck, then draw 5 cards.",
+        "extra": "Effects that happen due to trashing cards (such as Rocks) will happen before you shuffle.<n>This happens between turns, and so Possession (from Alchemy) will no longer be doing anything.",
+        "name": "Donate",
+        "raw_wikitext": "At the start of your next turn, first, put your deck and discard pile into your hand, trash any number of cards from it, then shuffle the rest into your deck and draw 5&nbsp;cards.",
+        "wikitext": "At the start of your next turn, first, put your deck and discard pile into your hand, trash any number of cards from it, then shuffle the rest into your deck and draw 5&nbsp;cards."
+    },
+    "Doubloons": {
+        "description": "3 <*COIN*><line>When you gain this, gain a Gold.",
+        "extra": "When you gain this, you also gain a Gold.",
+        "name": "Doubloons",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}{{Divline}}When you gain this, gain a Gold.",
+        "wikitext": "3 <*COIN*><line>When you gain this, gain a Gold."
+    },
+    "Druid": {
+        "description": "+1 Buy<br>Receive one of the set aside Boons (leaving it there).<line>Setup: Set aside the top 3 Boons, face-up.",
+        "extra": "At the start of the game, deal out three Boons face up for Druid. If there are other Fate cards in the same game, those Fate cards will not produce those Boons that game; the deck will consist of the other nine Boons. When you play Druid, you choose one of its three Boons to receive, and leave it there in the setaside area for Druid, even if it is one of the Boons that says to keep it until Cleanup (e.g. The Field's Gift).",
+        "name": "Druid",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p> Receive one of the set-aside Boons (leaving it there).</p>{{Divline}}Setup: Set aside the top 3&nbsp;Boons face up.",
+        "wikitext": "<b>+1&nbsp;Buy</b><n> Receive one of the set-aside Boons (leaving it there).<n><line>Setup: Set aside the top 3&nbsp;Boons face up."
+    },
+    "Ducat": {
+        "description": "+1 Coffers<br>+1 Buy<line>When you gain this, you may trash a Copper from your hand.",
+        "extra": "When you play this, you get no _ Coin, but get +1 Coffers and +1 Buy.  When you gain this, you may trash a Copper from your hand; this is optional.",
+        "name": "Ducat",
+        "raw_wikitext": "'''+1&nbsp;Coffers'''<br>'''+1&nbsp;Buy'''{{Divline}}When you gain this, you may trash a Copper from your hand.",
+        "wikitext": "<b>+1&nbsp;Coffers</b><br><b>+1&nbsp;Buy</b><line>When you gain this, you may trash a Copper from your hand."
+    },
+    "Duchess": {
+        "description": "+2 Coins<n>Each player (including you) looks at the top card of his deck, and discards it or puts it back.<line>In games using this, when you gain a Duchy, you may gain a Duchess.",
+        "extra": "When you play this, you get +2 coins, and each player, including you, looks at the top card of his own deck and either discards it or puts it back on top, his choice. Any player with no cards in his deck shuffles his discard pile first; any player who still has no cards to look at does not look at one. When a player gains a Duchy in a game with Duchess in the Supply, that player may also gain a Duchess from the Supply. This works whether the player gained a Duchy due to buying one, or gained a Duchy some other way. Duchess does not interact in any special way with the promotional card Black Market.",
+        "name": "Duchess",
+        "raw_wikitext": "{{Costplus|2}}<p>Each player (including you) looks at the top card of their deck and may discard it.</p>{{Divline}}In games using this, when you gain a Duchy, you may gain a Duchess.",
+        "wikitext": "+2 Coins<n>Each player (including you) looks at the top card of their deck and may discard it.<n><line>In games using this, when you gain a Duchy, you may gain a Duchess."
+    },
+    "Duchy": {
+        "description": "3 <*VP*>",
+        "extra": "Put 8 in the Supply in a game with two players. Put 12 in the Supply in a game with three or more players.",
+        "name": "Duchy",
+        "raw_wikitext": "{{VP|3|xl}}",
+        "wikitext": "3 <*VP*>"
+    },
+    "Duke": {
+        "description": "Worth 1 <VP> per Duchy you have.",
+        "extra": "This does nothing until the end of the game, at which time it's worth 1 <VP> per Duchy you have. This counts all of your cards - your Discard pile and hand are part of your Deck at that point. <line>Use 8 Dukes for games with 2 players, 12 for games with 3 or more players.",
+        "name": "Duke",
+        "raw_wikitext": "Worth {{VP|'''1'''}} per Duchy you have.",
+        "wikitext": "Worth 1 <VP> per Duchy you have."
+    },
+    "Dungeon": {
+        "description": "+1 Action<n>Now and at the start of your next turn: +2 Cards then discard 2 cards.",
+        "extra": "When you play this, you get +1 Action, draw 2 cards, and discard 2 cards; then at the start of your next turn, you again draw 2 cards and discard 2 cards.",
+        "name": "Dungeon",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Now and at the start of your next turn: '''+2&nbsp;Cards''', then discard 2&nbsp;cards.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Now and at the start of your next turn: <b>+2&nbsp;Cards</b>, then discard 2&nbsp;cards."
+    },
+    "Duplicate": {
+        "description": "Put this on your Tavern mat.<line>When you gain a card costing up to 6 Coins, you may call this, to gain a copy of that card.",
+        "extra": "When you play this, you put it on your Tavern mat. It stays on your mat until you call it. You can call it when gaining a card costing up to 6 Coins , and gain another copy of that card. The gained card comes from the Supply and is put into your discard pile; Duplicate cannot gain non-supply cards such as Teacher. Duplicate can be called during other players' turns when you gain cards; for example, another player might buy Messenger and choose to have each player gain an Estate, and you could Duplicate that Estate. You can call multiple Duplicates to gain multiple copies of the same card. Duplicate is discarded during the Clean-up of the turn you call it, whether or not it is your turn.",
+        "name": "Duplicate",
+        "raw_wikitext": "Put this on your Tavern mat.{{Divline}}When you gain a card costing up to {{nowrap|{{Cost|6}},}} you may call this, to gain a copy of that card.",
+        "wikitext": "Put this on your Tavern mat.<line>When you gain a card costing up to 6 Coins, you may call this, to gain a copy of that card."
+    },
+    "Elder": {
+        "description": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (e.g. \"choose one\") this turn, you may choose an extra (different) option.",
+        "extra": "You can play an Action card with no \"choose\" ability; it will simply do what it normally does.<n>If you play one with a \"choose\" ability, you may take an extra choice, but don't have to.<n>If you choose multiple things, you do those things in the order listed on the card.<n>If you use Elder on Courtier, you get one extra choice, not one extra choice per type.<n>Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Elder",
+        "raw_wikitext": "{{Costplus|2}}<p>You may play an Action card from your hand. When it gives you a choice of abilities (with \"choose\") this turn, you may choose an extra (different) option.</p>",
+        "wikitext": "+2 Coins<n>You may play an Action card from your hand. When it gives you a choice of abilities (with \"choose\") this turn, you may choose an extra (different) option."
+    },
+    "Embargo": {
+        "description": "+2 Coins<n>Trash this to add an Embargo token to a Supply pile. (For the rest of the game, when a player buys a card from that pile, they gain a Curse.)",
+        "extra": "You can pick any pile in the supply. If multiple Embargo cards are used to put Embargo tokens on the same pile, a player gains a Curse card for every Embargo token when they buy a card from that pile. You do not gain a Curse card if you gain a card from an Embargoed pile without buying it (for example, if you gain a card with Smugglers). If you Throne Room an Embargo, you place two Embargo tokens and they do not have to go on the same Supply pile. If you run out of Embargo tokens, use a suitable replacement to mark Embargoed piles. If there are no Curses left, Embargo tokens do nothing.",
+        "name": "Embargo",
+        "raw_wikitext": "{{Costplus|2}}<p>Trash this to add an Embargo token to a Supply pile. (For the rest of the game, when a player buys a card from that pile, they gain a Curse.)</p>",
+        "wikitext": "+2 Coins<n>Trash this to add an Embargo token to a Supply pile. (For the rest of the game, when a player buys a card from that pile, they gain a Curse.)"
+    },
+    "Embassy": {
+        "description": "+5 Cards<br>Discard 3 cards.<line>When you gain this, each other player gains a Silver.",
+        "extra": "When you play this, you draw five cards, then discard three cards. The cards you discard can be ones that were in your hand and/or ones you just drew. You discard three cards if able, even if you were unable to draw the full five cards (due to not having enough cards in your deck and discard pile). If you do not have three cards to discard, you discard as many as you can. When you gain this, each other player gains a Silver. Players only gain Silvers when you gain this, not when you play this. They gain Silvers whether you gained Embassy due to buying it, or gained it some other way. Gaining Silvers is not optional for them. The Silvers come from the Supply. If there are not enough Silvers left to go around, deal them out in turn order, starting with the player to the left of the player who gained Embassy.",
+        "name": "Embassy",
+        "raw_wikitext": "'''+5&nbsp;Cards'''<p>Discard 3&nbsp;cards.</p>{{Divline}}When you gain this, each other player gains a Silver.",
+        "wikitext": "<b>+5&nbsp;Cards</b><n>Discard 3&nbsp;cards.<n><line>When you gain this, each other player gains a Silver."
+    },
+    "Emissary": {
+        "description": "+3 Cards<n>If this made you shuffle (at least one card), +1 Action and +2 Favors.",
+        "extra": "First draw 3 cards; then see if drawing those cards caused you to shuffle. If it did, you get +1 Action and +2 Favors.<n>It only counts as shuffling if at least one card was in your discard pile.",
+        "name": "Emissary",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>If this made you shuffle (at least one card), '''+1&nbsp;Action''' and '''+2&nbsp;Favors'''.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>If this made you shuffle (at least one card), <b>+1&nbsp;Action</b> and <b>+2&nbsp;Favors</b>."
+    },
+    "Emporium": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<line>When you gain this, if you have at least 5 Action cards in play, +2 <VP>.",
+        "extra": "This counts Action cards in play, including Action cards played this turn, Duration cards in play from previous turns, and Reserve cards (from Adventures) called into play this turn.",
+        "name": "Emporium",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}{{Divline}}When you gain this, if you have at least 5&nbsp;Action cards in play, {{VP|'''+2'''}}.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<line>When you gain this, if you have at least 5&nbsp;Action cards in play, {{VP|<b>+2</b>}}."
+    },
+    "Encampment": {
+        "description": "+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.",
+        "extra": "Revealing a Plunder or Gold is optional. When you return Encampment to the Supply, it goes on top of its pile, potentially covering up a Plunder.",
+        "name": "Encampment",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+2&nbsp;Actions'''<p>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to its pile at the start of Clean-up.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to its pile at the start of Clean-up."
+    },
+    "Encampment - Plunder": {
+        "description": "<left><u>Encampment</u>:</left><n>+2 Cards<br>+2 Actions<n>You may reveal a Gold or Plunder from your hand. If you do not, set this aside, and return it to the Supply at the start of Clean-up.<n><left><u>Plunder</u>:</left><n>+2 Coin<br>+1 <VP>",
+        "extra": "Revealing a Plunder or Gold is optional. When you return Encampment to the Supply, it goes on top of its pile, potentially covering up a Plunder. Plunder: This gives you a <VP> token every time you play it.",
+        "name": "Encampment / Plunder"
+    },
+    "Enchantress": {
+        "description": "Until your next turn, the first time each other play plays an Action card on their turn, they get +1 Card and +1 Action instead of following its instructions.<n><n>At the start of your next turn,<n>+2 Cards",
+        "extra": "Players revealing a card like Moat when this is played have to do it right then, not later, even though the attack will not hurt them until their turn. The first Action each other player plays, just on their next turn, will give them +1 Card +1 Action instead of what it would have normally done. This does not affect abilities below a dividing line; they still function. For example a player playing Sacrifice would get +1 Card +1 Action and not do anything Sacrifice normally does; a player playing Groundskeeper would get +1 Card +1 Action and would still get <VP> for gaining Victory cards. It can be helpful to turn the affected card sideways, to remember that it did not do what it normally did. Enchantress does not affect card abilities from cards played on previous turns; for example if an opponent plays Enchantress and you have an Archive out from a previous turn, on your turn you will first get a card from your Archive as normal, and then the first Action card actually played on that turn will be affected by Enchantress. If Enchantress affects a Crown played in a Buy phase, its player gets +1 Card +1 Action, but has no way to use the +1 Action, since it is their Buy phase (but it might matter e.g. if the player buys Villa).",
+        "name": "Enchantress",
+        "raw_wikitext": "Until your next turn, the first time each other player plays an Action card on their turn, they get '''+1&nbsp;Card''' and '''+1&nbsp;Action''' instead of following its instructions.<p>At the start of your next turn, '''+2&nbsp;Cards'''</p>",
+        "wikitext": "Until your next turn, the first time each other player plays an Action card on their turn, they get <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b> instead of following its instructions.<n>At the start of your next turn, <b>+2&nbsp;Cards</b>"
+    },
+    "Enclave": {
+        "description": "Gain a Gold. Exile a Duchy from the Supply.",
+        "extra": "The Duchy goes directly from the Duchy pile to your Exile mat.",
+        "name": "Enclave",
+        "raw_wikitext": "Gain a Gold. Exile a Duchy from the Supply.",
+        "wikitext": "Gain a Gold. Exile a Duchy from the Supply."
+    },
+    "Endless Chalice": {
+        "description": "Now and at the start of each of your turns for the rest of the game:<br>1 <*COIN*><br><br>+1 Buy",
+        "extra": "Once played, this stays in play for the rest of the game.",
+        "name": "Endless Chalice",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "Now and at the start of each of your turns for the rest of the game:<br>{{Cost|1|l}}<br>'''+1&nbsp;Buy'''",
+        "wikitext": "Now and at the start of each of your turns for the rest of the game:<br>1 <*COIN*><br><b>+1&nbsp;Buy</b>"
+    },
+    "Engineer": {
+        "description": "Gain a card costing up to 4 Coins. You may trash this. If you do, gain a card costing up to 4 Coins.",
+        "extra": "Engineer cannot gain copies of itself, or any other card with Debt in the cost. When you play it, you gain a card, then may trash Engineer to gain a second card (which can be the same as the first or different).",
+        "name": "Engineer",
+        "raw_wikitext": "Gain a card costing up to {{Cost|4}}. You may trash this. If you do, gain a card costing up to {{Cost|4}}.",
+        "wikitext": "Gain a card costing up to 4 Coins. You may trash this. If you do, gain a card costing up to 4 Coins."
+    },
+    "Enhance": {
+        "description": "You may trash a non-Victory card from your hand, to gain a card costing up to 2 coin more than it.",
+        "extra": "If you trash a card, you must gain a card costing up to 2 coin more than it.",
+        "name": "Enhance",
+        "raw_wikitext": "You may trash a non-Victory card from your hand, to gain a card costing up to {{Cost|2}} more than it.",
+        "wikitext": "You may trash a non-Victory card from your hand, to gain a card costing up to 2 Coins more than it."
+    },
+    "Enlarge": {
+        "description": "Now and at the start of your next turn: Trash a card from your hand, and gain one costing up to 2 Coin more.",
+        "extra": "Once you've played Enlarge, trashing a card at the start of your next turn is mandatory.",
+        "name": "Enlarge",
+        "raw_wikitext": "Now and at the start of your next turn: Trash a card from your hand, and gain one costing up to {{Cost|2}} more.",
+        "wikitext": "Now and at the start of your next turn: Trash a card from your hand, and gain one costing up to 2 Coins more."
+    },
+    "Enlightenment": {
+        "description": "Treasures are also Actions. When you play a Treasure in an Action phase, instead of following its instructions, <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>.",
+        "name": "Enlightenment",
+        "raw_wikitext": "Treasures are also Actions. When you play a Treasure in an Action phase, instead of following its instructions, '''+1&nbsp;Card''' and '''+1&nbsp;Action'''."
+    },
+    "Envious": {
+        "description": "At the start of your Buy phase, return this, and Silver and Gold make 1 Coin this turn.",
+        "name": "Envious",
+        "raw_wikitext": "At the start of your Buy phase, return this, and Silver and Gold make {{Cost|1}} this turn."
+    },
+    "Envious / Deluded": {
+        "description": "This is a double-sided card.<left><u>Envious</u>:</left><center>At the start of your Buy phase, return this, and Silver and Gold make 1 Coin this turn.</center><left><u>Deluded</u>:</left><center>At the start of your Buy phase, return this, and you can’t buy Actions this turn.</center>",
+        "extra": "Envious: This causes Silver and Gold to make 1 Coin when you played in your Buy phase for one turn, rather than their usual 2 Coins and 3 Coins, starting in the Buy phase. It does not affect other Treasures, just Silver and Gold. If you get Envious during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally it will apply to your next turn.\n\nDeluded: This prevents you from buying Action cards during one turn, starting in the Buy phase. If you get Deluded during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally it will apply to your next turn.",
+        "name": "Envious / Deluded"
+    },
+    "Envoy": {
+        "description": "Reveal the top 5 cards of your deck. The player to your left chooses one for you to discard. Draw the rest.",
+        "extra": "If you do not have 5 cards in your deck, reveal as many as you can and shuffle your discard pile to reveal the rest. The player to your left then chooses one of the revealed cards for you to discard and then you draw the rest. If you do not have enough cards left to reveal 5 cards, even after shuffling, reveal as many as you can. The opponent to your left still discards one card before you draw the rest.",
+        "name": "Envoy",
+        "raw_wikitext": "Reveal the top 5&nbsp;cards of your deck. The player to your left chooses one. Discard that one and put the rest into your hand.",
+        "wikitext": "Reveal the top 5&nbsp;cards of your deck. The player to your left chooses one. Discard that one and put the rest into your hand."
+    },
+    "Envy": {
+        "description": "If you don't have Deluded or Envious, take Envious.",
+        "extra": "Deluded / Envious is two-sided; take it with the Envious side face up.",
+        "name": "Envy",
+        "raw_wikitext": "If you don't have Deluded or Envious, take Envious.",
+        "wikitext": "If you don't have Deluded or Envious, take Envious."
+    },
+    "Estate": {
+        "description": "1 <*VP*>",
+        "extra": "Put 8 in the Supply in a game with two players. Put 12 in the Supply in a game with three or more players.",
+        "name": "Estate",
+        "raw_wikitext": "{{VP|1|xl}}",
+        "wikitext": "1 <*VP*>"
+    },
+    "Exorcist": {
+        "description": "Trash a card from your hand. Gain a cheaper Spirit from one of the Spirit Piles.",
+        "extra": " The Spirits are Will-o'-Wisp, Imp, and Ghost. If for example you trash a Silver, you can gain a Will-o'-Wisp or Imp, as those both cost less than Silver.<br><br>Setup: Put all three Spirit piles - Will-o'-Wisp, Imp, and Ghost - near the Supply.",
+        "name": "Exorcist",
+        "raw_wikitext": "Trash a card from your hand. Gain a cheaper Spirit from one of the Spirit piles.",
+        "wikitext": "Trash a card from your hand. Gain a cheaper Spirit from one of the Spirit piles."
+    },
+    "Expand": {
+        "description": "Trash a card from your hand. Gain a card costing up to 3 Coins more than the trashed card.",
+        "extra": "This is not in your hand after you play it, so you cannot trash it as the card trashed. The card you gain can cost up to 3 coins more than the trashed card, but it can also cost any smaller amount, even less than the cost of the trashed card. You can trash a card and gain a copy of the same card. If you have no card in hand to trash, you do not gain a card. The card you gain comes from the Supply and is put into your discard pile.",
+        "name": "Expand",
+        "raw_wikitext": "Trash a card from your hand. Gain a card costing up to {{Cost|3}} more than it.",
+        "wikitext": "Trash a card from your hand. Gain a card costing up to 3 Coins more than it."
+    },
+    "Expedition": {
+        "description": "Draw 2 extra cards for your next hand.",
+        "extra": "This increases the number of cards you draw in Clean- up of the same turn. It is cumulative. Normally you draw 5 cards; after an Expedition you would draw 7, after two Expeditions you would draw 9, and so on. It only applies for the turn you buy it. If you play Outpost (from Seaside), getting an extra turn with only 3 cards, and also buy Expedition, you add the 2 extra cards onto the base of 3 cards, for 5 cards total.",
+        "name": "Expedition",
+        "raw_wikitext": "Draw 2&nbsp;extra cards for your next hand.",
+        "wikitext": "Draw 2&nbsp;extra cards for your next hand."
+    },
+    "Experiment": {
+        "description": "+2 Cards<br>+1 Action<n>Return this to the Supply.<line>When you gain this, gain another Experiment (that doesn't come with another).",
+        "extra": "When you play this, you get +2 Cards and +1 Action, and return it to its Supply pile.  When you gain it, you gain another one; this applies whether you gain it via buying it or some other way. If you gain one to a place other than your discard pile, the 2nd copy goes to your discard pile. For example if you use Sculptor to gain Experiment, you get one in your hand, and one in your discard pile. If you plan Band of Misfits (from Dark Ages) or Overlord (from Empires) as Experiment, you will return the card to its own pile, not to the Experiment pile. If Experiment somehow is not in play (for example if played from the trash via Necromancer from Nocturne), it fails to return to its pile.",
+        "name": "Experiment",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Return this to its pile.</p>{{Divline}}When you gain this, gain another Experiment (that doesn't come with another).",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Return this to its pile.<n><line>When you gain this, gain another Experiment (that doesn't come with another)."
+    },
+    "Exploration": {
+        "description": "At the end of your Buy phase, if you didn't buy any cards, +1 Coffers and +1 Villager.",
+        "extra": "This only cares if you bought a card in your Buy phase; it does not care if you gained cards other ways, or if you bought an Event (from Adventures or Empires) or Project. For example if all you buy on your turn is Exploration, you will get +1 Coffers and +1 Villager that turn.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Exploration",
+        "raw_wikitext": "At the end of your Buy phase, if you didn't gain any cards during it, '''+1&nbsp;Coffers''' and '''+1&nbsp;Villager'''.",
+        "wikitext": "At the end of your Buy phase, if you didn't gain any cards during it, <b>+1&nbsp;Coffers</b> and <b>+1&nbsp;Villager</b>."
+    },
+    "Explorer": {
+        "description": "You may reveal a Province card from your hand. If you do, gain a Gold card, putting it into your hand. Otherwise, gain a Silver card, putting it into your hand.",
+        "extra": "You don't have to reveal a Province if you have one. If you do reveal one you gain a Gold, otherwise you gain a Silver. The gained card comes from the supply and is put into your hard; it can be spent the same turn.",
+        "name": "Explorer",
+        "raw_wikitext": "You may reveal a Province from your hand. If you do, gain a Gold to your hand. If you don't, gain a Silver to your hand.",
+        "wikitext": "You may reveal a Province from your hand. If you do, gain a Gold to your hand. If you don't, gain a Silver to your hand."
+    },
+    "Fair": {
+        "description": "At the start of your turn, +1 Buy.",
+        "extra": "You simply have +1 Buy on each of your turns.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Fair",
+        "raw_wikitext": "At the start of your turn, '''+1&nbsp;Buy'''.",
+        "wikitext": "At the start of your turn, <b>+1&nbsp;Buy</b>."
+    },
+    "Fairgrounds": {
+        "description": "Worth 2 <VP> for every 5 differently named cards in your deck (rounded down).",
+        "extra": "At the end of the game, this is worth 2 <VP> per 5 differently named cards in your deck, rounded down. So if you have 0-4 different cards, it is worth 0 VP; if you have 5-9, it is worth 2 VP; if you have 10-14, it is worth 4 VP; if you have 15-19, it is worth 6; and so on. By default there are only 17 differently named cards available in a game, but sometimes there may be more cards, such as via Young Witch's setup rule, or due to Tournament. Use 8 Fairgrounds in a game with 2 players, and 12 for a game with 3 or more players.",
+        "name": "Fairgrounds",
+        "raw_wikitext": "Worth {{VP|'''2'''}} per 5&nbsp;differently named cards you have (round down).",
+        "wikitext": "Worth 2 <VP> per 5&nbsp;differently named cards you have (round down)."
+    },
+    "Faithful Hound": {
+        "description": "+2 Cards<line>When you discard this other than during Clean-up, you may set it aside, and put it into your hand at end of turn.",
+        "extra": "'End of turn' is after drawing in Clean-up. The Reaction ability can happen on your turn and on other players' turns; if for example you discard Faithful Hound to another player's Raider, you can set it aside and return it to your hand at the end of that turn. Faithful Hound does not have to be in your hand for the ability to work; for example you can set it aside when it is discarded from your deck due to Night Watchman. The ability does not work if Faithful Hound is put into your discard pile without being discarded; for example nothing special happens when you gain Faithful Hound, or put your deck into your discard pile with Scavenger (from Dark Ages). The ability does not do anything during Clean-up. Setting Faithful Hound aside is optional. You cannot choose to discard Faithful Hound without something telling you to discard.",
+        "name": "Faithful Hound",
+        "raw_wikitext": "'''+2&nbsp;Cards'''{{Divline}}When you discard this other than during Clean-up, you may set it aside, and put it into your hand at end of turn.",
+        "wikitext": "<b>+2&nbsp;Cards</b><line>When you discard this other than during Clean-up, you may set it aside, and put it into your hand at end of turn."
+    },
+    "Falconer": {
+        "description": "Gain a card to your hand costing less than this.<line>When any player gains a card with 2 or more types (Action, Attack, etc.), you may play this from your hand.",
+        "extra": "This can only gain cards from the Supply.<n>You can react with this to any gained card with 2 or more types; it can be a card that was bought, or a card gained some other way, such as via a Falconer.<n>You can do this regardless of who gained the card - you or anyone else - and regardless of whose turn it is.<n>The types are the words on the bottom line – including Action, Attack, Curse, Duration, Reaction, Treasure, and Victory (with more in other expansions).<n>If you gain a Falconer to your hand - such as via Artisan - you can react to that gain and play it, since it has two types.",
+        "name": "Falconer",
+        "raw_wikitext": "Gain a card to your hand costing less than this.{{Divline}}When any player gains a card with 2&nbsp;or more types (Action, Attack, etc.), you may play this from your hand.",
+        "wikitext": "Gain a card to your hand costing less than this.<line>When any player gains a card with 2&nbsp;or more types (Action, Attack, etc.), you may play this from your hand."
+    },
+    "Familiar": {
+        "description": "+1 Card<br>+1 Action<n>Each other player gains a curse.",
+        "extra": "If there aren't enough Curses left to go around when you play Familiar, you deal them out in turn order, starting with the player to your left. If you play Familiar with no Curses remaining, you will still get +1 Card and +1 Action. A player gaining a Curse puts it face-up into his Discard pile.",
+        "name": "Familiar",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Each other player gains a Curse.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Each other player gains a Curse."
+    },
+    "Family of Inventors": {
+        "description": "At the start of your Buy phase, you may put a Favor token you have on a non-Victory Supply pile.  Cards cost 1 Coin less per Favor token on their piles.",
+        "extra": "",
+        "name": "Family of Inventors",
+        "raw_wikitext": "At the start of your Buy phase, you may put a '''Favor''' token you have on a non-Victory Supply pile. Cards cost {{Cost|1}} less per '''Favor''' token on their piles.",
+        "wikitext": "At the start of your Buy phase, you may put a <b>Favor</b> token you have on a non-Victory Supply pile. Cards cost 1 Coin less per <b>Favor</b> token on their piles."
+    },
+    "Famine": {
+        "description": "Reveal the top 3 cards of your deck. Discard the Actions. Shuffle the rest into your deck.",
+        "extra": "The revealed cards that are not Actions are shuffled back into your deck.",
+        "name": "Famine",
+        "raw_wikitext": "Reveal the top 3&nbsp;cards of your deck. Discard the Actions. Shuffle the rest into your deck.",
+        "wikitext": "Reveal the top 3&nbsp;cards of your deck. Discard the Actions. Shuffle the rest into your deck."
+    },
+    "Farmers' Market": {
+        "description": "+1 Buy<n>If there are 4 <VP> or more on the Farmers' Market Supply pile, take them and trash this. Otherwise, add 1 <VP> to the pile and then +1 Coin per 1 <VP> on the pile.",
+        "extra": "The first time this is played, it produces +1 Coin (and +1 Buy), the next time +2 Coin, then +3 Coin, then +4 Coin, then the next time the player takes the 4 <VP> (and gets no + _ Coin), then the next time it is back to +1 Coin. This still functions if the Farmers' Market pile is empty.",
+        "name": "Farmers' Market",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>If there are {{VP|'''4'''}} or more on the Farmers' Market pile, take them and trash this. Otherwise, add {{VP|'''1'''}} to the pile and then {{Costplus|1}} per {{VP|'''1'''}} on the pile.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>If there are 4 <VP> or more on the Farmers' Market pile, take them and trash this. Otherwise, add 1 <VP> to the pile and then +1 Coin per 1 <VP> on the pile."
+    },
+    "Farmhands": {
+        "description": "+1 Card<br>+2 Actions<line>When you gain this, you may set aside an Action or Treasure from your hand, and play it at the start of your next turn.",
+        "extra": "Setting aside a card when you gain this is optional. Once you do it, you have to play the card at the start of your next turn, even if you no longer want to. Playing the Action card does not \"use up\" one of your Action plays for the turn. The set aside card is face up.",
+        "name": "Farmhands",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, you may set aside an Action or Treasure from your hand, and play it at the start of your next turn.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, you may set aside an Action or Treasure from your hand, and play it at the start of your next turn."
+    },
+    "Farming Village": {
+        "description": "+2 Actions<n>Reveal cards from the top of your deck until you reveal an Action or Treasure card. Put that card into your hand and discard the other cards.",
+        "extra": "Reveal cards from the top of your deck until you reveal a Treasure or Action card. If you run out of cards before finding one, shuffle your discard pile (but not the revealed cards), and keep revealing cards. If you still cannot find one, just discard all of the revealed cards. If you do find a Treasure or Action card, put it into your hand, and discard the rest of the revealed cards. A card with multiple types, one of which is Treasure or Action (for example Diadem, a Treasure - Prize), is a Treasure or Action and so will be drawn by this. You do not choose Treasure or Action - you stop on the first card matching either type.",
+        "name": "Farming Village",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Reveal cards from your deck until you reveal a Treasure or Action card. Put that card into your hand and discard the rest.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Reveal cards from your deck until you reveal a Treasure or Action card. Put that card into your hand and discard the rest."
+    },
+    "Farmland": {
+        "description": "2 <*VP*><line>When you buy this, trash a card from your hand. Gain a card costing exactly 2 Coins more than the trashed card.",
+        "extra": "This is a Victory card, not an Action card. It is worth 2 victory points at the end of the game. When you buy it, you trash a card from your hand if able, and if you did, you gain a card from the supply costing exactly 2 coins more than the trashed card if able. If there are no cards left in your hand to trash, you do not trash or gain a card, and if you trashed a card but there are no cards in the supply costing exactly 2 coins more than the trashed card, you do not gain a card. This ability only functions when you buy Farmland, not when you gain it some other way. During set-up, put all 12 Farmlands in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game.",
+        "name": "Farmland",
+        "raw_wikitext": "{{VP|2|l}}{{Divline}}When you gain this, trash a card from your hand and gain a non-Farmland card costing exactly {{Cost|2}} more than it.",
+        "wikitext": "2 <*VP*><line>When you gain this, trash a card from your hand and gain a non-Farmland card costing exactly 2 Coins more than it."
+    },
+    "Farrier": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<line><b>Overpay:</b> +1 Card at the end of this turn per 1 coin overpaid.",
+        "extra": "When you gain a Farrier you overpaid for, you draw an extra card at end of turn per 1 coin you overpaid. For example you could pay 4 coin for Farrier, and draw 2 extra cards at end of turn. This doesn't happen if you gain a Farrier without paying for it (such as with Horn of Plenty).",
+        "name": "Farrier",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''{{Divline}}'''Overpay:''' '''+1&nbsp;Card''' at the end of this turn per {{Cost|1}} overpaid.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><line><b>Overpay:</b> <b>+1&nbsp;Card</b> at the end of this turn per 1 Coin overpaid."
+    },
+    "Fated": {
+        "description": "When shuffling, you may look through the cards and reveal Fated cards to put them on the top or bottom.",
+        "extra": "Each time you shuffle, you can choose to put Fated cards on the top or bottom of your deck, while shuffling the other cards normally.<br>In games with Fated, you can look through your deck before shuffling, even if you're sure you don't have any Fated cards.",
+        "name": "Fated",
+        "raw_wikitext": "When shuffling, you may look through the cards and reveal Fated cards to put them on the top or bottom.",
+        "wikitext": "When shuffling, you may look through the cards and reveal Fated cards to put them on the top or bottom."
+    },
+    "Fawning": {
+        "description": "When you gain a Province, gain a Fawning card. A card that has this trait gains you a free copy of itself whenever you gain a Province.",
+        "extra": "This is mandatory.",
+        "name": "Fawning",
+        "raw_wikitext": "When you gain a Province, gain a Fawning card.",
+        "wikitext": "When you gain a Province, gain a Fawning card."
+    },
+    "Fear": {
+        "description": "If you have at least 5 cards in hand, discard an Action or Treasure (or reveal you can't.)",
+        "extra": "You discard an Action or Treasure if you have either, and only reveal your hand if you have no Actions and no Treasures.",
+        "name": "Fear",
+        "raw_wikitext": "If you have at least 5&nbsp;cards in hand, discard an Action or Treasure (or reveal you can't).",
+        "wikitext": "If you have at least 5&nbsp;cards in hand, discard an Action or Treasure (or reveal you can't)."
+    },
+    "Feast": {
+        "description": "Trash this card. Gain a card costing up to 5 Coins.",
+        "extra": "The gained card goes into your Discard pile. It has to be a card from the Supply. You cannot use coins from Treasures or previous Actions (like the Market) to increase the cost of the card that you gain. If you use Throne Room on Feast, you will gain two cards, even though you can only trash Feast once. Gaining the card isn't contingent on trashing Feast; they're just two things that the card tries to make you do.",
+        "name": "Feast",
+        "raw_wikitext": "Trash this card. Gain a card costing up to {{Cost|5}}.",
+        "wikitext": "Trash this card. Gain a card costing up to 5 Coins."
+    },
+    "Fellowship of Scribes": {
+        "description": "After playing an Action, if you have 4 or fewer cards in hand, you may spend a Favor for +1 Card.",
+        "extra": "",
+        "name": "Fellowship of Scribes",
+        "raw_wikitext": "After playing an Action, if you have 4&nbsp;or fewer cards in hand, you may spend a '''Favor''' for '''+1&nbsp;Card'''.",
+        "wikitext": "After playing an Action, if you have 4&nbsp;or fewer cards in hand, you may spend a <b>Favor</b> for <b>+1&nbsp;Card</b>."
+    },
+    "Feodum": {
+        "description": "Worth 1 <VP> for every 3 Silvers in your deck (round down).<line>When you trash this, gain 3 Silvers.",
+        "extra": "This is a Victory card. Play with 8 for games with 2 players, or 12 cards for games with 3 or more players. At the end of the game, each Feodum is worth 1 Victory for every 3 Silvers in your deck, rounded down. For example, if you have 11 Silvers, your Feodums are worth 3 Victory each. If a Feodum is trashed, you gain 3 Silvers. The Silvers come from the Supply and are put into your discard pile. If there are not enough Silvers left, gain as many as you can.",
+        "name": "Feodum",
+        "raw_wikitext": "Worth {{VP|'''1'''}} per 3&nbsp;Silvers you have (round down).{{Divline}}When you trash this, gain 3&nbsp;Silvers.",
+        "wikitext": "Worth 1 <VP> per 3&nbsp;Silvers you have (round down).<line>When you trash this, gain 3&nbsp;Silvers."
+    },
+    "Ferry": {
+        "description": "Move your - 2 Coin cost token to an Action Supply pile (cards from that pile cost 2 Coin less on your turns, but not less than 0 Coin).",
+        "extra": "When you buy this, you move your - 2 Coin cost token to any Action Supply pile. This token makes cards from that pile cost 2 Coins less, but not less than 0 Coins, on your turns; see the Tokens section.",
+        "name": "Ferry",
+        "raw_wikitext": "Move your –{{Cost|2}} token to an Action Supply pile. (Cards from that pile cost {{Cost|2}} less on your turns.)",
+        "wikitext": "Move your –2 Coins token to an Action Supply pile. (Cards from that pile cost 2 Coins less on your turns.)"
+    },
+    "Ferryman": {
+        "description": "+2 Cards<br>+1 Action<br>Discard a card.<line>Setup: Choose an unused Kingdom card pile costing 3 coin or 4 coin. Gain one when you gain a Ferryman.",
+        "extra": "When you gain a Ferryman, you also gain a copy of whichever card was set aside in setup. For example in setup you might set aside Shop, which costs 3 coin; then that game, when you gained a Ferryman, you'd also gain a Shop. The card chosen for Ferryman can't be gained other ways, only by gaining a Ferryman. If the chosen card is a split pile (such as the Augurs from Dominion: Allies), different cards will be gained via Ferryman gains as they get uncovered.",
+        "name": "Ferryman",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Discard a card.</p>{{Divline}}'''Setup:''' Choose an unused Kingdom card pile costing {{Cost|3}} or {{Cost|4}}. Gain one when you gain a Ferryman.",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Discard a card.<n><line><b>Setup:</b> Choose an unused Kingdom card pile costing 3 Coins or 4 Coins. Gain one when you gain a Ferryman."
+    },
+    "Festival": {
+        "description": "+2 Actions<br>+1 Buy<br>+2 Coins",
+        "extra": "If you are playing multiple Festivals, keep a careful count of your Actions. Say how many you have left out loud; this trick works every time (i.e. \"I'm playing the Festival and now have two Actions remaining. I play a Market and have two Actions remaining. I play another Festival and now have three actions remaining...).",
+        "name": "Festival",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<br>'''+1&nbsp;Buy'''<br>{{Costplus|2}}",
+        "wikitext": "<b>+2&nbsp;Actions</b><br><b>+1&nbsp;Buy</b><br>+2 Coins"
+    },
+    "Figurehead": {
+        "description": "3 <*COIN*><br><br>At the start of your next turn, +2 Cards.",
+        "extra": "When you play this, you get +3 Coin and at the start of your next turn, you get +2 Cards.",
+        "name": "Figurehead",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<p>At the start of your next turn, '''+2&nbsp;Cards'''.</p>",
+        "wikitext": "3 <*COIN*><n>At the start of your next turn, <b>+2&nbsp;Cards</b>."
+    },
+    "Figurine": {
+        "description": "+2 Cards<br>You may discard an Action card for +1 Buy and +1 Coin.",
+        "extra": "This is a Treasure, and so is played in your Buy phase, but draws cards.<br>This means that usually if it draws you an Action card, that card won't be useful that turn, except that Figurine itself lets you discard one Action card for +1 Buy and +1 Coin.",
+        "name": "Figurine",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>You may discard an Action card for '''+1&nbsp;Buy''' and {{Costplus|1}}.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>You may discard an Action card for <b>+1&nbsp;Buy</b> and +1 Coin."
+    },
+    "First Mate": {
+        "description": "Play any number of Action cards with the same name from your hand, then draw until you have 6 cards in hand.",
+        "extra": "If you don't have any Action cards to play, you'll still draw up to 6.<br>If the Action card you play draws you another copy of itself, you can play that copy, and so on.<br>First Mate can play First Mates; keep careful track of which card you're resolving, as you would with multiple Throne Room.",
+        "name": "First Mate",
+        "raw_wikitext": "Play any number of Action cards with the same name from your hand, then draw until you have 6&nbsp;cards in hand.",
+        "wikitext": "Play any number of Action cards with the same name from your hand, then draw until you have 6&nbsp;cards in hand."
+    },
+    "Fisherman": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<line>During your turns, if your discard pile is empty, this costs 3 Coin less.",
+        "extra": "This costs 5 Coin normally, but 2 Coin whenever the player whose turn it is has an empty discard pile.<n>If you have and two Buys with an empty discard pile, you can buy Fisherman for 2 Coin, but then you will no longer have an empty discard pile, so you cannot buy a second for 2 Coin.",
+        "name": "Fisherman",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}{{Divline}}During your turns, if your discard pile is empty, this costs {{Cost|3}} less.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<line>During your turns, if your discard pile is empty, this costs 3 Coins less."
+    },
+    "Fishing Village": {
+        "description": "+2 Actions<br>+1 Coin<n>At the start of your next turn:<n>+1 Action<br>+1 Coin",
+        "extra": "You get a coin to spend and 2 more Actions to use this turn. At the start of your next turn you get a coin and only one more Action. This means you will be able to play 2 Actions total on your next turn (counting your normal Action). Leave this in front of you until the Clean-up phase of your next turn.",
+        "name": "Fishing Village",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<br>{{Costplus|1}}<p>At the start of your next turn: '''+1&nbsp;Action''' and {{Costplus|1}}.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><br>+1 Coin<n>At the start of your next turn: <b>+1&nbsp;Action</b> and +1 Coin."
+    },
+    "Fishmonger": {
+        "description": "+1 Buy<br>+1 Coin<line>You can play this from your deck as if in your hand.",
+        "extra": "See the Shadows section. When you play Fishmonger, you get +1 Buy and +1 Coin.",
+        "name": "Fishmonger",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}{{Divline}}You can play this from your deck as if in your hand.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<line>You can play this from your deck as if in your hand."
+    },
+    "Flag": {
+        "description": "When drawing your hand, +1 Card.",
+        "extra": "Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Flag",
+        "raw_wikitext": "When drawing your hand, '''+1&nbsp;Card'''.",
+        "wikitext": "When drawing your hand, <b>+1&nbsp;Card</b>."
+    },
+    "Flag Bearer": {
+        "description": "+2 Coin<n><line>When you gain or trash this, take the Flag",
+        "extra": "When you gain or trash a Flag Bearer, you take the Flag. The Flag causes you to draw an extra card when drawing your hand in Clean-up. This is true even if your hand would normally be some amount other than 5 cards - for example if you played Outpost (from Seaside), instead of drawing 3 cards for your Outpost turn, you would draw 4. If Flag Bearer is trashed, the player trashing it takes the Flag, regardless of whose turn it is.",
+        "name": "Flag Bearer",
+        "raw_wikitext": "{{Costplus|2}}{{Divline}}When you gain or trash this, take the Flag.",
+        "wikitext": "+2 Coins<line>When you gain or trash this, take the Flag."
+    },
+    "Flag Bearer - Flag": {
+        "description": "<left><u>Flag Bearer</u>:</left><n>+2 Coin<n><line>When you gain or trash this, take the Flag<n><left><u>Flag</u>:</left><n>When drawing your hand, +1 Card.",
+        "extra": "When you gain or trash a Flag Bearer, you take the Flag. The Flag causes you to draw an extra card when drawing your hand in Clean-up. This is true even if your hand would normally be some amount other than 5 cards - for example if you played Outpost (from Seaside), instead of drawing 3 cards for your Outpost turn, you would draw 4. If Flag Bearer is trashed, the player trashing it takes the Flag, regardless of whose turn it is.<n><n>Flag is an Artifact. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Flag Bearer / Flag"
+    },
+    "Flagship": {
+        "description": "+2 Coin<br>The next time you play a non-Command Action card, replay it.",
+        "extra": "This isn't optional; whatever that next non-Command Action card is, Flagship replays it.<br>It replays it even if the card trashed itself, and even if it isn't your turn.<br>Command cards, such as Flagship itself, are not replayed; Flagship waits for a non-Command Action card.",
+        "name": "Flagship",
+        "raw_wikitext": "{{Costplus|2}}<p>The next time you play a non-Command Action card, replay it.</p>",
+        "wikitext": "+2 Coins<n>The next time you play a non-Command Action card, replay it."
+    },
+    "Fleet": {
+        "description": "After the game ends, there's an extra round of turns just for players with this.",
+        "extra": "The extra turns go in order starting with the next player after the one that just took a turn. Other extra turns, such as from Outpost (in Seaside) can happen in-between those turns; however after the last extra turn due to Fleet, no other extra turns can happen (since e.g. Outpost does not keep the game going after it ends). Players do not sort through their cards and add up their scores until all of the Fleet turns are done, even the players without Fleet. If the game end conditions are no longer met after Fleet turns, the game is still over.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Fleet",
+        "raw_wikitext": "After the game ends, there's an extra round of turns just for players with this.",
+        "wikitext": "After the game ends, there's an extra round of turns just for players with this."
+    },
+    "Flourishing Trade": {
+        "description": "Cards cost 1 Coin less. You may use Action plays as Buys.",
+        "name": "Flourishing Trade",
+        "raw_wikitext": "Cards cost {{Cost|1}} less. You may use Action plays as Buys."
+    },
+    "Followers": {
+        "description": "+2 Cards<n>Gain an Estate. Each other player gains a Curse and discards down to 3 cards in hand.<n><i>(This is not in the Supply.)</i>",
+        "extra": "Do the things in the order listed. You draw 2 cards; then you gain an Estate from the Supply, putting it into your discard pile; then each other player gains a Curse from the Supply, putting it into his discard pile; then each other player discards down to 3 cards in hand. A player with 3 or fewer cards in hand does not discard any cards. If there are no Estates left, you do not gain one. If there are not enough Curses left, deal out the remaining Curses in turn order. This is a Prize; see the Additional Rules.",
+        "name": "Followers",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Gain an Estate. Each other player gains a Curse and discards down to 3&nbsp;cards in hand.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Gain an Estate. Each other player gains a Curse and discards down to 3&nbsp;cards in hand.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Fool": {
+        "description": "If you aren’t the player with Lost in the Woods, take it, take 3 Boons, and receive the Boons in any order.<br><br><i>Heirloom: Lucky Coin</i>",
+        "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.",
+        "name": "Fool",
+        "raw_wikitext": "<p>If you aren't the player with Lost in the Woods: take it, take 3&nbsp;Boons, and receive the Boons in any order.</p>''Heirloom: Lucky Coin''",
+        "wikitext": "If you aren't the player with Lost in the Woods: take it, take 3&nbsp;Boons, and receive the Boons in any order.<n><i>Heirloom: Lucky Coin</i>"
+    },
+    "Fool - Lucky Coin": {
+        "description": "<left><u>Fool</u>:</left><center>If you aren’t the player with Lost in the Woods, take it, take 3 Boons, and receive the Boons in any order.</center><left><i>Heirloom: Lucky Coin</i></left><left><u>Lucky Coin</u>:</left><center>1 <*COIN*></center><n><n>When you play this, gain a Silver.",
+        "extra": "If you have Lost in the Woods, playing Fool does nothing. If you do not have Lost in the Woods, you take it - even from another player, if another player has it - and also take 3 Boons and receive them in the order you choose (discarding them when receiving them, or in Clean-up as appropriate). You do not need to pick the full order in advance - pick one to resolve, then after resolving it pick another to resolve. The player with Lost in the Woods (if any) can optionally discard a card to receive a Boon, at the start of each of their turns. In games using Fool, replace one of your starting Coppers with a Lucky Coin.\nYou can choose not to play Lucky Coin, and thus not gain a Silver.",
+        "name": "Fool / Lucky Coin"
+    },
+    "Fool's Gold": {
+        "description": "If this is the first time you played a Fool's Gold this turn, +1 coin, otherwise +4 coins.<line>When another player gains a Province, you may trash this from your hand, to gain a Gold onto your deck.",
+        "extra": "This is both a Treasure and a Reaction. It can be played in your Buy phase like other Treasures. When you play it, it is worth 1 coin if this is the first time you played a Fool's Gold this turn, and otherwise it is worth 4 coins. So if your lay three Fool's Golds in the same turn, the first is worth 1 coin, the second is worth 4 coins, and the third is worth 4 coins. Fool's Gold is also a Reaction. When another player gains a Province, you may trash Fool's Gold from your hand; if you do, you gain a Gold from the Supply, putting it on top of your deck rather than into your discard pile. If there are no cards in your deck, the Gold becomes the only card in your deck. If there are no Gold cards left in the Supply, you do not gain one, but can still trash Fool's Gold. This Reaction is only usable when another player gains a Province, not you. It is usable whether a Province was gained due to being bought, or gained some other way.",
+        "name": "Fool's Gold",
+        "raw_wikitext": "If this is the first time you played a Fool's Gold this turn, {{Costplus|1}}, otherwise {{Costplus|4}}.{{Divline}}When another player gains a Province, you may trash this from your hand, to gain a Gold onto your deck.",
+        "wikitext": "If this is the first time you played a Fool's Gold this turn, +1 Coin, otherwise +4 Coins.<line>When another player gains a Province, you may trash this from your hand, to gain a Gold onto your deck."
+    },
+    "Footpad": {
+        "description": "+2 Coffers<br>Each other player discards down to 3 cards in hand.<line>In games using this, when you gain a card in an Action phase, +1 Card.",
+        "extra": "This changes any game it's part of, even if no-one has gained a Footpad. For that entire game, any time you gain a card in an Action phase, you draw a card. For example if you played Remake to turn two Estates into two Silvers, you'd draw two cards. Drawing isn't optional. This doesn't draw you cards in Buy phases or Clean-up, just Action phases. When you play a Footpad, you get +2 Coffers, and the other players discard down to 3 cards in hand.",
+        "name": "Footpad",
+        "raw_wikitext": "'''+2&nbsp;Coffers'''<p>Each other player discards down to 3&nbsp;cards in hand.</p>{{Divline}}In games using this, when you gain a card in an Action phase, '''+1&nbsp;Card'''.",
+        "wikitext": "<b>+2&nbsp;Coffers</b><n>Each other player discards down to 3&nbsp;cards in hand.<n><line>In games using this, when you gain a card in an Action phase, <b>+1&nbsp;Card</b>."
+    },
+    "Forager": {
+        "description": "+1 Action<br>+1 Buy<n>Trash a card from your hand.<n>+1 Coin per differently named Treasure in the trash.",
+        "extra": "Trash a card from your hand if you can. Whether or not you can, you still get +1 Coin per differently named Treasure in the trash, plus +1 Action and +1 Buy. Multiple copies of the same Treasure card do not increase how much you get. For example, if the trash has four Coppers, a Counterfeit, and six Estates, you get +2 Coins. Cards with multiple types, one of which is Treasure (such as Harem from Intrigue), are Treasures.",
+        "name": "Forager",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<p>Trash a card from your hand, then {{Costplus|1}} per differently named Treasure in the trash.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><n>Trash a card from your hand, then +1 Coin per differently named Treasure in the trash."
+    },
+    "Foray": {
+        "description": "Discard 3 cards, revealing them. If they have 3 different names, gain a Loot.",
+        "extra": "If you didn't have 3 cards to discard, you don't gain a Loot.",
+        "name": "Foray",
+        "raw_wikitext": "Discard 3&nbsp;cards, revealing them. If they have 3&nbsp;different names, gain a Loot.",
+        "wikitext": "Discard 3&nbsp;cards, revealing them. If they have 3&nbsp;different names, gain a Loot."
+    },
+    "Foresight": {
+        "description": "Reveal cards from your deck until revealing an Action. Set it aside and discard the rest. Put it into your hand at end of turn.",
+        "name": "Foresight",
+        "raw_wikitext": "Reveal cards from your deck until revealing an Action. Set it aside and discard the rest. Put it into your hand at end of turn."
+    },
+    "Forest Dwellers": {
+        "description": "At the start of your turn, you may spend a Favor to look at the top 3 cards of your deck, discard any number and put the rest back in any order.",
+        "extra": "",
+        "name": "Forest Dwellers",
+        "raw_wikitext": "At the start of your turn, you may spend a '''Favor''' to look at the top 3&nbsp;cards of your deck, discard any number and put the rest back in any order.",
+        "wikitext": "At the start of your turn, you may spend a <b>Favor</b> to look at the top 3&nbsp;cards of your deck, discard any number and put the rest back in any order."
+    },
+    "Forge": {
+        "description": "Trash any number of cards from your hand. Gain a card with cost exactly equal to the total cost in coins of the trashed cards.",
+        "extra": "\"Any number\" includes zero. If you trash no cards, you have to gain a card costing 0 coins if you can. This is different from how cards like Expand work if you do not trash anything, because Forge looks at the total, not at any one card's cost. If there is no card at the required cost, you do not gain a card. The card you gain comes from the Supply and is put into your discard pile. Potion symbols (on cards from Alchemy) are not added, and the card you gain cannot have a potion symbol in its cost.",
+        "name": "Forge",
+        "raw_wikitext": "Trash any number of cards from your hand. Gain a card with cost exactly equal to the total cost in {{Cost}} of the trashed cards.",
+        "wikitext": "Trash any number of cards from your hand. Gain a card with cost exactly equal to the total cost in {{Cost}} of the trashed cards."
+    },
+    "Fortress": {
+        "description": "+1 Card<br>+2 Actions<line>When you trash this, put it into your hand.",
+        "extra": "When you play this, you draw a card and get +2 Actions. If this is trashed, you take it from the trash and put it into your hand. This happens no matter whose turn it is when Fortress is trashed. It is not optional. You still trashed Fortress, even though you get it back; for example if you play Death Cart and choose to trash Fortress, the \"if you do\" on Death Cart is true, you did trash an Action, so you do not trash Death Cart.",
+        "name": "Fortress",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you trash this, put it into your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you trash this, put it into your hand."
+    },
+    "Forts": {
+        "description": "This pile starts the game with 4 copies each of Tent, Garrison, Hill Fort, and Stronghold, in that order. Only the top card can be gained or bought.",
+        "extra": "Tent: If you have multiple Tents in play, you can choose how many you want to put on top of your deck.<n>Garrison: This can only have tokens on it if it's in play; if it leaves play, it has no tokens. You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison. If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once. If Garrison doesn't have any tokens on it, you discard Garrison from play during Clean-up.<n>Hill Fort: First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or get +1 Card and +1 Action. If the card is no longer where it was gained to then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.<n>Stronghold: If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up.",
+        "name": "Forts"
+    },
+    "Fortune": {
+        "description": "+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
+        "extra": "You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
+        "name": "Fortune",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Double your {{Cost}} if you haven't yet this turn.{{Divline}}When you gain this, gain a Gold per Gladiator you have in play.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Double your {{Cost}} if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play."
+    },
+    "Fortune Hunter": {
+        "description": "+2 Coin<br>Look at the top 3 cards of your deck. You may play a Treasure from them. Put the rest back in any order.",
+        "extra": "Completely resolve playing the Treasure before putting the other cards back on top; for example if the Treasure is a Figurine, the two cards you draw won't be the other ones you looked at with Fortune Hunter.",
+        "name": "Fortune Hunter",
+        "raw_wikitext": "{{Costplus|2}}<p>Look at the top 3&nbsp;cards of your deck. You may play a Treasure from them. Put the rest back in any order.</p>",
+        "wikitext": "+2 Coins<n>Look at the top 3&nbsp;cards of your deck. You may play a Treasure from them. Put the rest back in any order."
+    },
+    "Fortune Teller": {
+        "description": "+2 Coin<n>Each other player reveals cards from the top of his deck until he reveals a Victory of Curse card. He puts it on top and discards the other revealed cards.",
+        "extra": "Each other player reveals cards from the top of his deck until he reveals a Victory or Curse card. If he runs out of cards before finding one, he shuffles his discard pile (but not the revealed cards), and keeps revealing cards. If he still cannot find one, he just discards all of the revealed cards. If he does find one, he puts the Victory or Curse card on top of his deck, and discards the other revealed cards. If his deck has no other cards in it, it becomes the only card in his deck. A card with multiple types, one of which is Victory (such as Nobles from Intrigue), is a Victory card. You do not choose Victory or Curse - they stop on the first card that matches either type.",
+        "name": "Fortune Teller",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player reveals cards from the top of their deck until they reveal a Victory card or a Curse. They put it on top and discard the rest.</p>",
+        "wikitext": "+2 Coins<n>Each other player reveals cards from the top of their deck until they reveal a Victory card or a Curse. They put it on top and discard the rest."
+    },
+    "Forum": {
+        "description": "+3 Cards<br>+1 Action<n>Discard 2 cards.<line>When you buy this, +1 Buy.",
+        "extra": "For example, with 13 Coin and only one Buy, you could buy a Forum, getting +1 Buy, then buy a Province.",
+        "name": "Forum",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Discard 2&nbsp;cards.</p>{{Divline}}When you gain this, '''+1&nbsp;Buy'''.",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Discard 2&nbsp;cards.<n><line>When you gain this, <b>+1&nbsp;Buy</b>."
+    },
+    "Fountain": {
+        "description": "When scoring, 15 <VP> if you have at least 10 Coppers.",
+        "extra": "You either get 15 <VP> or 0<VP>; there is no extra bonus for having 20 Coppers.",
+        "name": "Fountain",
+        "raw_wikitext": "When scoring, {{VP|'''15'''}} if you have at least 10&nbsp;Coppers.",
+        "wikitext": "When scoring, 15 <VP> if you have at least 10&nbsp;Coppers."
+    },
+    "Friendly": {
+        "description": "At the start of your Clean-up phase, you may discard a Friendly card to gain a Friendly card.",
+        "extra": "You may only discard one Friendly card per turn this way.",
+        "name": "Friendly",
+        "raw_wikitext": "At the start of your Clean-up phase, you may discard a Friendly card to gain a Friendly card.",
+        "wikitext": "At the start of your Clean-up phase, you may discard a Friendly card to gain a Friendly card."
+    },
+    "Frigate": {
+        "description": "+3 Coin<br>Until the start of your next turn, each time another player plays an Action card, they discard down to 4 cards in hand afterwards.",
+        "extra": "This applies each time another player plays an Action, until your next turn. That includes later on during your turn, if they manage to play an Action then (for example a Stowaway). They completely resolve playing the Action before discarding.",
+        "name": "Frigate",
+        "raw_wikitext": "{{Costplus|3}}<p>Until the start of your next turn, each time another player plays an Action card, they discard down to 4&nbsp;cards in hand afterwards.</p>",
+        "wikitext": "+3 Coins<n>Until the start of your next turn, each time another player plays an Action card, they discard down to 4&nbsp;cards in hand afterwards."
+    },
+    "Fugitive": {
+        "description": "+2 Cards<br>+1 Action<n>Discard a card.<line>When you discard this from play, you may exchange it for a Disciple.<n><i>(This is not in the Supply.)</i>",
+        "extra": "When you play this, you draw 2 cards, get +1 Action, and then discard a card from your hand. The discarded card does not have to be one of the cards just drawn.",
+        "name": "Fugitive",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Discard a card.</p>{{Divline}}<p>When you discard this from play, you may exchange it for a Disciple.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Discard a card.<n><line><n>When you discard this from play, you may exchange it for a Disciple.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Galleria": {
+        "description": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, +1 Buy.",
+        "extra": "What matters is how much a card actually costs when you gain it. If, for example, cards cost 1 Coin less due to Bridge, then gaining Silver would not produce +1 Buy, but gaining Duchy would.",
+        "name": "Galleria",
+        "raw_wikitext": "{{Costplus|3}}<p>This turn, when you gain a card costing {{Cost|3}} or {{Cost|4}}, '''+1&nbsp;Buy'''.</p>",
+        "wikitext": "+3 Coins<n>This turn, when you gain a card costing 3 Coins or 4 Coins, <b>+1&nbsp;Buy</b>."
+    },
+    "Gamble": {
+        "description": "+1 Buy<n>Reveal the top card of your deck. If it's a Treasure or Action, you may play it. Otherwise, discard it.",
+        "extra": "If you don't play the card, you discard it, whether or not it's a Treasure or Action.",
+        "name": "Gamble",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Discard the top card of your deck. If it's an Action or Treasure, you may play it.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Discard the top card of your deck. If it's an Action or Treasure, you may play it."
+    },
+    "Gang of Pickpockets": {
+        "description": "At the start of your turn, discard down to 4 cards in hand unless you spend a Favor.",
+        "extra": "",
+        "name": "Gang of Pickpockets",
+        "raw_wikitext": "At the start of your turn, discard down to 4&nbsp;cards in hand unless you spend a '''Favor'''.",
+        "wikitext": "At the start of your turn, discard down to 4&nbsp;cards in hand unless you spend a <b>Favor</b>."
+    },
+    "Gardens": {
+        "description": "Worth 1 <VP> for every 10 cards in your deck (rounded down).",
+        "extra": "This Kingdom card is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point per 10 cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Round down; if you have 39 cards, Gardens is worth 3 victory points. During set-up, place 12 Gardens in the Supply for a 3+ player game and 8 in the Supply for a 2 player game.",
+        "name": "Gardens",
+        "raw_wikitext": "Worth {{VP|'''1'''}} per 10&nbsp;cards you have (round down).",
+        "wikitext": "Worth 1 <VP> per 10&nbsp;cards you have (round down)."
+    },
+    "Garrison": {
+        "description": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for +1 Card each.",
+        "extra": "This can only have tokens on it if it's in play; if it leaves play, it has no tokens.<n>You can use coin tokens for this; on Garrison they have no other meaning, they're just tokens on Garrison.<n>If you Throne Room Garrison and then gain 3 cards, it will get 6 tokens total, and you'll draw 6 cards next turn, not 12, as you can only remove the tokens once.<n>If Garrison doesn't have any tokens on it (i.e. because you didn't gain any cards after playing it), you discard Garrison from play during Clean-up. This means you can Improve the Garrison if you haven't yet gained any cards this turn, since it is due to get discarded from play. Improve causes you to gain a card, but since Garrison is no longer in play by the time you gain it, you can't put tokens on Garrison at that point.<n>If you play Garrison with a card like Band of Misfits, it's not in play, so you can't put any tokens on it.",
+        "name": "Garrison",
+        "raw_wikitext": "{{Costplus|2}}<p>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for '''+1&nbsp;Card''' each.</p>",
+        "wikitext": "+2 Coins<n>This turn, when you gain a card, add a token here. At the start of your next turn, remove them for <b>+1&nbsp;Card</b> each."
+    },
+    "Gatekeeper": {
+        "description": "At the start of your next turn, +3 Coin. Until then, when another player gains an Action or Treasure card they don't have an Exiled copy of, they Exile it.",
+        "extra": "While under this attack, whenever you gain an Action or Treasure that you do not have a copy of on your Exile mat, you Exile the gained card.<n>Gaining a card that you do have a copy of on your Exile mat is unaffected, and lets you discard copies from your Exile mat if you want to as usual.<n>Other abilities that happen when you gain a card happen at the same time, and you can only put the card on your mat if it has not moved anywhere since gaining it; so you can, for example, use a Sleigh to put a gained card into your hand, then fail to put it on your Exile mat.<n>Gatekeeper only Exiles Actions and Treasures, it does not Exile, for example, Province.<n>It only cares about cards in Exile, it does not care how they got there.",
+        "name": "Gatekeeper",
+        "raw_wikitext": "At the start of your next turn, {{Costplus|3}}. Until then, when another player gains an Action or Treasure card they don't have an Exiled copy of, they Exile it.",
+        "wikitext": "At the start of your next turn, +3 Coins. Until then, when another player gains an Action or Treasure card they don't have an Exiled copy of, they Exile it."
+    },
+    "Gather": {
+        "description": "Gain a card costing exactly 3 Coins, a card costing exactly 4 Coins, and a card costing exactly 5 Coins.",
+        "name": "Gather",
+        "raw_wikitext": "Gain a card costing exactly {{Cost|3}}, a card costing exactly {{Cost|4}}, and a card costing exactly {{Cost|5}}."
+    },
+    "Gear": {
+        "description": "+2 Cards<n>Set aside up to 2 cards from your hand face down. At the start of your next turn, put them into your hand.",
+        "extra": "You may set aside zero, one, or two cards from your hand. Put them face down under the Gear; you may look at them. They do not have to be cards you drew with Gear. If you set aside zero cards, Gear will be discarded the same turn you played it; if you set aside one or two cards, you put them into your hand at the start of your next turn, and Gear is discarded at the end of that turn.",
+        "name": "Gear",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Set aside up to 2&nbsp;cards from your hand face down (under this). At the start of your next turn, put them into your hand.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Set aside up to 2&nbsp;cards from your hand face down (under this). At the start of your next turn, put them into your hand."
+    },
+    "Ghost": {
+        "description": "Reveal cards from your deck until you reveal an Action. Discard the other cards and set aside the Action. At the start of your next turn, play it twice.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": "If you run out of cards before revealing an Action, shuffle your discard pile but not the revealed cards, and continue. If you still do not find an Action, just discard everything and do not do anything else. If you find an Action card, you discard the other cards, set the Action card aside, and play it twice at the start of your next turn. This is not optional. If you have multiple start-of-turn effects, you can put them in any order, but when you resolve Ghost, you play the Action twice then; you cannot resolve other effects in the middle. You play the Action card, resolving it completely, then play it a second time. Playing the card does not use up Action plays for the turn. If Ghost plays a Duration card, Ghost will stay out with the Duration card. If Ghost plays a card that trashes itself, it will play it a second time even though the card is no longer in play. If Ghost fails to play a card, it will be discarded from play that turn.",
+        "name": "Ghost",
+        "raw_wikitext": "<p>Reveal cards from your deck until you reveal an Action. Discard the other cards and set aside the Action. At the start of your next turn, play it twice.</p>''(This is not in the Supply.)''",
+        "wikitext": "Reveal cards from your deck until you reveal an Action. Discard the other cards and set aside the Action. At the start of your next turn, play it twice.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Ghost Ship": {
+        "description": "+2 Card<n>Each other player with 4 or more cards in hand puts cards from his hand on top of his deck until he has 3 cards in his hand.",
+        "extra": "The other players choose which cards they put on their decks and in what order. This has no effect on another player who already has only 3 cards in hand. A player with no cards left in their deck does not shuffle; the cards put back become the only cards in their deck.",
+        "name": "Ghost Ship",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each other player with 4&nbsp;or more cards in hand puts cards from their hand onto their deck until they have 3&nbsp;cards in hand.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Each other player with 4&nbsp;or more cards in hand puts cards from their hand onto their deck until they have 3&nbsp;cards in hand."
+    },
+    "Ghost Town": {
+        "description": "At the start of your next turn,<br>+1 Card and +1 Action.<line>This is gained to your hand (instead of your discard pile).",
+        "extra": "Since Night is after the Buy phase, normally you can play this the turn you buy it.",
+        "name": "Ghost Town",
+        "raw_wikitext": "At the start of your next turn, '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.{{Divline}}This is gained to your hand (instead of your discard pile).",
+        "wikitext": "At the start of your next turn, <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>.<line>This is gained to your hand (instead of your discard pile)."
+    },
+    "Giant": {
+        "description": "Turn your Journey token over (it starts face up). If it's face down, +1 Coin. If it's face up, +5 Coins, and each other player reveals the top card of his deck, trashes it if it costs 3 Coins to 6 Coins, and otherwise discards it and gains a Curse.",
+        "extra": "At the start of the game, place your Journey token (the one with the boot) face up. When you play this, you turn the Journey token over. Then, if it is face down, you get +1 Coin and nothing more happens. If it is face up, you get +5 Coins and the attack part happens. The attack resolves in turn order, starting with the player to your left. The player reveals the top card of his deck, and either trashes it if it costs from 3 to 6 Coins, or discards it and gains a Curse otherwise. Cards with in the cost (from Alchemy) do not cost from 3 to 6 Coins. Cards with an asterisk or + by the cost that cost from 3 to 6 Coins (such as Teacher, or Masterpiece from Guilds) do get trashed. Players can respond to Giant being played with Reactions that respond to Attacks (such as Caravan Guard), even if Giant will only be producing +1 Coin this time.",
+        "name": "Giant",
+        "raw_wikitext": "Turn your Journey token over (it starts face up). Then if it's face down, {{Costplus|1}}. If it's face up, {{Costplus|5}}, and each other player reveals the top card of their deck, trashes it if it costs from {{Cost|3}} to {{Cost|6}}, and otherwise discards it and gains a Curse.",
+        "wikitext": "Turn your Journey token over (it starts face up). Then if it's face down, +1 Coin. If it's face up, +5 Coins, and each other player reveals the top card of their deck, trashes it if it costs from 3 Coins to 6 Coins, and otherwise discards it and gains a Curse."
+    },
+    "Gladiator": {
+        "description": "+2 Coin<n>Reveal a card from your hand. The player to your left may reveal a copy from their hand. If they do not, +1 Coin and trash a Gladiator from the Supply.",
+        "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.",
+        "name": "Gladiator",
+        "raw_wikitext": "{{Costplus|2}}<p>Reveal a card from your hand. The player to your left may reveal a copy from their hand. If they don't, {{Costplus|1}} and trash a Gladiator from its pile.</p>",
+        "wikitext": "+2 Coins<n>Reveal a card from your hand. The player to your left may reveal a copy from their hand. If they don't, +1 Coin and trash a Gladiator from its pile."
+    },
+    "Gladiator - Fortune": {
+        "description": "<left><u>Gladiator</u>:</left><n>If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator.<n><left><u>Fortune</u>:</left><n>+1 Buy<n>When you play this, double your Coin if you haven't yet this turn.<line>When you gain this, gain a Gold per Gladiator you have in play.",
+        "extra": "If there are no Gladiators in the Supply, you cannot trash one, but that does not stop you from getting the +1 Coin. If you have no cards in hand, the player to your left cannot reveal a copy of the card you revealed, so you will get the +1 Coin and trash a Gladiator. Fortune: You only double your Coin the first time you play a Fortune in a turn; any further times only get you +1 Buy.",
+        "name": "Gladiator / Fortune"
+    },
+    "Goat": {
+        "description": "1 <*COIN*><br><br>When you play this, you may trash a card from your hand.",
+        "extra": "Trashing a card is optional.",
+        "name": "Goat",
+        "raw_wikitext": "{{Cost|1|l}}<p>You may trash a card from your hand.</p>",
+        "wikitext": "1 <*COIN*><n>You may trash a card from your hand."
+    },
+    "Goatherd": {
+        "description": "+1 Action<n>You may trash a card from your hand.<n>+1 Card per card the player to your right trashed on their last turn.",
+        "extra": "You draw cards even if you did not trash a card.<n>One way to keep count of the number of cards trashed is to put them on the trash sideways.",
+        "name": "Goatherd",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>You may trash a card from your hand.</p>'''+1&nbsp;Card''' per card the player to your right trashed on their last turn.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>You may trash a card from your hand.<n><b>+1&nbsp;Card</b> per card the player to your right trashed on their last turn."
+    },
+    "Gold": {
+        "description": "3 <*COIN*>",
+        "extra": "30 cards per game.",
+        "name": "Gold",
+        "raw_wikitext": "{{Cost|3|xl}}",
+        "wikitext": "3 <*COIN*>"
+    },
+    "Gold Mine": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<br><br>You may gain a Gold and get +4 Debt.",
+        "extra": "You can gain a Gold even if you already have Debt; see the Debt section. You can't gain a Gold without taking 4 Debt.",
+        "name": "Gold Mine",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<p>You may gain a Gold and get {{Debtplus|4}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><n>You may gain a Gold and get {{Debtplus|4}}."
+    },
+    "Golem": {
+        "description": "Reveal cards from your deck until you reveal 2 Action cards other than Golem Cards.<n>Discard the other cards, then play the Action cards in either order.",
+        "extra": "Reveal cards from the top of your deck, one at a time, until you have revealed two Action cards that are not Golem. If you run out of cards before revealing two non-Golem Actions, shuffle your discard pile (but not the revealed cards) and continue. If you run out and have no discard pile left either, you just get the Actions you found. Discard all of the revealed cards except for the non-Golem Actions you found. If you did not find any, you're done. If you found one, play it. If you found two, play them both, in either order. You cannot choose not to play one of them. These Action cards are not in your hand and so are unaffected by things that look for cards in your hand. For example, if one of them is Throne Room (from Dominion), you cannot use it on the other one.",
+        "name": "Golem",
+        "raw_wikitext": "Reveal cards from your deck until you reveal 2&nbsp;Action cards other than Golems. Discard the other cards, then play the Action cards in either order.",
+        "wikitext": "Reveal cards from your deck until you reveal 2&nbsp;Action cards other than Golems. Discard the other cards, then play the Action cards in either order."
+    },
+    "Gondola": {
+        "description": "Either now or at the start of your next turn: +2 Coin.<line>When you gain this, you may play an Action card from your hand.",
+        "extra": "When playing Gondola, choose whether to get +2 Coin immediately, or at the start of your next turn.<br>If you play Gondola multiple times, such as with King's Cache, you choose each time whether to get the +2 Coin now or next turn, and Gondola only stays in play if at least one of the plays was for next turn (in which case the King's Cache also stays in play).",
+        "name": "Gondola",
+        "raw_wikitext": "Either now or at the start of your next turn: {{Costplus|2}}.{{divline}}When you gain this, you may play an Action card from your hand.",
+        "wikitext": "Either now or at the start of your next turn: +2 Coins.<line>When you gain this, you may play an Action card from your hand."
+    },
+    "Good Harvest": {
+        "description": "The first time you play each differently named Treasure each turn, first, <b>+1&nbsp;Buy</b> and +1 Coin.",
+        "name": "Good Harvest",
+        "raw_wikitext": "The first time you play each differently named Treasure each turn, first, '''+1&nbsp;Buy''' and {{Costplus|1}}."
+    },
+    "Goons": {
+        "description": "+1 Buy<br>+2 Coins<n>Each other player discards down to 3 cards in hand.<line>While you have this in play, when you buy a card, +1 <VP>.",
+        "extra": "You get 1 <VP> token for each card you buy, but do not get a <VP> token for gaining a card some other way. Multiple copies of Goons are cumulative; if you have two Goons in play and buy a Silver, you get 2 <VP> tokens. However if you King's Court a Goons, despite having played the card 3 times, there is still only one copy of it in play, so buying Silver would only get you 1 <VP> token.<n>When a player takes <VP> tokens, he takes a player mat to put them on. <VP> tokens are not private and anyone can count them. <VP> tokens come in 1 <VP> and 5 <VP> denominations and players can make change as needed. Tokens are unlimited and if they run out, use something else to track any further tokens. At the end of the game, players add the total value of their <VP> tokens to their score.",
+        "name": "Goons",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|2}}<p>Each other player discards down to 3&nbsp;cards in hand.</p>{{divline}}While you have this in play, when you buy a card, {{VP|'''+1'''}}.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+2 Coins<n>Each other player discards down to 3&nbsp;cards in hand.<n><line>While you have this in play, when you buy a card, {{VP|<b>+1</b>}}."
+    },
+    "Governor": {
+        "description": "+1 Action<n>Choose one; you get the version in parentheses: Each player gets +1(+3) Cards; or each player gains a Silver (Gold); or each player may trash a card from his hand and gain a card costing exactly 1 Coin (2 Coins) more.",
+        "extra": "You always get +1 Action. Then you either 1) draw three cards and each other player draws a card; 2) gain a Gold and each other player gains a Silver; 3) may trash a card from your hand and gain a card costing exactly 2 Coins more and each other player may trash a card from his hand and gain a card costing exactly 1 Coin more. Go in turn order, starting with yourself; this may matter if piles are low. The gained cards come from the Supply and are put into discard piles; if there are none left, those cards are not gained. For example if you choose the second option and there is only one Silver in the Supply, the player to your left gets it and no-one else gets one. For the third option, you only gain a card if you trashed a card, and only if there is a card available in the Supply with the exact cost required. If you do trash a card, you must gain a card if you can. You cannot trash a Governor you played to itself, as it is no longer in your hand when you play it (though you can trash another copy of Governor from your hand).",
+        "name": "Governor",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Choose one; you get the version in parentheses: Each player gets '''+1&nbsp;(+3)&nbsp;Cards'''; or each player gains a Silver (Gold); or each player may trash a card from their hand and gain a card costing exactly {{Cost|1}} ({{Cost|2}}) more.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Choose one; you get the version in parentheses: Each player gets <b>+1&nbsp;(+3)&nbsp;Cards</b>; or each player gains a Silver (Gold); or each player may trash a card from their hand and gain a card costing exactly 1 Coin (2 Coins) more."
+    },
+    "Grand Castle": {
+        "description": "5 <*VP*><line>When you gain this, reveal your hand. {{VP|<b>+1</b>}} per Victory card in your hand and/or in play.",
+        "name": "Grand Castle",
+        "raw_wikitext": "{{VP|5|l}}{{Divline}}When you gain this, reveal your hand. {{VP|'''+1'''}} per Victory card in your hand and/or in play."
+    },
+    "Grand Market": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<br>+2 Coins<line>You can't buy this if you have any Copper in play.",
+        "extra": "You do not have to play all of the Treasures in your hand in your Buy phase. Coppers in your hand do not stop you from buying Grand Market - only Coppers in play do. Coppers that were in play earlier in the turn but are not anymore also don't stop you; if you have 11 Coppers in play and 2 Buys, you could buy a Mint, trash all of your played Treasures, and then buy a Grand Market. You can gain Grand Market other ways - for example with Expand - whether or not you have Coppers in play. Treasures other than Copper do not prevent you from buying Grand Market, even if they are worth 1 coin (such as Loan).",
+        "name": "Grand Market",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<br>{{Costplus|2}}{{divline}}You can’t buy this if you have any Coppers in play.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><br>+2 Coins<line>You can’t buy this if you have any Coppers in play."
+    },
+    "Graverobber": {
+        "description": "Choose one: Gain a card from the trash costing from 3 Coins to 6 Coins, putting it on top of your deck; or trash an Action card from your hand and gain a card costing up to 3 Coins more than it.",
+        "extra": "You choose either option, then do as much of it as you can; you can choose an option even if you will not be able to do it. You can look through the trash at any time. If you choose to gain a card from the trash, the other players get to see what it is, and it goes on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. If there is no card in the trash costing from 3 Coins to 6 Coins, you will fail to gain one. Cards with Potion in the cost (from Alchemy) do not cost from 3 Coins to 6 Coins. If you choose to trash an Action card from your hand, the card you gain comes from the Supply and is put into your discard pile.",
+        "name": "Graverobber",
+        "raw_wikitext": "Choose one: Gain a card from the trash costing from {{Cost|3}} to {{Cost|6}}, onto your deck; or trash an Action card from your hand and gain a card costing up to {{Cost|3}} more than it.",
+        "wikitext": "Choose one: Gain a card from the trash costing from 3 Coins to 6 Coins, onto your deck; or trash an Action card from your hand and gain a card costing up to 3 Coins more than it."
+    },
+    "Great Hall": {
+        "description": "+1 Card<br>+1 Action<line>1 <*VP*>",
+        "extra": "This is both an Action card and a Victory card. When you play it, you draw a card and may play another Action. At the end of the game, it's worth 1 <VP>, like an Estate. <line>Use 8 Great Halls for games with 2 players, 12 for games with 3 or more players.",
+        "name": "Great Hall",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''{{Divline}}{{VP|1|l}}",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><line>1 <*VP*>"
+    },
+    "Great Leader": {
+        "description": "After each Action card you play, <b>+1&nbsp;Action</b>.",
+        "name": "Great Leader",
+        "raw_wikitext": "After each Action card you play, '''+1&nbsp;Action'''."
+    },
+    "Greed": {
+        "description": "Gain a Copper onto your deck.",
+        "extra": "",
+        "name": "Greed",
+        "raw_wikitext": "Gain a Copper onto your deck.",
+        "wikitext": "Gain a Copper onto your deck."
+    },
+    "Grey Mustang": {
+        "description": "+1 Card<n>(Victory cards may be discarded, then draw another)<n>+2 Actions<n>-1 Coin<br>(The coin is used for the entertainment of the precious thoroughbred.)<line>1 <*VP*><br>The victory point is counted at the end of the game.",
+        "extra": "",
+        "name": "Grey Mustang",
+        "notes": [
+            "Fan expansion: Animals"
+        ]
+    },
+    "Groom": {
+        "description": "Gain a card costing up to 4 Coin If it's an...<br>Action card, gain a Horse;<br>Treasure card, gain a Silver;<br>Victory card, +1 Card and +1 Action.",
+        "extra": "First gain a card, then apply the bonuses in the order listed.<n>A card can give you multiple bonuses; for example, if you gain a Mill (from Intrigue), you gain a Horse and then get +1 Card and +1 Action.",
+        "name": "Groom",
+        "raw_wikitext": "<p>Gain a card costing up to {{Cost|4}}. If it's an&hellip;</p>Action card, gain a Horse;<br>Treasure card, gain a Silver;<br>Victory card, '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.",
+        "wikitext": "Gain a card costing up to 4 Coins. If it's an&hellip;<n>Action card, gain a Horse;<br>Treasure card, gain a Silver;<br>Victory card, <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Grotto": {
+        "description": "+1 Action<br>Set aside up to 4 cards from your hand face down (on this). At the start of your next turn, discard them, then draw as many.",
+        "extra": "For example you could set aside 3 cards from your hand, and at the start of your next turn, discard those 3 cards, then draw 3 cards.",
+        "name": "Grotto",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Set aside up to 4&nbsp;cards from your hand face down (on this). At the start of your next turn, discard them, then draw as many.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Set aside up to 4&nbsp;cards from your hand face down (on this). At the start of your next turn, discard them, then draw as many."
+    },
+    "Groundskeeper": {
+        "description": "+1 Card<br>+1 Action<line>While this is in play, when you gain a Victory card, +1 <VP>",
+        "extra": "This can trigger multiple times in a turn, for cards gained different ways. For example you could play Groundskeeper, then play Engineer gaining an Estate and taking 1 <VP>, then in your Buy phase buy a Duchy taking another +1 <VP>. Multiple Groundskeepers are cumulative. If you Crown a Groundskeeper, there is still just one Groundskeeper in play, so you only get +1 <VP> per Victory card gained.",
+        "name": "Groundskeeper",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>This turn, when you gain a Victory card, {{VP|'''+1'''}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>This turn, when you gain a Victory card, {{VP|<b>+1</b>}}."
+    },
+    "Growth": {
+        "description": "When you gain a Treasure, gain a cheaper card.",
+        "name": "Growth",
+        "raw_wikitext": "When you gain a Treasure, gain a cheaper card."
+    },
+    "Guard Dog": {
+        "description": "+2 Cards<br>If you have 5 or fewer cards in hand, +2 Cards.<line>When another player plays an Attack, you may first play this from your hand.",
+        "extra": "When you play this, you draw 2 cards, then count the cards in your hand; if it's 5 or fewer, you draw 2 more cards. When another player plays an Attack card, you may play this before that Attack resolves; then the Attack still happens (unless you stop it another way, such as with a Moat you just drew). So if another player plays Berserker, and you respond with Guard Dog, you'll first draw 2 cards, then discard down to 3 cards in hand. As usual playing it means putting it into play and following its instructions. If you play this during another player's turn, you discard it from play during that turn's Clean-up.",
+        "name": "Guard Dog",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>If you have 5&nbsp;or fewer cards in hand, '''+2&nbsp;Cards'''.</p>{{Divline}}When another player plays an Attack, you may first play this from your hand.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>If you have 5&nbsp;or fewer cards in hand, <b>+2&nbsp;Cards</b>.<n><line>When another player plays an Attack, you may first play this from your hand."
+    },
+    "Guardian": {
+        "description": "Until your next turn, when another player plays an Attack card, it doesn’t affect you. At the start of your next turn, +1 Coin.<line>This is gained to your hand (instead of your discard pile).",
+        "extra": "Since Night is after the Buy phase, normally you can play this the turn you buy it. When you play Guardian, you are unaffected by Attack cards other players play between then and your next turn (even if you want one to affect you). Guardian does not prevent you from using Reactions when other players play Attacks.",
+        "name": "Guardian",
+        "raw_wikitext": "At the start of your next turn, {{Costplus|1}}. Until then, when another player plays an Attack card, it doesn't affect you. {{Divline}}This is gained to your hand (instead of your discard pile).",
+        "wikitext": "At the start of your next turn, +1 Coin. Until then, when another player plays an Attack card, it doesn't affect you. <line>This is gained to your hand (instead of your discard pile)."
+    },
+    "Guide": {
+        "description": "+1 Card<br>+1 Action<n>Put this on your Tavern mat.<line>At the start of your turn, you may call this, to discard your hand and draw 5 cards.",
+        "extra": "When you play this, you get +1 Card and +1 Action, and put it on your Tavern mat. It stays on your mat until you call it at the start of one of your turns. If multiple things can happen at the start of your turn, you can do them in any order. When you call Guide, it moves from the mat into play, and you discard your hand, then draw 5 cards. You discard it that turn with your other cards in play.",
+        "name": "Guide",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Put this on your Tavern mat.</p>{{Divline}}At the start of your turn, you may call this, to discard your hand and draw 5&nbsp;cards.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Put this on your Tavern mat.<n><line>At the start of your turn, you may call this, to discard your hand and draw 5&nbsp;cards."
+    },
+    "Guildhall": {
+        "description": "When you gain a Treasure, +1 Coffers.",
+        "extra": "This happens whether you gain a Treasure due to buying it, or some other way.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Guildhall",
+        "raw_wikitext": "When you gain a Treasure, '''+1&nbsp;Coffers'''.",
+        "wikitext": "When you gain a Treasure, <b>+1&nbsp;Coffers</b>."
+    },
+    "Guildmaster": {
+        "description": "+3 Coins<n>This turn, when you gain a card, +1 Favor.",
+        "extra": "If an Ally ability triggers on gaining cards, e.g. Band of Nomads, you can use the Favor you just got on it.",
+        "name": "Guildmaster",
+        "raw_wikitext": "{{Costplus|3}}<p>This turn, when you gain a card, '''+1&nbsp;Favor'''.</p>",
+        "wikitext": "+3 Coins<n>This turn, when you gain a card, <b>+1&nbsp;Favor</b>."
+    },
+    "Haggler": {
+        "description": "+2 Coins<line>While you have this in play, when you buy a card, gain a cheaper non-Victory card.",
+        "extra": "When you play this, you get +2 coins. While this is in play, whenever you buy a card, you gain a cheaper card that is not a Victory card. For example, you could buy a Province, and gain a Gold via Haggler. Gaining a card is not optional. The gained card comes from the Supply and is put into your discard pile. Haggler only gives you an extra card when you buy a card, not when you gain a card some other way (such as with Haggler itself). If there is no cheaper card available in the Supply (e.g., if you buy a Copper), you do not gain a card. Using a card that lets you play a card several times (like Throne Room from Dominion) on Haggler does not gain you two or more cards per card bought, as there is still only one copy of Haggler in play. The bonus is cumulative if you have three Hagglers in play, you will gain three more cards for each card you buy. Cards with two types, one of which is Victory, are Victory cards and so cannot be gained with Haggler.",
+        "name": "Haggler",
+        "raw_wikitext": "{{Costplus|2}}<p>This turn, when you gain a card, if you bought it, gain a cheaper non-Victory card.</p>",
+        "wikitext": "+2 Coins<n>This turn, when you gain a card, if you bought it, gain a cheaper non-Victory card."
+    },
+    "Hamlet": {
+        "description": "+1 Card<br>+1 Action<n>You may discard a card; If you do +1 Action.<n>You may discard a card; If you do +1 Buy",
+        "extra": "First draw a card, and get +1 Action. Then you may either discard one card to get another +1 Action; or you may discard one card to get +1 Buy; or you may discard two cards and get both +1 Action and +1 Buy; or you may discard no cards at all. You only get the extra +1 Action or +1 Buy if you actually discarded a card for it. You cannot discard multiple cards to get multiple +Actions or multiple +Buys.",
+        "name": "Hamlet",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may discard a card for '''+1&nbsp;Action'''.</p>You may discard a card for '''+1&nbsp;Buy'''.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may discard a card for <b>+1&nbsp;Action</b>.<n>You may discard a card for <b>+1&nbsp;Buy</b>."
+    },
+    "Hammer": {
+        "description": "3 <*COIN*><br><br>Gain a card costing up to 4 Coin.",
+        "extra": "Each time you play this, you get +3 Coin and gain a card costing up to 4 Coin. This isn't optional.",
+        "name": "Hammer",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<p>Gain a card costing up to {{Cost|4}}.</p>",
+        "wikitext": "3 <*COIN*><n>Gain a card costing up to 4 Coins."
+    },
+    "Harbinger": {
+        "description": "+1 Card<br>+1 Action<n>Look through your discard pile. You may put a card from it onto your deck.",
+        "extra": "First draw a card and get +1 Action; then look through your discard pile, and you may put a card from it on top of your deck.<n>Putting a card on top is optional.",
+        "name": "Harbinger",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Look through your discard pile. You may put a card from it onto your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Look through your discard pile. You may put a card from it onto your deck."
+    },
+    "Harbor Village": {
+        "description": "+1 Card<br>+2 Actions<br>After the next Action you play this turn, if it gave you +_ Coin, +1 Coin.",
+        "extra": "This only cares if the Action itself gave you +_ Coin not if you otherwise got +_ Coin due to playing it (such as due to Training, from Adventures, or due to receiving The Forest's Gift, from Nocturne).<br>It's okay if you no longer have the _ Coin (such as due to Storyteller).<br>+Coffers (from Guilds and Renaissance) is not +_ Coin.<br>+0 Coin doesn't get you the bonus.<br>Using a Way (from Menagerie) to get +_ Coin (e.g. Way of the Sheep) does get you the bonus.<br>If you Throne Room a Harbor Village and then play a Militia, you played Harbor Village, then Harbor Village, then Militia, so you get nothing for the first play of Harbor Village and +1 Coin for the second play of it.",
+        "name": "Harbor Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>After the next Action you play this turn, if it gave you {{Costplus}}, {{Costplus|1}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>After the next Action you play this turn, if it gave you {{Costplus}}, +1 Coin."
+    },
+    "Harem": {
+        "description": "2 <*COIN*><line>2 <*VP*>",
+        "extra": "This is both a Treasure card and a Victory card. You can play it for 2 coins, just like a Silver card. At the end of the game, it's worth 2 <VP>. <line>Use 8 Harems for games with 2 players, 12 for games with 3 or more players.",
+        "name": "Harem / Farm",
+        "raw_wikitext": "{{Cost|2|l}}{{Divline}}{{VP|2|l}}",
+        "wikitext": "2 <*COIN*><line>2 <*VP*>"
+    },
+    "Harsh Winter": {
+        "description": "When you gain a card on your turn, if there's {{Debt}} on its pile, take it; otherwise put {{Cost|||2}} on its pile.",
+        "name": "Harsh Winter",
+        "raw_wikitext": "When you gain a card on your turn, if there's {{Debt}} on its pile, take it; otherwise put {{Cost|||2}} on its pile."
+    },
+    "Harvest": {
+        "description": "Reveal the top 4 cards of your deck, then discard them. +1 Coin per differently named card revealed.",
+        "extra": "Reveal the top 4 cards of your deck. If there are not enough cards, reveal what you can, shuffle your discard pile, and reveal the rest. If there still are not 4 cards total to reveal, just reveal what you can. You discard the revealed cards, and get +1 coin per differently named card revealed. For example if you revealed Copper, Silver, Copper, Estate, that would be +3 coins .",
+        "name": "Harvest",
+        "raw_wikitext": "Reveal the top 4&nbsp;cards of your deck, then discard them. {{Costplus|1}} per differently named card revealed.",
+        "wikitext": "Reveal the top 4&nbsp;cards of your deck, then discard them. +1 Coin per differently named card revealed."
+    },
+    "Hasty": {
+        "description": "When you gain a Hasty card, set it aside, and play it at the start of your next turn.",
+        "extra": "If this plays a card that can't normally be played, like Territory (from Allies), that card goes into play but doesn't do anything else then.",
+        "name": "Hasty",
+        "raw_wikitext": "When you gain a Hasty card, set it aside, and play it at the start of your next turn.",
+        "wikitext": "When you gain a Hasty card, set it aside, and play it at the start of your next turn."
+    },
+    "Haunted Castle": {
+        "description": "2 <*VP*><line>When you gain this during your turn, gain a Gold, and each other player with 5&nbsp;or more cards in hand puts 2&nbsp;of them onto their deck.",
+        "name": "Haunted Castle",
+        "raw_wikitext": "{{VP|2|l}}{{Divline}}When you gain this during your turn, gain a Gold, and each other player with 5&nbsp;or more cards in hand puts 2&nbsp;of them onto their deck."
+    },
+    "Haunted Mirror": {
+        "description": "1 <*COIN*><line>When you trash this, you may discard an Action card, to gain a Ghost from its pile.",
+        "extra": "Haunted Mirror does not give you a way to trash it, but does something if you find a way to.",
+        "name": "Haunted Mirror",
+        "raw_wikitext": "{{Cost|1|l}}{{Divline}}When you trash this, you may discard an Action card, to gain a Ghost.",
+        "wikitext": "1 <*COIN*><line>When you trash this, you may discard an Action card, to gain a Ghost."
+    },
+    "Haunted Woods": {
+        "description": "Until your next turn, when any other player buys a card, he puts his hand on top of his deck in any order.<n>At the start of your next turn:<n>+3 Cards",
+        "extra": "Playing this sets up two effects for the future: you will draw 3 cards at the start of your next turn; and until then, other players will put the rest of their hand on their deck whenever they buy a card. A player may not have any cards left in hand when buying a card; typically cards left in hand will include Victory cards, Curses, and unplayed Actions. A player may intentionally avoid playing Treasures and Actions in order to take advantage of having to put his hand on his deck. Players who do not buy any cards can discard their hand normally. Buying Events is not buying cards and so does not trigger this. If you play Haunted Woods and then take an extra turn immediately, such as with Mission or Outpost (from Seaside), you will draw the 3 cards at the start of that turn and discard Haunted Woods that turn, and other players will never be affected by it. If you want to use a Reaction card like Moat against Haunted Woods, you have to use it right when Haunted Woods is played.",
+        "name": "Haunted Woods",
+        "raw_wikitext": "<p>At the start of your next turn: '''+3&nbsp;Cards'''.</p>Until then, when any other player gains a card they bought, they put their hand onto their deck in any order.",
+        "wikitext": "At the start of your next turn: <b>+3&nbsp;Cards</b>.<n>Until then, when any other player gains a card they bought, they put their hand onto their deck in any order."
+    },
+    "Haunting": {
+        "description": "If you have at least 4 cards in hand, put one of them onto your deck.",
+        "extra": "",
+        "name": "Haunting",
+        "raw_wikitext": "If you have at least 4&nbsp;cards in hand, put one of them onto your deck.",
+        "wikitext": "If you have at least 4&nbsp;cards in hand, put one of them onto your deck."
+    },
+    "Haven": {
+        "description": "+1 Card<br>+1 Action<n>Set aside a card from your hand face down. At the start of your next turn, put it into your hand.",
+        "extra": "First draw a card; then choose a card from your hand and set it aside, face down. Put the set aside card on the Haven, to remind you what it's for. Other players don't get to see what you put down. You have to set aside a card; it's not optional. Haven and the card stay there until the start of your next turn, at which point you put the set aside card into your hand. Haven itself is discarded during the Clean-up phase of that subsequent turn.",
+        "name": "Haven",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Set aside a card from your hand face down (under this). At the start of your next turn, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Set aside a card from your hand face down (under this). At the start of your next turn, put it into your hand."
+    },
+    "Herald": {
+        "description": "+1 Card<br>+1 Action<br>Reveal the top card of your deck.<br>If it is an Action, play it.<line>When you buy this, you may overpay for it. For each 1 Coin you overpaid, look through your discard pile and put a card from it on top of your deck.",
+        "extra": "When you play this, first draw a card and get +1 Action, then reveal the top card of your deck. If it is an Action card, play it; this is not optional. Playing the Action card does not \"use up\" one of your Action plays for the turn. Cards with multiple types, one of which is Action (such as Great Hall from Intrigue), are Action cards. If Herald plays a Duration card (from Seaside), the Herald is still discarded normally at end of turn, as it is not needed to track anything. When you buy this, you put one card from your discard pile on top of your deck for each extra 1 Coin you pay over the cost. For example, if you buy Herald for 6 Coins, you will put two cards from your discard pile on top of your deck. This card lets you look through your discard pile; normally you cannot. You cannot look through your discard pile first to see how much you want to overpay, and once you overpay you must put the appropriate number of cards on top of your deck if possible. If you overpay enough to put more cards on your deck than there are cards in your discard pile, you just put all of your discard pile onto your deck. You may not look through your discard pile if you buy Herald without overpaying for it. When you put multiple cards on your deck due to overpaying for a Herald, put them on your deck in any order.",
+        "name": "Herald",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If it's an Action, play it.</p>{{Divline}}'''Overpay:''' Per {{Cost|1}} overpaid, put any card from your discard pile onto your deck.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If it's an Action, play it.<n><line><b>Overpay:</b> Per 1 Coin overpaid, put any card from your discard pile onto your deck."
+    },
+    "Herb Gatherer": {
+        "description": "+1 Buy<n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<br>You may rotate the Augurs.",
+        "extra": "Putting your deck into your discard pile does not trigger \"when you discard this\" abilities like Tunnel's.<n>Playing a Treasure from your discard pile is optional, as is rotating the Augurs.",
+        "name": "Herb Gatherer",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Put your deck into your discard pile. Look through it and you may play a Treasure from it.</p>You may rotate the Augurs.",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Put your deck into your discard pile. Look through it and you may play a Treasure from it.<n>You may rotate the Augurs."
+    },
+    "Herbalist": {
+        "description": "+1 Buy<br>+1 Coin<line>When you discard this from play, you may put one of your Treasures from play on top of your deck.",
+        "extra": "You get an extra 1 Coin to spend this turn, and may buy an additional card in your Buy phase. When you discard this from play (usually during Clean-up), you may choose a Treasure card you have in play, and put that card on your deck. If you have no cards in your deck, that Treasure will become the only card in your deck. You choose what order to discard cards during Clean-up; so, for example, if you have Herbalist, Potion, and Alchemist in play, you could choose to discard Alchemist first, putting it on top of your deck, then discard Herbalist, and put Potion on top of your deck. If you have multiple Herbalists in play, each one will let you put another Treasure from play onto your deck.",
+        "name": "Herbalist",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}<p>Once this turn, when you discard a Treasure from play, you may put it onto your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<n>Once this turn, when you discard a Treasure from play, you may put it onto your deck."
+    },
+    "Hermit": {
+        "description": "Look through your discard pile. You may trash a card from your discard pile or hand that is not a Treasure. Gain a card costing up to 3 Coins.<line>When you discard this from play, if you did not buy any cards this turn, trash this and gain a Madman from the Madman pile.",
+        "extra": "When you play this, look through your discard pile, and then you may choose to trash a card that is not a Treasure, from either your hand or your discard pile. You do not have to trash a card and cannot trash Treasures. A card with multiple types, one of which is Treasure (such as Harem from Intrigue), is a Treasure. After trashing or not, you gain a card costing up to 3 Coins. The card you gain comes from the Supply and is put into your discard pile. Gaining a card is mandatory if it is possible. Then, when you discard Hermit from play - normally, in Clean-up, after playing it in your Action phase - if you did not buy any cards this turn, you trash Hermit and gain a Madman. The Madman comes from the Madman pile, which is not in the Supply, and is put into your discard pile. It does not matter whether or not you gained cards other ways, only whether or not you bought a card. If there are no Madman cards left, you do not gain one. If Hermit is not discarded from play during Clean-up - for example, if you put it on your deck with Scheme (from Hinterlands) - then the ability that trashes it will not trigger.",
+        "name": "Hermit",
+        "raw_wikitext": "Look through your discard pile. You may trash a non-Treasure from it or from your hand. Gain a card costing up to {{Cost|3}}. At the end of your Buy phase this turn, if you didn't gain any cards in it, exchange this for a Madman.",
+        "wikitext": "Look through your discard pile. You may trash a non-Treasure from it or from your hand. Gain a card costing up to 3 Coins. At the end of your Buy phase this turn, if you didn't gain any cards in it, exchange this for a Madman."
+    },
+    "Hermit - Madman": {
+        "description": "<left><u>Hermit</u>:</left><center>Look through your discard pile. You may trash a card from your discard pile or hand that is not a Treasure. Gain a card costing up to 3 Coins.</center><line><center>When you discard this from play, if you did not buy any cards this turn, trash this and gain a Madman from the Madman pile.</center><left><u>Madman</u>:</left><center>+2 Actions</center><center>Return this to the Madman pile. If you do, +1 Card per card in your hand.</center><center><i>(This card is not in the supply.)</i></center>",
+        "extra": "<u>Hermit</u>:When you play this, look through your discard pile, and then you may choose to trash a card that is not a Treasure, from either your hand or your discard pile. You do not have to trash a card and cannot trash Treasures. After trashing or not, you must gain a card costing up to 3 Coin. Then, when you discard Hermit from play - normally, in Clean-up, after playing it in your Action phase - if you did not buy any cards this turn, you trash Hermit and gain a Madman. The Madman comes from the Madman pile, which is not in the Supply. It does not matter whether or not you gained cards other ways, only whether you did not buy a card. If there are no Madman cards left, you do not gain one. Buying a card with Black Market from the Black Market deck prevents a Madman gain, even if no card is bought during the player's buy phase that turn. Gaining the Madman is not contingent on trashing the Hermit: when using Scheme's (from Hinterlands) ability and putting the Hermit on top of your deck prevents Hermit's trashing, but you still gain the Madman. This works almost identically with Prince.<n><u>Madman</u>:This card is not in the Supply; it can only be obtained via Hermit. When you play it, you get +2 Actions, return it to the Madman pile if you can (this is not optional), and if you did return it, you draw a card per card in your hand. For example if you had three cards in hand after playing Madman, you would draw three cards. Normally nothing will prevent you from returning Madman to the Madman pile, but you may fail to due to playing Madman twice via cards like Throne Room. So, for example, if you Procession a Madman, you will get +2 Actions, return Madman to the Madman pile, draw a card per card in your hand, get another +2 Actions, fail to return Madman and so not draw cards the second time, fail to trash Madman, and then gain an Action card costing exactly 1 Coin if you can. Since Madman is not in the Supply, the Madman pile being empty does NOT count towards the three-pile end-game condition.",
+        "name": "Hermit / Madman"
+    },
+    "Hero": {
+        "description": "+2 Coins<n>Gain a Treasure.<line>When you discard this from play, you may exchange it for a Champion.<n><i>(This is not in the Supply.)</i>",
+        "extra": "The Treasure comes from the Supply and is put into your discard pile. It can be any Treasure being used that game.",
+        "name": "Hero",
+        "raw_wikitext": "{{Costplus|2}}<p>Gain a Treasure.</p>{{Divline}}<p>When you discard this from play, you may exchange it for a Champion.</p>''(This is not in the Supply.)''",
+        "wikitext": "+2 Coins<n>Gain a Treasure.<n><line><n>When you discard this from play, you may exchange it for a Champion.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Hideout": {
+        "description": "+1 Card<br>+2 Actions<br><br>Trash a card from your hand. If it's a Victory card, gain a Curse.",
+        "extra": "Trashing is not optional. Curses are not Victory cards.",
+        "name": "Hideout",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>Trash a card from your hand. If it's a Victory card, gain a Curse.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>Trash a card from your hand. If it's a Victory card, gain a Curse."
+    },
+    "Highway": {
+        "description": "+1 Card<br>+1 Action<line>While this is in play, cards cost 1 coin less.",
+        "extra": "This makes all cards cheaper (to a minimum of 0 coins) as long as it is in play. When it leaves play, it stops making cards cheaper. This applies to cards everywhere - cards in the Supply, cards in hand, cards in Decks. For example if you played Highway, then Develop, trashing a Copper, you could gain an Estate, as Estate would cost 1 coin while Copper would still cost 0 coins. Using a card that lets you play a card several times (like Throne Room from Dominion) on Highway will not make cards cost less, as there is still only one copy of Highway in play. The bonus is cumulative; if you have three Highways in play, all cards cost 3 coins less (to a minimum of 0 coins).",
+        "name": "Highway",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>This turn, cards cost {{Cost|1}} less.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>This turn, cards cost 1 Coin less."
+    },
+    "Highwayman": {
+        "description": "At the start of your next turn, discard this from play and +3 Cards.<br>Until then, the first Treasure each other player plays each turn does nothing.",
+        "extra": "You draw the 3 cards even if Highwayman can't be discarded from play.<n>Discarding Highwayman happens first, so it's possible to even draw that Highwayman with the +3 Cards.<n>The attack stops each other player's first Treasure from doing anything, each turn; if they take extra turns, every turn is affected.<n>This isn't cumulative; if multiple players play copies of Highwayman, or one player plays multiple copies of it, still only one Treasure per turn does nothing.<n>The Treasure does nothing even if it's also an Action.<n>This stops the Treasure from doing what it does when played, but doesn't stop abilities below a dividing line, like Capital's.<n>If the Treasure is also an Action, a Way can still be used on it, and Enchantress can still work on it; the player who played the Treasure decides which effect applies.",
+        "name": "Highwayman",
+        "raw_wikitext": "<p>At the start of your next turn, discard this from play and '''+3&nbsp;Cards'''.</p><p>Until then, the first Treasure each other player plays each turn does nothing.</p>",
+        "wikitext": "At the start of your next turn, discard this from play and <b>+3&nbsp;Cards</b>.<n>Until then, the first Treasure each other player plays each turn does nothing."
+    },
+    "Hill Fort": {
+        "description": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or +1 Card and +1 Action.",
+        "extra": "First completely resolve gaining a card costing up to 4 Coins; then choose whether to put it into your hand or to get +1 Card and +1 Action.<n>If the card is no longer where it was gained to (normally your discard pile) then you will fail to put it into your hand if you choose that. If it's been covered up in your discard pile, you can still put it into your hand.",
+        "name": "Hill Fort",
+        "raw_wikitext": "Gain a card costing up to {{Cost|4}}. Choose one: Put it into your hand; or '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.",
+        "wikitext": "Gain a card costing up to 4 Coins. Choose one: Put it into your hand; or <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Hireling": {
+        "description": "At the start of each of your turns for the rest of the game:<n>+1 Card<n><i>(This stays in play.)</i>",
+        "extra": "After playing this, you draw an extra card at the start of each of your turns for the rest of the game. Hireling stays in play for the rest of the game to track this. If you use Disciple (or a similar card, like Throne Room) to play Hireling twice, you will draw two extra cards each turn, and Disciple will also stay in play for the rest of the game.",
+        "name": "Hireling",
+        "raw_wikitext": "At the start of each of your turns for the rest of the game: '''+1&nbsp;Card'''.",
+        "wikitext": "At the start of each of your turns for the rest of the game: <b>+1&nbsp;Card</b>."
+    },
+    "Hoard": {
+        "description": "2 <*COIN*><line>While you have this in play, when you buy a Victory card, gain a Gold.",
+        "extra": "This is a Treasure worth 2 coins, like Silver. When you buy a Victory card with this in play, you gain a Gold card from the Supply, putting it into your discard pile. If there are no Golds left, you do not get one. If you have multiple Hoards in play, you will gain multiple Golds from buying a single one. So for example if you had two Hoards in play and no other money, with +1 Buy, you could buy two Estates and gain four Golds. Victory cards include cards that are other types as well, such as Nobles and Harem in Intrigue. You gain a Gold even if you use Watchtower to immediately trash the Victory card you gained. Victory cards gained other than by buying them do not get you Gold.",
+        "name": "Hoard",
+        "raw_wikitext": "{{Cost|2|l}}<p>This turn, when you gain a Victory card, if you bought it, gain a Gold.</p>",
+        "wikitext": "2 <*COIN*><n>This turn, when you gain a Victory card, if you bought it, gain a Gold."
+    },
+    "Horn": {
+        "description": "Once per turn, when you discard a Border Guard from play, you may put it onto your deck.",
+        "extra": "Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Horn",
+        "raw_wikitext": "Once per turn, when you discard a Border Guard from play, you may put it onto your deck.",
+        "wikitext": "Once per turn, when you discard a Border Guard from play, you may put it onto your deck."
+    },
+    "Horn of Plenty": {
+        "description": "0 <*COIN*><n>When you play this, gain a card costing up to 1 Coin per differently named card you have in play, counting this. If it's a Victory card, trash this.",
+        "extra": "This is a Treasure worth 0 coins. You play it in your Buy phase, like other Treasures. It does not produce any coins to spend. However, when you play it, you gain a card costing up to per differently named card you have in play. This includes itself, other played Treasures, played Actions, and any Duration cards (from Seaside) played on your previous turn. It only counts cards currently in play, not ones that were in play but left; for example if you played a Feast (from Dominion) this turn, you will have trashed it, so it will not count for Horn of Plenty. The card you gain must come from the Supply, and is put into your discard pile. If it is a Victory card, trash Horn of Plenty. Cards with multiple types, one of which is Victory (such as Nobles from Intrigue) are Victory cards. You do not have to play Horn of Plenty in your Buy phase, and you choose the order that you play Treasures. You do not trash Horn of Plenty if you gain a Victory card some other way while it's in play (such as by buying one).",
+        "name": "Horn of Plenty",
+        "raw_wikitext": "Gain a card costing up to {{Cost|1}} per differently named card you have in play (counting this). If it's a Victory card, trash this.",
+        "wikitext": "Gain a card costing up to 1 Coin per differently named card you have in play (counting this). If it's a Victory card, trash this."
+    },
+    "Horse": {
+        "description": "+2 Cards<br>+1 Action<n>Return this to its pile.<n><i>(This is not in the Supply.)</i>",
+        "extra": "It is a one-shot non-terminal draw card, similar to Experiment from Renaissance; but unlike Experiment, it is not in the supply, and therefore can only be gained in more restricted ways.",
+        "name": "Horse",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Return this to its pile.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Return this to its pile.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Horse Traders": {
+        "description": "+1 Buy<br>+3 Coin<br>Discard 2 Cards<line>When another player plays an Attack card, you may set this aside from your hand. If you do, then at the start of your next turn, +1 Card and return this to your hand.",
+        "extra": "When you play this, you get +1 Buy and +3 coins, and discard 2 cards from your hand. If you do not have enough cards to discard, just discard what you can; you still get the +1 Buy and +3 coins. When another player plays an Attack card, before that card does anything, you may reveal this from your hand. If you do, you set it aside, and at the start of your next turn, you return it to your hand and draw a card. While it is set aside, it is not in play or in your hand, and cannot be further revealed to Attacks. Therefore it will only work on one Attack per round of turns. You can reveal it for an Attack and still play it on your next turn. You can reveal multiple Horse Traders to a single Attack. For example, if another player plays Followers, you could reveal and set aside two Horse Traders from your hand, then gain a Curse but discard no cards, as you would only have three cards in hand at that point. Then on your next turn you would pick up the two Horse Traders and also draw two cards.",
+        "name": "Horse Traders",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|3}}<p>Discard 2&nbsp;cards.</p>{{Divline}}When another player plays an Attack card, you may first set this aside from your hand. If you do, then at the start of your next turn, '''+1&nbsp;Card''' and return this to your hand.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+3 Coins<n>Discard 2&nbsp;cards.<n><line>When another player plays an Attack card, you may first set this aside from your hand. If you do, then at the start of your next turn, <b>+1&nbsp;Card</b> and return this to your hand."
+    },
+    "Hostelry": {
+        "description": "+1 Card<br>+2 Actions<line>When you gain this, you may discard any number of Treasures, revealed, to gain that many Horses.",
+        "extra": "When you gain this, you may discard any number of Treasure cards from your hand, to gain that many Horses from their pile.<n>Reveal the discarded Treasure cards.<n>You do not have to discard anything, and cannot discard anything but Treasures.",
+        "name": "Hostelry",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, you may discard any number of Treasures, revealed, to gain that many Horses.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, you may discard any number of Treasures, revealed, to gain that many Horses."
+    },
+    "Housecarl": {
+        "description": "+1 Card per differently named Action card you have in play.<br><br><i>(This is not in the supply.)</i>",
+        "extra": "This includes Housecarl itself.",
+        "name": "Housecarl",
+        "raw_wikitext": "<p>'''+1&nbsp;Card''' per differently named Action card you have in play.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Card</b> per differently named Action card you have in play.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Hovel": {
+        "description": "When you buy a Victory card, you may trash this from your hand.",
+        "extra": "This is a Shelter; see Preparation. It is never in the Supply. When you buy a Victory card, if Hovel is in your hand, you may trash the Hovel. A card with multiple types, one of which is Victory, is a Victory card. You do not get anything for trashing Hovel; you just get to get rid of it.",
+        "name": "Hovel",
+        "raw_wikitext": "When you gain a Victory card, you may trash this from your hand.",
+        "wikitext": "When you gain a Victory card, you may trash this from your hand."
+    },
+    "Huge Turnip": {
+        "description": "+2 Coffers<br><br>+1 coin per Coffers you have.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": "The +1 coin per Coffers you have includes the 2 you just got.",
+        "name": "Huge Turnip",
+        "raw_wikitext": "'''+2&nbsp;Coffers'''<p>{{Costplus|1}} per Coffers you have.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Coffers</b><n>+1 Coin per Coffers you have.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Humble Castle": {
+        "description": "1 <*COIN*><line>Worth 1 <VP> per Castle you have.",
+        "name": "Humble Castle",
+        "raw_wikitext": "{{Cost|1|l}}{{Divline}}Worth {{VP|'''1'''}} per Castle you have."
+    },
+    "Hunter": {
+        "description": "+1 Action<n>Reveal the top 3 cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.",
+        "extra": "From the three cards, choose an Action, then a Treasure, then a Victory card.<n>Cards with multiple types can be chosen for any matching type.",
+        "name": "Hunter",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Reveal the top 3&nbsp;cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Reveal the top 3&nbsp;cards of your deck. From those cards, put an Action, a Treasure, and a Victory card into your hand. Discard the rest."
+    },
+    "Hunting Grounds": {
+        "description": "+4 Cards<line>When you trash this, gain a Duchy or 3 Estates.",
+        "extra": "When you play this, draw 4 cards. If this is trashed, you either gain a Duchy or 3 Estates, your choice. These cards come from the Supply and are put into your discard pile. If you choose the 3 Estates and there are not 3 left, just gain as many as you can.",
+        "name": "Hunting Grounds",
+        "raw_wikitext": "'''+4&nbsp;Cards'''{{Divline}}When you trash this, gain a Duchy or 3&nbsp;Estates.",
+        "wikitext": "<b>+4&nbsp;Cards</b><line>When you trash this, gain a Duchy or 3&nbsp;Estates."
+    },
+    "Hunting Lodge": {
+        "description": "+1 Card<br>+2 Actions<br>You may discard your hand for +5 Cards.",
+        "extra": "When you play this, first draw a card and get +2 Actions; then decide if you want to discard your hand (which will include the card you just drew).<n>If you do discard your hand, draw 5 cards (which may cause you to shuffle in the discarded cards).",
+        "name": "Hunting Lodge",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>You may discard your hand for '''+5&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>You may discard your hand for <b>+5&nbsp;Cards</b>."
+    },
+    "Hunting Party": {
+        "description": "+1 Card<br>+1 Action<n>Reveal your hand. Reveal cards from your deck until you reveal a card that isn't in a duplicate of one in your hand and discard the rest.",
+        "extra": "First you draw a card and get +1 Action. Then you reveal your hand, and reveal cards from your deck until revealing one that is not a duplicate of one in your hand. A card is not a duplicate of one in your hand if it does not have the same name as any cards in your hand. If you run out of cards while revealing cards, shuffle your discard pile (but not the revealed cards) and keep revealing cards. If you still do not find one, just discard all of the cards revealed from your deck. If you do find a card not matching any cards in your hand, put it into your hand and discard the other cards revealed from your deck.",
+        "name": "Hunting Party",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal your hand. Reveal cards from your deck until you reveal a card that isn't a copy of one in your hand. Put it into your hand and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal your hand. Reveal cards from your deck until you reveal a card that isn't a copy of one in your hand. Put it into your hand and discard the rest."
+    },
+    "Idol": {
+        "description": "2 <*COIN*><br>When you play this, if you then have an odd number of Idols in play, receive a Boon; if an even number, each other player gains a Curse.",
+        "extra": "Idol cares how many Idols you have in play, not how many you have played this turn; some cards can make those numbers different (e.g. Counterfeit from Dark Ages). If you have one Idol in play, you receive a Boon, if two, the other players gain a Curse, if three, you receive a Boon, and so on.",
+        "name": "Idol",
+        "raw_wikitext": "{{Cost|2|l}}<p>If you have an odd number of Idols in play (counting this), receive a Boon; otherwise, each other player gains a Curse.</p>",
+        "wikitext": "2 <*COIN*><n>If you have an odd number of Idols in play (counting this), receive a Boon; otherwise, each other player gains a Curse."
+    },
+    "Ill-Gotten Gains": {
+        "description": "1 <*COIN*><n>You may gain a Copper to your hand.<line>When you gain this, each other player gains a Curse.",
+        "extra": "This is a Treasure worth 1 coin like Copper. When you play it, you may gain a Copper. The gained Copper comes from the Supply and is put into your hand; you can immediately play it. If there is no Copper left in the Supply, you do not gain one. When you gain Ill-Gotten Gains, each other player gains a Curse. This happens whether you gain Ill-Gotten Gains due to buying it, or you gain it some other way. The Curses come from the Supply and go into discard piles. If there are not enough Curses left to go around, deal them out in turn order, starting with the player to the left of the player who gained Ill-Gotten Gains. III-Gotten Gains is not an Attack, and gaining it is not playing an Attack; cards like Moat from Dominion do not work against it.",
+        "name": "Ill-Gotten Gains",
+        "raw_wikitext": "{{Cost|1|l}}<p>You may gain a Copper to your hand.</p>{{Divline}}When you gain this, each other player gains a Curse.",
+        "wikitext": "1 <*COIN*><n>You may gain a Copper to your hand.<n><line>When you gain this, each other player gains a Curse."
+    },
+    "Imp": {
+        "description": "+2 Cards<br>You may play an Action card from your hand that you don’t have a copy of in play.<br><br><i>(This is not in the supply).</i>",
+        "extra": "After drawing two cards, you can play an Action card from your hand, provided that you do not have a copy of that card in play. It does not matter if you played the Action card this turn, only that it is not in play when you play Imp; you can use Imp to play a card that you played but trashed and so do not have in play, like a Pixie you trashed, but cannot use it to play a card you did not play this turn that is still in play, such as a Secret Cave from your previous turn. Imp normally cannot play an Imp as that is a card you have in play.",
+        "name": "Imp",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>You may play an Action card from your hand that you don't have a copy of in play.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>You may play an Action card from your hand that you don't have a copy of in play.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Imperial Envoy": {
+        "description": "+5 Cards<br>+1 Buy<br>+2 Debt",
+        "extra": "This works even if you already had Debt; see the Debt section.",
+        "name": "Imperial Envoy",
+        "raw_wikitext": "'''+5&nbsp;Cards'''<br>'''+1&nbsp;Buy'''<br>{{Debtplus|2}}",
+        "wikitext": "<b>+5&nbsp;Cards</b><br><b>+1&nbsp;Buy</b><br>{{Debtplus|2}}"
+    },
+    "Importer": {
+        "description": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets +4 Favors.",
+        "extra": "At the start of the game, each player gets five Favors instead of one. Importer doesn't provide a way to get any more Favors during the game.",
+        "name": "Importer",
+        "raw_wikitext": "At the start of your next turn, gain a card costing up to {{nowrap|{{Cost|5}}.}}{{Divline}}Setup: Each player gets '''+4&nbsp;Favors'''.",
+        "wikitext": "At the start of your next turn, gain a card costing up to 5 Coins.<line>Setup: Each player gets <b>+4&nbsp;Favors</b>."
+    },
+    "Improve": {
+        "description": "+2 Coin<br><br>At the start of Clean-up, you may trash an Action card you would discard from play this turn, to gain a card costing exactly 1 Coin more than it.",
+        "extra": "You can only trash an Action card that would be discarded this turn; you cannot trash a non-Action like Silver, or a Duration card that will stay out (but you can trash a Duration card that will be discarded). You can trash the Improve itself. The card you gain does not have to be an Action, it just has to cost exactly 1 Coin more than the trashed Action. Using this ability is optional, but if you trash a card then you have to gain one if you can.",
+        "name": "Improve",
+        "raw_wikitext": "{{Costplus|2}}<p>At the start of Clean-up, you may trash an Action card you would discard from play this turn, to gain a card costing exactly {{Cost|1}} more than it.</p>",
+        "wikitext": "+2 Coins<n>At the start of Clean-up, you may trash an Action card you would discard from play this turn, to gain a card costing exactly 1 Coin more than it."
+    },
+    "Infirmary": {
+        "description": "+1 Card<br>You may trash a card from your hand.<line><b>Overpay:</b> Play this once per 1 coin overpaid.",
+        "extra": "When you gain an Infirmary you overpaid for, you play it once per 1 coin you overpaid. For example if you buy an Infirmary for 5 coin, you'd play the Infirmary twice - drawing a card, optionally trashing a card from your hand, drawing another card, and optionally trashing another card. This doesn't happen when you gain Infirmary without paying for it (such as with Horn of Plenty).",
+        "name": "Infirmary",
+        "raw_wikitext": "'''+1&nbsp;Card'''<p>You may trash a card from your hand.</p>{{Divline}}'''Overpay:''' Play this once per {{Cost|1}} overpaid.",
+        "wikitext": "<b>+1&nbsp;Card</b><n>You may trash a card from your hand.<n><line><b>Overpay:</b> Play this once per 1 Coin overpaid."
+    },
+    "Inheritance": {
+        "description": "Once per game: Set aside a non-Command Action card from the Supply costing up to 4 Coin. Move your Estate token to it. (During your turns, Estates are also Actions with \"Play the card with your Estate token, leaving it there.\")",
+        "extra": "You can only buy this once per game. When you do, set aside a non-Command Action card from the Supply that costs up to 4 Coins, and put your Estate token on it (the one depicting a house). This is not gaining a card, and does not count for things that care about gaining, such as Treasure Hunter; however at the end of the game, include the card in your deck when scoring. For the rest of the game, all of your Estates have the abilities and types of the set aside card. For example if you set aside a Port, then your Estates are Action - Victory cards, that can be played for +1 Card +2 Actions. This also changes Estates you buy or otherwise gain during the game; if you used Inheritance on a Port and then later bought an Estate, that Estate would come with a Port, just as buying a Port gains you a Port. This only affects your own Estates, not Estates of other players. An Estate is yours if either it started in your deck, or you gained it or bought it, or you were passed it with Masquerade (from Intrigue). An Estate stops being yours if you trash it, return it to the Supply, pass it with Masquerade, or are stopped from gaining it due to Possession (from Alchemy) or Trader (from Hinterlands). There are no limits on the set aside card other than being a non-Victory Action from the Supply costing up to 4 Coins; it may be a Duration card, a Reaction card, and so on. It does not have to continue costing up to 4 Coins, it only has to cost up to 4 Coins when set aside. Your Estates are still worth 1 Victory Point when scoring at the end of the game. Your Estates only copy abilities and types; they do not copy cost, name, or what pile they are from (thus they don't trigger tokens like +1 Action on the copied pile, and are not the Bane for Young Witch from Cornucopia even if the copied pile is the Bane). Starting Estates come from the Estates pile.",
+        "name": "Inheritance",
+        "raw_wikitext": "Once per game: Set aside a non-Command non-Duration Action card from the Supply costing up to {{Cost|4}}. Move your Estate token to it. (During your turns, Estates are also Command Actions with \"Play the card with your Estate token, leaving it there.\")",
+        "wikitext": "Once per game: Set aside a non-Command non-Duration Action card from the Supply costing up to 4 Coins. Move your Estate token to it. (During your turns, Estates are also Command Actions with \"Play the card with your Estate token, leaving it there.\")"
+    },
+    "Inherited": {
+        "description": "Setup: You start the game with an Inherited card in place of a starting card you choose.",
+        "extra": "If they care, players decide which card to replace in turn order.<br>Replaced Copper go back to the pile; replaced Estate go back to the box.<br>Replaced other cards (Shelters from Dark Ages, Heirlooms from Nocturne) go back to the box.<br>If the Inherited pile is a split pile (from Empires or Allies), players take cards from the pile in turn order. So in a 6-player game with the Townsfolk pile, the first four players get a Town Crier, and the next two get a Blacksmith.<br>Cards starting in your deck due to Inherited were never \"gained\" and did not trigger \"when you gain this\" effects.",
+        "name": "Inherited",
+        "raw_wikitext": "Setup: You start the game with an Inherited card in place of a starting card you choose.",
+        "wikitext": "Setup: You start the game with an Inherited card in place of a starting card you choose."
+    },
+    "Inn": {
+        "description": "+2 Cards<br>+2 Actions<br>Discard 2 cards.<line>When you gain this, look through your discard pile (including this), reveal any number of Action cards from it, and shuffle them into your deck.",
+        "extra": "When you play this, you draw 2 cards, get +2 Actions, then discard 2 cards. The cards you discard can be ones that were in your hand and/or ones you just drew. You discard cards if able, even if you were unable to draw 2 cards. When you gain this, you look through your discard pile (something normally not allowed) and shuffle any number of Action cards from it into your deck (leaving the rest of your discard pile in your discard pile). You do not have to shuffle any Action cards into your deck. You can shuffle the Inn you just gained into your deck; it is an Action card in your discard pile. Cards with two types, one of which is Action, are Action cards. You must reveal the Action cards that you choose to shuffle into your deck. It does not matter what order you leave your discard pile in afterwards. This ability functions if you gain Inn due to buying it, or gain Inn some other way.",
+        "name": "Inn",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+2&nbsp;Actions'''<p>Discard 2&nbsp;cards.</p>{{Divline}}When you gain this, reveal any number of Action cards from your discard pile and shuffle them into your deck.",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><n>Discard 2&nbsp;cards.<n><line>When you gain this, reveal any number of Action cards from your discard pile and shuffle them into your deck."
+    },
+    "Innkeeper": {
+        "description": "+1 Action<n>Choose one: +1 Card; or +3 Cards, then discard 3 cards; or +5 Cards, then discard 6 cards.",
+        "extra": "First get +1 Action and choose which option you want, then do it.<n>You either get +1 Card, or get +3 Cards but discard 3 cards, or get +5 Cards but discard 6 cards.",
+        "name": "Innkeeper",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Choose one: '''+1&nbsp;Card'''; or '''+3&nbsp;Cards''', then discard 3&nbsp;cards; or '''+5&nbsp;Cards''', then discard 6&nbsp;cards.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Choose one: <b>+1&nbsp;Card</b>; or <b>+3&nbsp;Cards</b>, then discard 3&nbsp;cards; or <b>+5&nbsp;Cards</b>, then discard 6&nbsp;cards."
+    },
+    "Innovation": {
+        "description": "The first time you gain an Action card in each of your turns, you may set it aside.<n>If you do, play it.",
+        "extra": "This is optional, but only applies to your first Action card gained each turn; whether or not you use Innovation then, you will not be able to use it on subsequent gains that turn. This applies to cards gained due to being bought, or gained other ways. If the first Action card you gain in turn is in your Buy phase, that means you can play that card even though it is your Buy phase. If it gives you +Actions, that will not let you play more Action cards in your Buy phase; if it draws you Treasures, you can only play them if you have not bought anything yet.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Innovation",
+        "raw_wikitext": "Once during each of your turns, when you gain an Action card, you may play it.",
+        "wikitext": "Once during each of your turns, when you gain an Action card, you may play it."
+    },
+    "Insignia": {
+        "description": "3 <*COIN*><br><br>This turn, when you gain a card, you may put it onto your deck.",
+        "extra": "If you gain multiple cards, this applies to each of them - you can put any or all of them on top of your deck.",
+        "name": "Insignia",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<p>This turn, when you gain a card, you may put it onto your deck.</p>",
+        "wikitext": "3 <*COIN*><n>This turn, when you gain a card, you may put it onto your deck."
+    },
+    "Inspiring": {
+        "description": "After playing an Inspiring card on your turn, you may play an Action from your hand that you don't have a copy of in play.",
+        "extra": "When you play an Inspiring card, after resolving it, you can play an Action card from your hand, provided that you don't have a copy of that card in play.<br>Duration cards that you played on previous turns that are still in play, are in play; cards that have left play somehow, like a Mining Village (from Intrigue) trashing itself, are not in play.<br>An Inspiring card can sometimes play a different Inspiring card (when Inspiring is on a split pile, like those in Empires and Allies), but can't normally play another copy of itself.",
+        "name": "Inspiring",
+        "raw_wikitext": "After playing an Inspiring card on your turn, you may play an Action from your hand that you don't have a copy of in play.",
+        "wikitext": "After playing an Inspiring card on your turn, you may play an Action from your hand that you don't have a copy of in play."
+    },
+    "Invasion": {
+        "description": "You may play an Attack from your hand.<br>Gain a Duchy. Gain an Action onto your deck.<br>Gain a Loot; play it.",
+        "extra": "You do the four things in that order.<br>Playing an Attack card is optional; the rest are mandatory.",
+        "name": "Invasion",
+        "raw_wikitext": "You may play an Attack from your hand. Gain a Duchy. Gain an Action onto your deck. Gain a Loot; play it.",
+        "wikitext": "You may play an Attack from your hand. Gain a Duchy. Gain an Action onto your deck. Gain a Loot; play it."
+    },
+    "Inventor": {
+        "description": "Gain a card costing up to 4 Coins, then cards cost 1 Coin less this turn (but not less than 0 Coin).",
+        "extra": "First you gain a card costing up to 4 Coin; then, after that happens, prices are lowered for the rest of the turn. The cost lowering applies to all cards everywhere, including cards in the Supply, in hands, and in Decks. It's cumulative; for example if you play two Inventors, the cost reduction from the first applies to playing the second (for example it could gain a Duchy, which would then cost 4 Coin), and afterwards cards cost 2 Coin less for the rest of the turn.",
+        "name": "Inventor",
+        "raw_wikitext": "Gain a card costing up to {{Cost|4}}, then cards cost {{Cost|1}} less this turn.",
+        "wikitext": "Gain a card costing up to 4 Coins, then cards cost 1 Coin less this turn."
+    },
+    "Invest": {
+        "description": "Exile an Action card from the Supply. While it's in Exile, when another player gains or Invests in a copy of it, +2 Cards.",
+        "extra": "It only matters if the card you Exile is an Action, not if the whole pile is.<n>While the card is Exiled, you draw 2 cards each time another player gains a copy of it, or uses Invest to Exile a copy of it.<n>This is not optional.<n>This is cumulative; if you Invest twice in the same card, you will get +4 Cards each time someone else gains a copy or Invests in it.<n>If the game has another way to Exile cards, keep the Invested ones separate from the other ones; for example, you can put them half under the mat.<n>Those other Exiled cards were not Invested and do not draw you cards.<n>Cards Exiled with Invest can be discarded from the mat in the normal way, by gaining another copy of the card; then you will no longer draw cards for players gaining/Investing in them.",
+        "name": "Invest",
+        "raw_wikitext": "Exile an Action card from the Supply. While it's in Exile, when another player gains or Invests in a copy of it, '''+2&nbsp;Cards'''.",
+        "wikitext": "Exile an Action card from the Supply. While it's in Exile, when another player gains or Invests in a copy of it, <b>+2&nbsp;Cards</b>."
+    },
+    "Investment": {
+        "description": "Trash a card from your hand.<n>Choose one: +1 Coin; or trash this to reveal your hand for +1 <VP> per differently named Treasure there.",
+        "extra": "You trash a card no matter what; it's okay if Investment was your last card in hand, you just fail to trash a card then. Then you choose either to get +1 Coin or to trash Investment. If you trash it, you reveal your hand and get +1 <VP> per differently named Treasure there; for example if you reveal two Coppers and a Silver, you get +2 <VP>. You can still play the revealed Treasures after resolving Investment. If you play the same Investment twice (e.g. with Crown) and trash it on the first play for <VP>, then you can't trash it on the second play for <VP>.",
+        "name": "Investment",
+        "raw_wikitext": "Trash a card from your hand. Choose one: {{Costplus|1}}; or trash this to reveal your hand for {{VP|'''+1'''}} per differently named Treasure there.",
+        "wikitext": "Trash a card from your hand. Choose one: +1 Coin; or trash this to reveal your hand for {{VP|<b>+1</b>}} per differently named Treasure there."
+    },
+    "Ironmonger": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top card of your deck; you may discard it. Either way, if it is an…<n>Action card, +1 Action<n>Treasure card, +1 Coin<n>Victory card, +1 Card",
+        "extra": "First you draw a card, then you reveal the top card of your deck, then you either discard that card or put it back on top of your deck. Then you get bonuses based on the types of the card you revealed. A card with 2 types gives you both bonuses; for example, if you revealed Harem (from Intrigue), you would both draw a card and get +1 Coins.",
+        "name": "Ironmonger",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck; you may discard it. Either way, if it is an&hellip;</p>Action card, '''+1&nbsp;Action'''<br>Treasure card, {{Costplus|1}}<br>Victory card, '''+1&nbsp;Card'''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck; you may discard it. Either way, if it is an&hellip;<n>Action card, <b>+1&nbsp;Action</b><br>Treasure card, +1 Coin<br>Victory card, <b>+1&nbsp;Card</b>"
+    },
+    "Ironworks": {
+        "description": "Gain a card costing up to 4 Coins. If it is an...<n>Action card, +1 Action.<n>Treasure card, +1 Coin.<n>Victory card, +1 Card.",
+        "extra": "The card you gain must be from the Supply and is put into your discard pile. You get a bonus depending on what type of card you gained. A card with 2 types gives you both bonuses; if you use Ironworks to gain a Great Hall, you will then draw a card (because Great Hall is a Victory card) and may play another Action (because Great Hall is an Action card). Costs of cards are affected by Bridge. [You cannot gain a card with Potion in the cost with Ironworks.]",
+        "name": "Ironworks",
+        "raw_wikitext": "<p>Gain a card costing up to {{Cost|4}}.<br>If the gained card is an&hellip;</p>Action card, '''+1&nbsp;Action'''<br>Treasure card, {{Costplus|1}}<br>Victory card, '''+1&nbsp;Card'''",
+        "wikitext": "Gain a card costing up to 4 Coins.<br>If the gained card is an&hellip;<n>Action card, <b>+1&nbsp;Action</b><br>Treasure card, +1 Coin<br>Victory card, <b>+1&nbsp;Card</b>"
+    },
+    "Island": {
+        "description": "Set aside this and another card from your hand. Return them to your deck at the end of the game.<line>2 <*VP*>",
+        "extra": "When you first take this card, take an Island player mat. Island is both an Action card and a Victory card. Use 8 Islands in a 2 player game, 12 Islands in a 3+ player game. Island and the card set aside with it are set aside face up on the Island player mat provided. They should not be shuffled back into your deck when you shuffle your discard pile. They are returned to your deck at the end of the game in order to calculate total victory points. Island is worth 2 VP. If you have no other cards in hand when you play Island, just set Island aside by itself. If you Throne Room an Island, set aside the Island and a card from your hand, then set aside another card from your hand. You may look through the cards on your Island playing mat and other players may ask to see them as well.",
+        "name": "Island",
+        "raw_wikitext": "Put this and a card from your hand onto your Island mat.{{Divline}}{{VP|2|l}}",
+        "wikitext": "Put this and a card from your hand onto your Island mat.<line>2 <*VP*>"
+    },
+    "Island Folk": {
+        "description": "At the end of your turn, if the previous turn wasn't yours, you may spend 5 Favors to take another turn.",
+        "extra": "",
+        "name": "Island Folk",
+        "raw_wikitext": "At the end of your turn, you may spend '''5&nbsp;Favors''' to take an extra turn after this one (but not a 3rd turn in a row).",
+        "wikitext": "At the end of your turn, you may spend <b>5&nbsp;Favors</b> to take an extra turn after this one (but not a 3rd turn in a row)."
+    },
+    "Jack of All Trades": {
+        "description": "Gain a Silver.<n>Look at the top card of your deck; discard it or put it back.<n>Draw until you have 5 cards in hand.<n>You may trash a card from your hand that is not a Treasure.",
+        "extra": "This card does four separate things, in the order listed; you do all of them (the last one is optional). First, gain a Silver from the Supply, putting it into your discard pile. If there are no Silvers left in the Supply, you do not gain one. Second, look at the top card of your deck, and either discard it or put it back on top. If there are no cards left in your deck, shuffle your discard pile to get a card to look at (this will shuffle in the Silver you just gained). If there are still no cards, you do not look at one. Third, draw cards until you have at least five cards in hand. If you already have five or more cards in hand, you do not draw any cards. If there are not enough cards left to draw between your deck and discard pile, just draw what you can. Fourth, you may trash a card from your hand that is not a Treasure card. Cards with two types, one of which is Treasure, are Treasures.",
+        "name": "Jack of All Trades",
+        "raw_wikitext": "Gain a Silver. Look at the top card of your deck; you may discard it. Draw until you have 5&nbsp;cards in hand. You may trash a non-Treasure card from your hand.",
+        "wikitext": "Gain a Silver. Look at the top card of your deck; you may discard it. Draw until you have 5&nbsp;cards in hand. You may trash a non-Treasure card from your hand."
+    },
+    "Jester": {
+        "description": "+2 Coins<n>Each other player discards the top card of his deck. If it's a Victory card he gains a Curse. Otherwise he gains a copy of the discarded card or you do, your choice.",
+        "extra": "Each player with no cards in his deck shuffles his discard pile in order to get a card to discard. If he still has no cards, he does not discard one. For each player who discarded a card, if it is a Victory card, he gains a Curse, and otherwise, you choose: either that player gains a copy of the card, or you do. The gained copies and Curses come from the Supply and are put into the discard piles of the players who gain them. If a card is revealed for which there are no copies in the Supply, no one gains a copy of it. This Attack hits other players in turn order, which can matter when some piles are low. A card with multiple types, one of which is Victory (such as Nobles from Intrigue) is a Victory card.",
+        "name": "Jester",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player discards the top card of their deck. If it's a Victory card they gain a Curse; otherwise they gain a copy of the discarded card or you do, your choice.</p>",
+        "wikitext": "+2 Coins<n>Each other player discards the top card of their deck. If it's a Victory card they gain a Curse; otherwise they gain a copy of the discarded card or you do, your choice."
+    },
+    "Jewelled Egg": {
+        "description": "1 <*COIN*><br><br>+1 Buy<line>When you trash this, gain a Loot.",
+        "extra": "The player trashing Jewelled Egg gets the Loot, regardless of which player played the card that caused them to trash it.",
+        "name": "Jewelled Egg",
+        "raw_wikitext": "{{Cost|1|l}}<br>'''+1 Buy'''{{Divline}}When you trash this, gain a Loot.",
+        "wikitext": "1 <*COIN*><br><b>+1 Buy</b><line>When you trash this, gain a Loot."
+    },
+    "Jewels": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>At the start of your next turn, put this on the bottom of your deck.",
+        "extra": "When you play this, you get +3 Coin and +1 Buy, and at the start of your next turn, put this on the bottom of your deck.",
+        "name": "Jewels",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>At the start of your next turn, put this on the bottom of your deck.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>At the start of your next turn, put this on the bottom of your deck."
+    },
+    "Journey": {
+        "description": "Once per turn: If the previous turn wasn't yours, you don't discard cards from play in Clean-up this turn, and take an extra turn after this one.",
+        "extra": "You can only buy this once per turn. When you do, if the previous turn was not yours - if it was another player's turn before this turn - you don't discard cards from play this turn, and you take another turn after this turn ends. You still discard your hand.<br>The extra turn is completely normal except that it doesn't count for the tiebreaker.<br>The cards left in play don't do anything special on the extra turn; a Copper left in play doesn't make 1 Coin on the extra turn and so on.<br>Cards with \"while this is in play\" abilities can continue to function, and the cards are in play for things that care about that, such as Swamp Shacks; otherwise, the cards being in play just means you won't draw them that turn.",
+        "name": "Journey",
+        "raw_wikitext": "You don't discard cards from play in Clean-up this turn. Take an extra turn after this one (but not a 3rd turn in a row).",
+        "wikitext": "You don't discard cards from play in Clean-up this turn. Take an extra turn after this one (but not a 3rd turn in a row)."
+    },
+    "Journeyman": {
+        "description": "Name a card. Reveal cards from the top of your deck until you reveal 3 cards that are not the named card. Put those cards into your hand and discard the rest.",
+        "extra": "This draws you three cards that are not a particular card. First name a card. It does not have to be a card being used this game. Then reveal cards from the top of your deck until you have revealed three cards that are not the named card. If you run out of cards without finding three, shuffle your discard pile into your deck and continue. If you still cannot find three, stop. Put the cards you found that were not the named card into your hand and discard the rest.",
+        "name": "Journeyman",
+        "raw_wikitext": "Name a card. Reveal cards from your deck until you reveal 3&nbsp;cards without that name. Put those cards into your hand and discard the rest.",
+        "wikitext": "Name a card. Reveal cards from your deck until you reveal 3&nbsp;cards without that name. Put those cards into your hand and discard the rest."
+    },
+    "Joust": {
+        "description": "+1 Card<br>+1 Action<br>+1 coin<br>You may set aside a Province from your hand to gain any Reward to your hand. Discard the Province in Clean-up.",
+        "extra": "Use one copy of each Reward for games with 2 players, and two copies of each Reward for games with 3-6 players. With 3 or more players, it's okay to gain a Reward you already have a copy of. To gain a Reward you have to set aside a Province from your hand, discarding that Province in Clean-up with your other cards. If all Rewards have been claimed, you can still set aside a Province, but this won't do anything special for you. Rewards are not in the Supply, and can only be gained via playing Joust.",
+        "name": "Joust",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>You may set aside a Province from your hand to gain any Reward to your hand. Discard the Province in Clean-up.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>You may set aside a Province from your hand to gain any Reward to your hand. Discard the Province in Clean-up."
+    },
+    "Joust and Rewards": {
+        "description": "+1 Card<br>+1 Action<br>+1 coin<br>You may set aside a Province from your hand to gain any Reward to your hand. Discard the Province in Clean-up.",
+        "extra": " Use one copy of each Reward for games with 2 players, and two copies of each Reward for games with 3-6 players. With 3 or more players, it's okay to gain a Reward you already have a copy of. To gain a Reward you have to set aside a Province from your hand, discarding that Province in Clean-up with your other cards. If all Rewards have been claimed, you can still set aside a Province, but this won't do anything special for you. Rewards are not in the Supply, and can only be gained via playing Joust.\nThere are two each of six rewards: Coronet, Courser, Demesne, Housecarl, Huge Turnip, Renown.<br>• These are cards which are never part of the Supply. If the Rewards run out, that does not count towards the game end condition.<br>• The Rewards may not be bought, or gained via cards like Horn of Plenty; only Joust can gain them from their pile. They can be gained from other places normally; for example Lurker from Intrigue can gain some of them from the trash.<br>• Use all 12 Rewards with 3 or more players; use just one of each with 2 players. With 3 or more players, a single player can get two of the same Reward.<br>• Trashed Rewards go to the trash pile, like other cards; they do not return to the Rewards pile.<br>• If using the promotional card Black Market, do not put Rewards into the Black Market deck. ",
+        "name": "Joust and Rewards"
+    },
+    "Junk Dealer": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>Trash a card from your hand.",
+        "extra": "You have to trash a card from your hand if you can. You draw before trashing.",
+        "name": "Junk Dealer",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>Trash a card from your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>Trash a card from your hand."
+    },
+    "Keep": {
+        "description": "When scoring, 5 <VP> per differently named Treasure you have, that you have more copies of than each other player, or tied for most.",
+        "extra": "This applies to each different Treasure being used in the game.<n>If all players have the same number of copies of a Treasure, they all get the 5 <VP> for that Treasure.",
+        "name": "Keep",
+        "raw_wikitext": "When scoring, {{VP|'''5'''}} per differently named Treasure you have, that you have more copies of than each other player, or tied for most.",
+        "wikitext": "When scoring, 5 <VP> per differently named Treasure you have, that you have more copies of than each other player, or tied for most."
+    },
+    "Key": {
+        "description": "At the start of your turn, +1 Coin.",
+        "extra": "Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Key",
+        "raw_wikitext": "At the start of your turn, {{Costplus|1}}.",
+        "wikitext": "At the start of your turn, +1 Coin."
+    },
+    "Kiln": {
+        "description": "+2 Coin<br>The next time you play a card this turn, you may first gain a copy of it.",
+        "extra": "Kiln can gain any type of card, as long as the card is played directly after Kiln.<n>It can only gain cards from the Supply.<n>You (optionally) gain a copy of the card before following the instructions on the card.<n>If the card is an Attack and other players want to use cards like Moat, you gain the card before they choose to use Moat or not.<n>If you Throne Room a Kiln, you will play Kiln, play Kiln again, first gaining a Kiln (optionally), and then can still gain a copy of the next card you play after that.<n>If the next card you play is an Action and you use a Way for it, that has no special interaction with Kiln; you still may optionally gain a copy of that card.",
+        "name": "Kiln",
+        "raw_wikitext": "{{Costplus|2}}<p>The next time you play a card this turn, you may first gain a copy of it.</p>",
+        "wikitext": "+2 Coins<n>The next time you play a card this turn, you may first gain a copy of it."
+    },
+    "Kind Emperor": {
+        "description": "At the start of your turn, and when you remove the last {{Sun}}: Gain an Action to your hand.",
+        "name": "Kind Emperor",
+        "raw_wikitext": "At the start of your turn, and when you remove the last {{Sun}}: Gain an Action to your hand."
+    },
+    "King's Cache": {
+        "description": "You may play a Treasure from your hand 3 times.",
+        "extra": "If you King's Cache a King's Cache, you will play three more Treasures three times each.<br>If you King's Cache a Treasure-Duration card, King's Cache will stay in play as long as that card does.",
+        "name": "King's Cache",
+        "raw_wikitext": "You may play a Treasure from your hand 3&nbsp;times.",
+        "wikitext": "You may play a Treasure from your hand 3&nbsp;times."
+    },
+    "King's Castle": {
+        "description": "Worth 2 <VP> per Castle you have.",
+        "name": "King's Castle",
+        "raw_wikitext": "Worth {{VP|'''2'''}} per Castle you have."
+    },
+    "King's Court": {
+        "description": "You may choose an Action card in your hand. Play it three times.",
+        "extra": "This is similar to Throne Room (from Dominion), but plays the Action three times rather than twice. You pick another Action card in your hand, play it, play it again, and play it a third time. This does not use up any extra Actions you were allowed to play due to cards like Worker's Village - King's Court itself uses up one Action and that is it. You cannot play any other cards in between resolving the King's Court-ed Action card multiple times, unless that Action card specifically tells you to (such as King's Court itself does). If you King's Court a King's Court, you will play three different Actions after that, playing each one of them three times - you do not play one Action nine times. If you King's Court a card that gives you +1 Action, such as Grand Market, you will end up with 3 Actions left afterwards.",
+        "name": "King's Court",
+        "raw_wikitext": "You may play an Action card from your hand three times.",
+        "wikitext": "You may play an Action card from your hand three times."
+    },
+    "Kintsugi": {
+        "description": "Trash a card from your hand. If you've gained a Gold this game, gain a card costing up to 2 Coins more than the trashed card.",
+        "name": "Kintsugi",
+        "raw_wikitext": "Trash a card from your hand. If you've gained a Gold this game, gain a card costing up to {{Cost|2}} more than the trashed card."
+    },
+    "Kitsune": {
+        "description": "+1 SunToken<br><br>Choose two different options: +2 Actions; +2 Coins; each other player gains a Curse; gain a Silver.",
+        "extra": "First the +1 SunToken happens, which may trigger a Prophecy; then you choose two different options, and do them in the order listed.",
+        "name": "Kitsune",
+        "raw_wikitext": "{{Sunplus}}<p>Choose two different options: '''+2&nbsp;Actions'''; {{Costplus|2}}; each other player gains a Curse; gain a Silver.</p>",
+        "wikitext": "{{Sunplus}}<n>Choose two different options: <b>+2&nbsp;Actions</b>; +2 Coins; each other player gains a Curse; gain a Silver."
+    },
+    "Knights": {
+        "description": "Shuffle the Knights pile before each game with it. Keep it face down except for the top card, which is the only one that can be bought or gained.<line>Each card has the same trashing attack ability - \"Each other player reveals the top 2 cards of their deck, trashes one of them costing from 3 Coin to 6 Coin, and discards the rest. If a Knight is trashed by this, trash this card\" - and a unique second ability:<left>5 Coin<u>Dame Anna</u>: You may trash up to 2 cards from your hand.</left><left>5 Coin<u>Dame Josephine</u>: 2 <VP></left><left>5 Coin<u>Dame Molly</u>: +2 Actions</left><left>5 Coin<u>Dame Natalie</u>: You may gain a card costing up to 3 Coin.</left><left>5 Coin<u>Dame Sylvia</u>: +2 Coin</left><left>5 Coin<u>Sir Bailey</u>: +1 Card +1 Action</left><left>5 Coin<u>Sir Destry </u>: +2 Cards</left><left>4 Coin<u>Sir Martin </u>: +2 Buys</left><left>5 Coin<u>Sir Michael</u>: Each other player discards down to 3 cards in hand.</left><left>5 Coin<u>Sir Vander</u>: When you trash this, gain a Gold.</left>",
+        "extra": "This is a pile with 10 differently-named unique Knights with a single randomizer card. There is the same basic ability on each card, but also another ability unique to that card in the pile, and they all have different names. Follow the rules on Knights in order from top to bottom; Sir Michael causes players to discard before it trashes cards. The ability they have in common is, each other player reveals the top two cards of their deck, trashes one of them that they choose that costs from 3 Coin to 6 Coin, and discards the rest; then, if a Knight was trashed, you trash the Knight you played that caused this trashing. Resolve this ability in turn order, starting with the player to your left. Cards with Potion (from Alchemy) or Debt (from Empires) in the cost do not cost from 3 Coin to 6 Coin. The player losing a card only gets a choice if both cards revealed cost from 3 Coin to 6 Coin. If they both do and one is a Knight but the player picks the other card, that will not cause the played Knight to be trashed. When Sir Martin is the top card of the pile, it can be gained with an Armory and so on. If Sir Vander is trashed, you gain a Gold; this happens whether it is trashed on your turn or someone else's. The player who had Sir Vander is the one who gains the Gold, regardless of who played the card that trashed it. The Gold from Sir Vander, and the card gained for Dame Natalie, comes from the Supply and is put into your discard pile. When playing Dame Anna, you may choose to trash zero, one, or two cards from your hand. Dame Josephine is also a Victory card, worth 2 <VP> at the end of the game. The Knight pile is not a Victory pile, and does not get a counter for Trade Route (from Prosperity) even if Dame Josephine starts on top.  If you choose to use the Knights with Black Market (a promotional card), put a Knight directly into the Black Market deck, rather than using the randomizer card. Sir Martin only costs 4 Coins, though the other Knights all cost 5 Coins.",
+        "name": "Knights",
+        "notes": [
+            "Dame / Sir Cards"
+        ]
+    },
+    "Laboratory": {
+        "description": "+2 Cards<br>+1 Action.",
+        "extra": "Draw two cards. You may play another Action card during your Action phase.",
+        "name": "Laboratory",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b>"
+    },
+    "Labyrinth": {
+        "description": "When you gain a 2nd card in one of your turns, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player.",
+        "extra": "This can only happen once per turn per player.<n>For example if you gain 4 cards in the same turn, only the second one will come with 2 <VP>.",
+        "name": "Labyrinth",
+        "raw_wikitext": "When you gain a 2nd card in one of your turns, take {{VP|'''2'''}} from here.{{Divline}}Setup: Put {{VP|'''6'''}} here per player.",
+        "wikitext": "When you gain a 2nd card in one of your turns, take 2 <VP> from here.<line>Setup: Put 6 <VP> here per player."
+    },
+    "Lackeys": {
+        "description": "+2 Cards<line>When you gain this, +2 Villagers.",
+        "extra": "Playing this gives +2 Cards; gaining it gives +2 Villagers.",
+        "name": "Lackeys",
+        "raw_wikitext": "'''+2&nbsp;Cards'''{{Divline}}When you gain this, '''+2&nbsp;Villagers'''.",
+        "wikitext": "<b>+2&nbsp;Cards</b><line>When you gain this, <b>+2&nbsp;Villagers</b>."
+    },
+    "Landing Party": {
+        "description": "+2 Cards<br>+2 Actions<br>The next time the first card you play on a turn is a Treasure, put this onto your deck afterwards.",
+        "extra": "Resolve the Treasure before putting Landing Party on your deck.<br>It's okay if the Treasure has more types, including Action (like Spell Scroll).",
+        "name": "Landing Party",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+2&nbsp;Actions'''<p>The next time the first card you play on a turn is a Treasure, put this onto your deck afterwards.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><n>The next time the first card you play on a turn is a Treasure, put this onto your deck afterwards."
+    },
+    "Lantern": {
+        "description": "Border Guards you play reveal 3 cards and discard 2. (It takes all 3 being Actions to take the Horn.)",
+        "extra": "Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Lantern",
+        "raw_wikitext": "Border Guards you play reveal 3&nbsp;cards and discard&nbsp;2. (It takes all 3&nbsp;being Actions to take the Horn.)",
+        "wikitext": "Border Guards you play reveal 3&nbsp;cards and discard&nbsp;2. (It takes all 3&nbsp;being Actions to take the Horn.)"
+    },
+    "Launch": {
+        "description": "Once per turn: Return to your Action phase.<br>+1 Card, +1 Action, and +1 Buy.",
+        "extra": "This ends your Buy phase and returns you to your Action phase.<br>This does not cause \"start of turn\" abilities to repeat; however when your Buy phase happens again after that, \"start of Buy phase\" abilities can repeat.",
+        "name": "Launch",
+        "raw_wikitext": "Once per turn: Return to your Action phase. '''+1&nbsp;Card''', '''+1&nbsp;Action''', and '''+1&nbsp;Buy'''.",
+        "wikitext": "Once per turn: Return to your Action phase. <b>+1&nbsp;Card</b>, <b>+1&nbsp;Action</b>, and <b>+1&nbsp;Buy</b>."
+    },
+    "League of Bankers": {
+        "description": "At the start of your Buy phase, +1 Coin per 4 Favors you have (round down).",
+        "extra": "",
+        "name": "League of Bankers",
+        "raw_wikitext": "At the start of your Buy phase, {{Costplus|1}} per '''4&nbsp;Favors''' you have (round down).",
+        "wikitext": "At the start of your Buy phase, +1 Coin per <b>4&nbsp;Favors</b> you have (round down)."
+    },
+    "League of Shopkeepers": {
+        "description": "After playing a Liaison, if you have 5 or more Favors, +1 Coin, and if 10 or more, +1 Action and +1 Buy.",
+        "extra": "",
+        "name": "League of Shopkeepers",
+        "raw_wikitext": "After playing a Liaison, if you have '''5''' or more '''Favors''', {{Costplus|1}}, and if '''10''' or more, '''+1&nbsp;Action''' and '''+1&nbsp;Buy'''.",
+        "wikitext": "After playing a Liaison, if you have <b>5</b> or more <b>Favors</b>, +1 Coin, and if <b>10</b> or more, <b>+1&nbsp;Action</b> and <b>+1&nbsp;Buy</b>."
+    },
+    "Legionary": {
+        "description": "+3 Coin<n>You may reveal a Gold from your hand. If you do, each other player discards down to 2 cards in hand, then draws a card.",
+        "extra": "Players wishing to respond to the Attack (e.g. with Moat) must do so before you choose whether or not to reveal a Gold.",
+        "name": "Legionary",
+        "raw_wikitext": "{{Costplus|3}}<p>You may reveal a Gold from your hand. If you do, each other player discards down to 2&nbsp;cards in hand, then draws a card.</p>",
+        "wikitext": "+3 Coins<n>You may reveal a Gold from your hand. If you do, each other player discards down to 2&nbsp;cards in hand, then draws a card."
+    },
+    "Leprechaun": {
+        "description": "Gain a Gold. If you have exactly 7 cards in play, gain a Wish from its pile. Otherwise, receive a Hex.",
+        "extra": "Cards you have in play normally include Leprechaun itself, other cards you have played this turn, and sometimes Duration cards from previous turns. Cards that were in play but no longer are - e.g. a Pixie you trashed - do not count.",
+        "name": "Leprechaun",
+        "raw_wikitext": "Gain a Gold. If you have exactly 7&nbsp;cards in play, gain a Wish. Otherwise, receive a Hex.",
+        "wikitext": "Gain a Gold. If you have exactly 7&nbsp;cards in play, gain a Wish. Otherwise, receive a Hex."
+    },
+    "Library": {
+        "description": "Draw until you have 7 cards in hand. You may set aside any Action cards drawn this way, as you draw them; discard the set aside cards after you finish drawing.",
+        "extra": "If you have to shuffle in the middle, the set-aside cards are not shuffled into the new Deck. They will be discarded when you have finished drawing cards. If you run out of cards even after shuffling, you just get however many there were. You are not obligated to set aside Actions - you just have the option to do so. If you have 7 or more cards in hand after you play the Library, you don't draw any cards.",
+        "name": "Library",
+        "raw_wikitext": "Draw until you have 7&nbsp;cards in hand, skipping any Action cards you choose to; set those aside, discarding them afterwards.",
+        "wikitext": "Draw until you have 7&nbsp;cards in hand, skipping any Action cards you choose to; set those aside, discarding them afterwards."
+    },
+    "Lich": {
+        "description": "+6 Cards<br>+2 Actions<n>Skip a turn.<line>When you trash this, discard it and gain a cheaper card from the trash.",
+        "extra": "Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual.<n>You can skip an extra turn, like one from Voyage.<n>Skipped turns still count for the tiebreaker however they would have if taken.<n>If you play multiple Liches you will skip multiple turns.<n>When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities.<n>Gaining a cheaper card is mandatory if possible.",
+        "name": "Lich",
+        "raw_wikitext": "'''+6&nbsp;Cards'''<br>'''+2&nbsp;Actions'''<p>Skip a turn.</p>{{Divline}}When you trash this, discard it and gain a cheaper card from the trash.",
+        "wikitext": "<b>+6&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><n>Skip a turn.<n><line>When you trash this, discard it and gain a cheaper card from the trash."
+    },
+    "Lighthouse": {
+        "description": "+1 Action<br>+1 Coin<br>At the start of your next turn, +1 Coin. Until then, when another player plays an Attack card, it doesn't affect you.",
+        "extra": "You get an action and a coin this turn, but only a coin next turn. Attack cards played by other players don't affect you, even if you want them to. You could reveal Secret Chamber in order to draw 2 cards and put 2 cards from your hand back on top of your deck when an Attack card is played, and you will still not suffer from the Attack card. You do still gain the benefits (like +Cards) of Attack cards you play on your turn. Lighthouse is discarded during the Cleanup phase of your next turn.",
+        "name": "Lighthouse",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>At the start of your next turn, {{Costplus|1}}. Until then, when another player plays an Attack card, it doesn't affect you.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+1 Coin<n>At the start of your next turn, +1 Coin. Until then, when another player plays an Attack card, it doesn't affect you."
+    },
+    "Litter": {
+        "description": "+2 Cards<br>+2 Actions<br>+1 Debt",
+        "extra": "This works even if you already had Debt; see the Debt section.",
+        "name": "Litter",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+2&nbsp;Actions'''<br>{{Debtplus|1}}",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><br>{{Debtplus|1}}"
+    },
+    "Livery": {
+        "description": "+3 Coin<br>This turn, when you gain a card costing 4 Coin or more, gain a Horse.",
+        "extra": "This is cumulative; for example, if you use Mastermind to play a Livery three times, then each card you gain that turn costing 4 Coin or more will come with three Horses.<n>Livery works on cards gained via buying them, and cards gained other ways.",
+        "name": "Livery",
+        "raw_wikitext": "{{Costplus|3}}<p>This turn, when you gain a card costing {{Cost|4}} or more, gain a Horse.</p>",
+        "wikitext": "+3 Coins<n>This turn, when you gain a card costing 4 Coins or more, gain a Horse."
+    },
+    "Loan": {
+        "description": "1 <*COIN*><n>Reveal cards from your deck until you reveal a Treasure. Discard it or trash it. Discard the other cards.",
+        "extra": "This is a Treasure worth 1 coin, like Copper. When you play it, you reveal cards from the top of your deck until revealing a Treasure card, and then you decide whether to trash that card or discard it. Then you discard all of the other revealed cards. If you run out of cards before revealing a Treasure, shuffle your discard pile (but not the revealed cards) to get more; if you still do not find a Treasure, just discard all of the revealed cards. Remember that you can play Treasures in any order in the Buy phase and can choose not to play some of your Treasures if you want.",
+        "name": "Loan",
+        "raw_wikitext": "{{Cost|1|l}}<p>Reveal cards from your deck until you reveal a Treasure. Discard it or trash it. Discard the other cards.</p>",
+        "wikitext": "1 <*COIN*><n>Reveal cards from your deck until you reveal a Treasure. Discard it or trash it. Discard the other cards."
+    },
+    "Locusts": {
+        "description": "Trash the top card of your deck. If it's Copper or Estate, gain a Curse. Otherwise, gain a cheaper card that shares a type with it.",
+        "extra": "Types are the words on the bottom banner, like Action and Attack. If there is no cheaper card that shares a type - for example if the card trashed is Curse - the player does not gain anything.",
+        "name": "Locusts",
+        "raw_wikitext": "Trash the top card of your deck. If it's Copper or Estate, gain a Curse. Otherwise, gain a cheaper card that shares a type with it.",
+        "wikitext": "Trash the top card of your deck. If it's Copper or Estate, gain a Curse. Otherwise, gain a cheaper card that shares a type with it."
+    },
+    "Longship": {
+        "description": "+2 Actions<br>At the start of your next turn, +2 Cards.",
+        "extra": "Playing this gives you +2 Actions then, and +2 Cards at the start of your next turn.",
+        "name": "Longship",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>At the start of your next turn, '''+2&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>At the start of your next turn, <b>+2&nbsp;Cards</b>."
+    },
+    "Lookout": {
+        "description": "+1 Action<n>Look at the top 3 cards of your deck. Trash one of them. Discard one of them. Put the other one on top of your deck.",
+        "extra": "If you do not have 3 cards to look at from the top of your deck, look at as many as you can and then shuffle your discard pile to look at the remaining cards. You should look at all 3 cards before deciding which to trash, which card to discard, and which card to put back on top of your deck. If the 3 cards you look at are the last 3 cards in your deck, the card you put back on top of your deck will be the only card left in your deck. If you have less than 3 cards to look at, even after shuffling, then you must follow the instructions on the card in order. If you only have one card to look at, you must trash it. If you have 2 cards to look at, you must trash one and discard one.",
+        "name": "Lookout",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Look at the top 3&nbsp;cards of your deck. Trash one of them. Discard one of them. Put the other one back on top of your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Look at the top 3&nbsp;cards of your deck. Trash one of them. Discard one of them. Put the other one back on top of your deck."
+    },
+    "Loot": {
+        "description": "<left><u>Amphora</u>: Either now or at the start of your next turn: +1 Buy and +3 Coin.</left><left><u>Doubloons</u>: 3 Coin; When you gain this, gain a Gold.</left><left><u>Endless Chalice</u>: Now and at the start of each of your turns for the rest of the game: 1 Coin; +1 Buy</left><left><u>Figurehead</u>: 3 Coin; At the start of your next turn, +2 Cards.</left><left><u>Hammer</u>: 3 Coin; Gain a card costing up to 4 Coin.</left><left><u>Insignia</u>: 3 Coin; This turn, when you gain a card, you may put it onto your deck.</left><left><u>Jewels</u>: 3 Coin; +1 Buy; At the start of your next turn, put this on the bottom of your deck.</left><left><u>Orb</u>: Look through your discard pile. Choose one: Play an Action or Treasure from it; or +1 Buy and +3 Coin.</left><left><u>Prize Goat</u>: 3 Coin; +1 Buy; You may trash a card from your hand.</left><left><u>Puzzle Box</u>3 Coin; +1 Buy; You may set aside a card from your hand face down. Put it into your hand at end of turn.</left><left><u>Sextant</u>: 3 Coin; +1 Buy; Look at the top 5 cards of your deck. Discard any number. Put the rest back in any order.</left><left><u>Shield</u>: 3 Coin; +1 Buy; When another player plays an Attack, you may first reveal this from your hand to be unaffected.</left><left><u>Spell Scroll</u>: Trash this to gain a cheaper card. If it's an Action or Treasure, you may play it.</left><left><u>Staff</u>: 3 Coin; +1 Buy; You may play an Action from your hand.</left><left><u>Sword</u>: 3 Coin; +1 Buy; Each other player discards down to 4 cards in hand.</left>",
+        "extra": "There are 15 Loot cards, with two copies of each. Shuffle them into a face-down pile before the game if any cards refer to Loot.<br>During the game, \"gain a Loot\" means you gain the top card of the Loot pile.<br>When you gain a Loot reveal it to all players. Then put it into your discard pile as usual.<br>Players can't look through the Loot pile during a game.<br>The Loot pile isn't in the Supply; players can't buy or gain from it, except with cards that specifically gain Loot.",
+        "name": "Loot"
+    },
+    "Looting": {
+        "description": "Gain a Loot.",
+        "extra": "You simply gain a Loot.",
+        "name": "Looting",
+        "raw_wikitext": "Gain a Loot.",
+        "wikitext": "Gain a Loot."
+    },
+    "Lost Arts": {
+        "description": "Move your +1 Action token to an Action Supply pile (when you play a card from that pile, you first get +1 Action).",
+        "extra": "When you buy this, you move your +1 Action token to any Action Supply pile. This token gives you +1 Action whenever you play a card from that pile; see the Tokens section.",
+        "name": "Lost Arts",
+        "raw_wikitext": "Move your +1&nbsp;Action token to an Action Supply pile. (When you play a card from that pile, you first get '''+1&nbsp;Action'''.)",
+        "wikitext": "Move your +1&nbsp;Action token to an Action Supply pile. (When you play a card from that pile, you first get <b>+1&nbsp;Action</b>.)"
+    },
+    "Lost City": {
+        "description": "+2 Cards<br>+2 Actions<line>When you gain this, each other player draws a card.",
+        "extra": "When you gain this, each other player draws a card. This applies whether you bought it or gained it some other way.",
+        "name": "Lost City",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, each other player draws a card.",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+2&nbsp;Actions</b><line>When you gain this, each other player draws a card."
+    },
+    "Lost in the Woods": {
+        "description": "At the start of your turn, you may discard a card to receive a Boon.",
+        "extra": "The two sides are the same; use either. Using the ability is optional. Lost in the Woods stays in front of you turn after turn, until another players takes it with a Fool.",
+        "name": "Lost in the Woods",
+        "raw_wikitext": "At the start of your turn, you may discard a card to receive a Boon.",
+        "wikitext": "At the start of your turn, you may discard a card to receive a Boon."
+    },
+    "Lucky Coin": {
+        "description": "1 <*COIN*><br><br>When you play this, gain a Silver.",
+        "extra": "You can choose not to play Lucky Coin, and thus not gain a Silver.",
+        "name": "Lucky Coin",
+        "raw_wikitext": "{{Cost|1|l}}<p>Gain a Silver.</p>",
+        "wikitext": "1 <*COIN*><n>Gain a Silver."
+    },
+    "Lurker": {
+        "description": "+1 Action<n>Choose one: Trash an Action card from the Supply; or gain an Action card from the trash.",
+        "extra": "The card trashed or gained has to be an Action card, but can have other types too. For example Lurker can trash Nobles from the Supply and can gain Nobles from the trash.<n>When gaining a card with Lurker, put the gained card into your discard pile.<n>When you trash a card from the supply that has a special effect when trashed, the on-trash effect activates. However, trashing from the supply does not allow you to react with Market Square.",
+        "name": "Lurker",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Choose one: Trash an Action card from the Supply; or gain an Action card from the trash.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Choose one: Trash an Action card from the Supply; or gain an Action card from the trash."
+    },
+    "Madman": {
+        "description": "+2 Actions<n>Return this to the Madman pile. If you do, +1 Card per card in your hand.<n><i>(This card is not in the supply.)</i>",
+        "extra": "This card is not in the Supply; it can only be obtained via Hermit. When you play it, you get +2 Actions, return it to the Madman pile if you can (this is not optional), and if you did return it, you draw a card per card in your hand. For example if you had three cards in hand after playing Madman, you would draw three cards. Normally, nothing will prevent you from returning Madman to the Madman pile, but you may fail to due to playing Madman twice via Procession, Throne Room (from Dominion), or King's Court (from Prosperity). So, for example, if you Procession a Madman, you will get +2 Actions, return Madman to the Madman pile, draw a card per card in your hand, get another +2 Actions, fail to return Madman and so not draw cards the second time, fail to trash Madman, and then gain an Action card costing exactly 1 Coin if you can.",
+        "name": "Madman",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Return this to the Madman pile. If you do, '''+1&nbsp;Card''' per card in your hand.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Return this to the Madman pile. If you do, <b>+1&nbsp;Card</b> per card in your hand.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Maelstrom": {
+        "description": "Trash 3 cards from your hand. Each other player with 5 or more cards in hand trashes one of them.",
+        "extra": "This isn't optional for the other players; they must trash a card if they have 5 or more cards in hand.",
+        "name": "Maelstrom",
+        "raw_wikitext": "Trash 3&nbsp;cards from your hand. Each other player with 5&nbsp;or more cards in hand trashes one of them.",
+        "wikitext": "Trash 3&nbsp;cards from your hand. Each other player with 5&nbsp;or more cards in hand trashes one of them."
+    },
+    "Magic Lamp": {
+        "description": "1 <*COIN*><br><br>When you play this, if there are at least 6 cards that you have exactly 1 copy of in play, trash this. If you do, gain 3 Wishes from their pile.",
+        "extra": "Magic Lamp itself counts as one of the six cards. A card you have two or more copies of in play does not count; you have to have exactly one copy in play to count a card. You can play more Treasures after trashing Magic Lamp, and still got 1 Coin from it for that turn.",
+        "name": "Magic Lamp",
+        "raw_wikitext": "{{Cost|1|l}}<p>If there are at least 6&nbsp;cards that you have exactly 1&nbsp;copy of in play (counting this), trash this. If you did, gain 3&nbsp;Wishes.</p>",
+        "wikitext": "1 <*COIN*><n>If there are at least 6&nbsp;cards that you have exactly 1&nbsp;copy of in play (counting this), trash this. If you did, gain 3&nbsp;Wishes."
+    },
+    "Magnate": {
+        "description": "Reveal your hand.<n>+1 Card per Treasure in it.",
+        "extra": "For example, if your hand had two Coppers and a Silver, you'd draw 3 cards.",
+        "name": "Magnate",
+        "raw_wikitext": "Reveal your hand. '''+1&nbsp;Card''' per Treasure in it.",
+        "wikitext": "Reveal your hand. <b>+1&nbsp;Card</b> per Treasure in it."
+    },
+    "Magpie": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top card of your deck. If it's a Treasure, put it into your hand. If it's an Action or Victory card, gain a Magpie.",
+        "extra": "If the top card of your deck is a Treasure, it goes into your hand. If the card is not a Treasure, leave it on top of your deck. If the card is an Action card or Victory card, you gain a Magpie; once the Magpie pile is empty, revealing an Action or Victory card will not get you anything. If you reveal a Harem (from Intrigue), you both put it into your hand and gain a Magpie, since it is both a Treasure and a Victory card.",
+        "name": "Magpie",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck.  If it's a Treasure, put it into your hand. If it's an Action or Victory card, gain a Magpie.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck.  If it's a Treasure, put it into your hand. If it's an Action or Victory card, gain a Magpie."
+    },
+    "Mandarin": {
+        "description": "+3 Coins<br>Put a card from your hand on top of your deck.<line>When you gain this, put all Treasures you have in play on top of your deck in any order.",
+        "extra": "When you play this, you get +3 coins, and put a card from your hand on top of your deck. If you have no cards left in hand, you do not put a card on top of your deck. If there are no cards left in your deck, the card you put on top becomes the only card in your deck. When you gain this, you put all of your Treasures from play on top of your deck in any order. You do not have to show this order to other players. You have to put all of your Treasures on top; you cannot leave some out. You only put Treasures from play on top of your deck, not unplayed Treasures from your hand. This does not stop you from having the coins you got from playing those Treasures; for example, if you have +1 Buy and play four Golds and buy a Mandarin, you put the Golds on top of your deck, and still have 7 coins left to spend. Mandarin puts your played Treasures on your deck whether you gained it due to buying it or gained it some other way, although normally you will only have Treasures in play in your Buy phase.",
+        "name": "Mandarin",
+        "raw_wikitext": "{{Costplus|3}}<p>Put a card from your hand onto your deck.</p>{{Divline}}When you gain this, put all Treasures you have in play onto your deck in any order.",
+        "wikitext": "+3 Coins<n>Put a card from your hand onto your deck.<n><line>When you gain this, put all Treasures you have in play onto your deck in any order."
+    },
+    "Mapmaker": {
+        "description": "Look at the top 4 cards of your deck. Put 2 into your hand and discard the rest.<line>When any player gains a Victory card, you may play this from your hand.",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.<br>You may play this when someone (including you) gains a Victory card due to buying it, or some other way.<br>When you play Mapmaker in response to someone gaining a Victory card, you can immediately play another Mapmaker afterwards - even one you just got via the first Mapmaker.",
+        "name": "Mapmaker",
+        "raw_wikitext": "Look at the top 4&nbsp;cards of your deck. Put 2&nbsp;into your hand and discard the rest.{{Divline}}When any player gains a Victory card, you may play this from your hand.",
+        "wikitext": "Look at the top 4&nbsp;cards of your deck. Put 2&nbsp;into your hand and discard the rest.<line>When any player gains a Victory card, you may play this from your hand."
+    },
+    "Marauder": {
+        "description": "Gain a Spoils from the Spoils pile.<n>Each other player gains a Ruins.",
+        "extra": "First you gain a Spoils. It comes from the Spoils pile, which is not part of the Supply, and is put into your discard pile. If there are no Spoils cards left, you do not get one. Then each other player gains a Ruins. These come from the Ruins pile in the Supply, and are put into discard piles. Go in turn order starting to your left; each player takes the top Ruins, revealing the next one each time. If the Ruins pile runs out, players stop gaining them at that point.",
+        "name": "Marauder",
+        "raw_wikitext": "Gain a Spoils. Each other player gains a Ruins.",
+        "wikitext": "Gain a Spoils. Each other player gains a Ruins."
+    },
+    "March": {
+        "description": "Look through your discard pile. You may play an Action card from it.",
+        "extra": "Normally you cannot look through your discard pile, so you cannot look to see if you want to buy March or not.<n>Once you buy March, you look through your discard pile, and then have the option of playing an Action card from it.<n>This does not use up an Action.",
+        "name": "March",
+        "raw_wikitext": "Look through your discard pile. You may play an Action card from it.",
+        "wikitext": "Look through your discard pile. You may play an Action card from it."
+    },
+    "Marchland": {
+        "description": "Worth 1 <VP> per 3 Victory cards you have (round down).<line>When you gain this, +1 Buy and discard any number of cards for +1 Coin each.",
+        "extra": "Marchland counts itself. Round down; if you have 11 Victory cards, each Marchland is worth 3 <VP>. Use 8 copies of Marchland for games with 2 players, 12 for games with 3 or more players. \"Any number\" includes zero.",
+        "name": "Marchland",
+        "raw_wikitext": "Worth {{VP|1}} per 3&nbsp;Victory cards you have (round down).{{Divline}}When you gain this, '''+1&nbsp;Buy''', and discard any number of cards for {{Costplus|1}} each.",
+        "wikitext": "Worth {{VP|1}} per 3&nbsp;Victory cards you have (round down).<line>When you gain this, <b>+1&nbsp;Buy</b>, and discard any number of cards for +1 Coin each."
+    },
+    "Margrave": {
+        "description": "+3 Cards<br>+1 Buy<br>Each other player draws a card, then discards down to 3 cards in hand.",
+        "extra": "You draw 3 cards and get +1 Buy. Each other player draws a card, then discards down to 3 cards in hand. Drawing a card is not optional for them. A player who only has 3 cards or fewer after drawing does not discard.",
+        "name": "Margrave",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Buy'''<p>Each other player draws a card, then discards down to 3&nbsp;cards in hand.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Buy</b><n>Each other player draws a card, then discards down to 3&nbsp;cards in hand."
+    },
+    "Market": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<br>+1 Coin<n>",
+        "extra": "Draw a card. You may play another Action card during your Actions phase. During your Buy phase, you may buy an additional card from the supply, and add one coin to the total value of the Treasure cards played.",
+        "name": "Market",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<br>{{Costplus|1}}",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><br>+1 Coin"
+    },
+    "Market Square": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<line>When one of your cards is trashed, you may discard this from your hand. If you do, gain a Gold.",
+        "extra": "When you play this, you draw a card and get +1 Action and +1 Buy. When one of your cards is trashed, you may discard Market Square from your hand. If you do, you gain a Gold. The Gold comes from the Supply and is put into your discard pile. If there is no Gold left in the Supply, you do not gain one. You may discard multiple Market Squares when a single card of yours is trashed.",
+        "name": "Market Square",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''{{Divline}}When one of your cards is trashed, you may discard this from your hand to gain a Gold.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><line>When one of your cards is trashed, you may discard this from your hand to gain a Gold."
+    },
+    "Market Towns": {
+        "description": "At the start of your Buy phase, you may spend a Favor to play an Action card from your hand. Repeat as desired.",
+        "extra": "",
+        "name": "Market Towns",
+        "raw_wikitext": "At the start of your Buy phase, you may spend a '''Favor''' to play an Action card from your hand. Repeat as desired.",
+        "wikitext": "At the start of your Buy phase, you may spend a <b>Favor</b> to play an Action card from your hand. Repeat as desired."
+    },
+    "Maroon": {
+        "description": "Trash a card from your hand. +2 Cards per type it has (Action, Attack, etc.).",
+        "extra": "Types are the words on the bottom banner of cards - Action, Attack, and so on.",
+        "name": "Maroon",
+        "raw_wikitext": "Trash a card from your hand. '''+2&nbsp;Cards''' per type it has (Action, Attack, etc.).",
+        "wikitext": "Trash a card from your hand. <b>+2&nbsp;Cards</b> per type it has (Action, Attack, etc.)."
+    },
+    "Marquis": {
+        "description": "+1 Buy<n>+1 Card per card in your hand. Discard down to 10 cards in hand.",
+        "extra": "Even if you were unable to draw the full amount, you still discard down to 10 cards in hand afterwards.",
+        "name": "Marquis",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>'''+1&nbsp;Card''' per card in your hand. Discard down to 10&nbsp;cards in hand.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n><b>+1&nbsp;Card</b> per card in your hand. Discard down to 10&nbsp;cards in hand."
+    },
+    "Masquerade": {
+        "description": "+2 Card<n>Each player with any cards in hand passes one to the next such player to their left, at once. Then you may trash a card from your hand.<n>[Each player passes a card in their hand to the player on their left. You may trash a card from your hand.]",
+        "extra": "First you draw 2 cards. Next, each player (all at the same time) chooses a card from his hand and places it face down on the table between him and the player to his left. The player to the left then puts that card into his hand. Cards are passed simultaneously, so you may not look at the card you are receiving until you have chosen a card to pass. Finally, you may trash a card from your hand. Only the player who played Masquerade may trash a card. This is not an Attack and cannot be responded to with Moat or Secret Chamber.",
+        "name": "Masquerade",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each player with any cards in hand passes one to the next such player to their left, at once. Then you may trash a card from your hand.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Each player with any cards in hand passes one to the next such player to their left, at once. Then you may trash a card from your hand."
+    },
+    "Mastermind": {
+        "description": "At the start of your next turn, you may play an Action card from your hand three times.",
+        "extra": "Playing an Action card via this is optional. If you do play one, you resolve the card completely, then play it a second time, then play it a third time, without playing other cards in-between (unless told to by a card).<n>Playing these Actions does not use up Action plays. For example, if you Mastermind a Bounty Hunter, you will get +3 Actions total, and be able to play 4 Action cards after that - your normal one, plus 3 more for the +3 Actions.<n>If a Mastermind plays a Duration card, the Mastermind stays in play as long as the Duration card does.<n>If a Mastermind plays another Mastermind, both will stay in play, and the turn after that you can play three different Action cards from your hand three times each.<n>If you Mastermind a Horse, you will get +2 Cards and +1 Action, return the Horse to its pile, get +2 Cards and +1 Action, fail to return the Horse since you already did, and get +2 Cards and +1 Action a third time and fail to return the Horse again.",
+        "name": "Mastermind",
+        "raw_wikitext": "At the start of your next turn, you may play an Action card from your hand three times.",
+        "wikitext": "At the start of your next turn, you may play an Action card from your hand three times."
+    },
+    "Masterpiece": {
+        "description": "1 <*COIN*><line>When you buy this, you may overpay for it. If you do, gain a Silver per 1 Coin you overpaid.",
+        "extra": "This is a Treasure worth 1 Coin, like Copper. When you buy it, you gain a Silver for each extra 1 Coin you pay over the cost. For example, if you buy a Masterpiece for 6 Coins, you gain three Silvers.",
+        "name": "Masterpiece",
+        "raw_wikitext": "{{Cost|1|l}}{{Divline}}Overpay: Gain a Silver per {{Cost|1}} overpaid.",
+        "wikitext": "1 <*COIN*><line>Overpay: Gain a Silver per 1 Coin overpaid."
+    },
+    "Menagerie": {
+        "description": "+1 Action<n>Reveal your hand.<n>If there are no duplicate cards in it, +3 Cards.<n>Otherwise, +1 Card.",
+        "extra": "If there are any two or more cards in your hand with the same name, you only draw one card; if there are no matches, you draw three cards. Only the card names matter for this; Copper and Silver are different cards for example, despite both being Treasures. If you have no cards in hand at all after playing Menagerie, then you have no matching cards, and so get +3 Cards.",
+        "name": "Menagerie",
+        "raw_wikitext": "'''+1 Action'''<p>Reveal your hand. If the revealed cards all have different names, '''+3&nbsp;Cards'''. Otherwise, '''+1&nbsp;Card'''.</p>",
+        "wikitext": "<b>+1 Action</b><n>Reveal your hand. If the revealed cards all have different names, <b>+3&nbsp;Cards</b>. Otherwise, <b>+1&nbsp;Card</b>."
+    },
+    "Mercenary": {
+        "description": "You may trash 2 cards from your hand.<n>If you do, +2 Cards, +2 Coins, and each other player discards down to 3 cards in hand.<n><i>(This is not in the Supply.)</i>",
+        "extra": "This card is not in the Supply; it can only be obtained via Urchin. When you play it, you may trash 2 cards from your hand. If you do, you draw two cards, get +2 Coins, and each other player discards down to 3 cards in hand. Players who already have 3 or fewer cards in hand do nothing. Players responding to this Attack with cards like Beggar must choose to do so before you decide whether or not to trash 2 cards from your hand. If you play this with only one card in hand, you may choose to trash that card, but then will fail the \"if you do\" and will not draw cards and so on. If the cards you trash do things when trashed, first trash them both, then choose what order to resolve the things they do when trashed.",
+        "name": "Mercenary",
+        "raw_wikitext": "<p>You may trash 2&nbsp;cards from your hand. If you did, '''+2&nbsp;Cards''', {{Costplus|2}}, and each other player discards down to 3&nbsp;cards in hand.</p>''(This is not in the Supply.)''",
+        "wikitext": "You may trash 2&nbsp;cards from your hand. If you did, <b>+2&nbsp;Cards</b>, +2 Coins, and each other player discards down to 3&nbsp;cards in hand.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Merchant": {
+        "description": "+1 Card<br>+1 Action<n>The first time you play a Silver this turn, +1 Coin.",
+        "extra": "When you play Merchant, you draw a card and get +1 Action.<n>If you end up playing a Silver later in the turn, it comes with 1 Coin.<n>If you play more than one Merchant, each gives you 1 Coin when you play that first Silver; but if you play more than one Silver, you only get the 1 Coin for the first Silver.<n><n>If you manage to play a Merchant after playing a Silver, the Merchant gives you no bonus (for the previous Silver or for any Silvers you might play later in the turn).<n>Playing Throne Room on Merchant will give you 2 Coin when you play your first Silver.",
+        "name": "Merchant",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>The first time you play a Silver this turn, {{Costplus|1}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>The first time you play a Silver this turn, +1 Coin."
+    },
+    "Merchant Camp": {
+        "description": "+2 Actions<br>+1 Coin<line>When you discard this from play, you may put it onto your deck.",
+        "extra": "If you have multiple Merchant Camps in play, you can choose how many you want to put on top of your deck.",
+        "name": "Merchant Camp",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<br>{{Costplus|1}}{{Divline}}When you discard this from play, you may put it onto your deck.",
+        "wikitext": "<b>+2&nbsp;Actions</b><br>+1 Coin<line>When you discard this from play, you may put it onto your deck."
+    },
+    "Merchant Guild": {
+        "description": "+1 Coin<line>While this is in play, when you buy a card, +1 Coffers (take a Coin token).",
+        "extra": "When you play this, you get +1 Buy and +1 Coin. While this is in play, any time you buy a card you also +1 Coffers (take a Coin token). Remember that you may only spend Coin tokens prior to buying cards, so you will not be able to immediately spend that Coin token. This ability is cumulative; if you have two Merchant Guilds in play, each card you buy will get you two Coin tokens. However if you play a Merchant Guild multiple times but only have one in play, such as with Throne Room (from Dominion) or King's Court (from Prosperity), you will only get one Coin token when you buy a card.",
+        "name": "Merchant Guild",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}<p>At the end of your Buy phase this turn, '''+1&nbsp;Coffers''' per card you gained in it.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<n>At the end of your Buy phase this turn, <b>+1&nbsp;Coffers</b> per card you gained in it."
+    },
+    "Merchant Ship": {
+        "description": "Now and at the start of your next turn: +2 Coins.",
+        "extra": "You get 2 coins to spend this turn, and 2 more on your next turn. Leave this in front of you until the Clean-up phase of your next turn.",
+        "name": "Merchant Ship",
+        "raw_wikitext": "Now and at the start of your next turn: {{Costplus|2}}.",
+        "wikitext": "Now and at the start of your next turn: +2 Coins."
+    },
+    "Messenger": {
+        "description": "+1 Buy<br>+2 Coins<n>You may put your deck into your discard pile.<line>When this is your first buy in a turn, gain a card costing up to 4 Coins, and each other player gains a copy of it.",
+        "extra": "When you play this, you get +1 Buy, +2 Coin , and may optionally put your deck into your discard pile. This is not discarding cards and does not trigger Tunnel (from Hinterlands). When you buy Messenger, if it is the first thing you bought that turn (card or Event), you gain a card costing up to 4 Coins from the Supply, putting it into your discard pile, and then each other player in turn order also gains a copy of that card. If the Supply runs out of copies of the card, further players do not get anything.",
+        "name": "Messenger",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|2}}<p>You may put your deck into your discard pile.</p>{{Divline}}When this is the first card you gain in your Buy phase, gain a card costing up to {{Cost|4}}, and each other player gains a copy of it.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+2 Coins<n>You may put your deck into your discard pile.<n><line>When this is the first card you gain in your Buy phase, gain a card costing up to 4 Coins, and each other player gains a copy of it."
+    },
+    "Militia": {
+        "description": "+2 Coins<n>Each other player discards down to 3 cards in his hand.",
+        "extra": "The attacked players discard cards until they have only 3 cards in hand. Players who had 3 or fewer cards in hand when Militia was played do not discard any cards.",
+        "name": "Militia",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player discards down to 3&nbsp;cards in hand.</p>",
+        "wikitext": "+2 Coins<n>Each other player discards down to 3&nbsp;cards in hand."
+    },
+    "Mill": {
+        "description": "+1 Card<br>+1 Action<br>You may discard 2 cards, for +2 Coin.<line>1 <*VP*>",
+        "extra": "You can choose to discard 2 cards even if you only have one card in hand, but you only get +2 Coin if you actually discarded 2 cards.<line>Use 8 Mills for games with 2 players, 12 for games with 3 or more players.",
+        "name": "Mill",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may discard 2&nbsp;cards. If you do, {{Costplus|2}}.</p>{{Divline}}{{VP|1|l}}",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may discard 2&nbsp;cards. If you do, +2 Coins.<n><line>1 <*VP*>"
+    },
+    "Miller": {
+        "description": "+1 Action<n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.",
+        "extra": "If you have fewer than four cards (after shuffling), you just look at what's left.",
+        "name": "Miller",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Look at the top 4 cards of your deck. Put one into your hand and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Look at the top 4 cards of your deck. Put one into your hand and discard the rest."
+    },
+    "Mine": {
+        "description": "You may trash a Treasure from your hand. Gain a Treasure to your hand costing up to 3 Coins more than it.<n>[Trash a Treasure card from your hand. Gain a Treasure card costing up to 3 Coins more; put it into your hand.]",
+        "extra": "Generally, you can trash a Copper card and gain a Silver, or trash a Silver card and gain a Gold. However, you could also trash a Treasure to gain the same Treasure or a cheaper one. The gained card goes in your hand; thus, you can spend it the same turn. If you don't have a Treasure card in your hand to trash, you can't gain anything.",
+        "name": "Mine",
+        "raw_wikitext": "You may trash a Treasure from your hand. Gain a Treasure to your hand costing up to {{Cost|3}} more than it.",
+        "wikitext": "You may trash a Treasure from your hand. Gain a Treasure to your hand costing up to 3 Coins more than it."
+    },
+    "Mining Road": {
+        "description": "+1 Action<br>+1 Buy<br>+2 Coin<br>Once this turn, when you gain a Treasure, you may play it.",
+        "extra": "Playing the Treasure is optional.<br>This ability is cumulative; if you play two Mining Roads, then twice that turn you may play a Treasure when you gain one. However two Mining Roads can't play the same gained Treasure twice.<br>Mining Road applies to Treasures gained due to being bought, or gained other ways.<br>It works in your Action phase if you gain a Treasure then.",
+        "name": "Mining Road",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<br>{{Costplus|2}}<p>Once this turn, when you gain a Treasure, you may play it.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><br>+2 Coins<n>Once this turn, when you gain a Treasure, you may play it."
+    },
+    "Mining Village": {
+        "description": "+1 Card<br>+2 Actions<n>You may trash this card immediately. If you do, +2 Coins.",
+        "extra": "You must decide whether or not to trash Mining Village or not before moving on to other actions or other phases. You get +1 Card and +2 Actions, whether you choose to trash it or not. If you trash it you also get +2 Coins. If you Throne Room a Mining Village, you cannot trash Mining Village twice. You will get +1 Card, +2 Actions, and +2 Coins the first time you play it and trash it and when you play it the second time with the Throne Room you get +1 Card and +2 Actions but cannot trash it again.",
+        "name": "Mining Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>You may trash this for {{Costplus|2}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>You may trash this for +2 Coins."
+    },
+    "Minion": {
+        "description": "+1 Action<n>Choose one: +2 Coins; or discard your hand, +4 Cards, and each other player with at least 5 cards in hand discards his hand and draws 4 cards.",
+        "extra": "You get +1 Action whichever option you choose. The options are +2 coins, or everything after that - discarding, drawing 4 cards, and other players discarding and drawing. A player who Moats this neither discards nor draws. Other players are only affected by this if they have 5 or more cards in hand. Other players can use Secret Chamber when you play Minion even if they do not have 5 or more cards in hand. [You make your choice on how to use Minion after other players are done revealing Reactions.]",
+        "name": "Minion",
+        "raw_wikitext": "'''+1 Action'''<p>Choose one: {{Costplus|2}}; or discard your hand, '''+4&nbsp;Cards''', and each other player with at least 5&nbsp;cards in hand discards their hand and draws 4&nbsp;cards.</p>",
+        "wikitext": "<b>+1 Action</b><n>Choose one: +2 Coins; or discard your hand, <b>+4&nbsp;Cards</b>, and each other player with at least 5&nbsp;cards in hand discards their hand and draws 4&nbsp;cards."
+    },
+    "Mint": {
+        "description": "You may reveal a Treasure card from your hand. Gain a copy of it.<line>When you buy this, trash all Treasures you have in play.",
+        "extra": "When you buy this, you trash all of your Treasure cards in play. You do not trash Treasure cards in your hand or elsewhere; just the ones in play, if any. If you buy multiple cards in a turn, trash your Treasures right when you buy Mint; you still have any leftover coins they produced for spending on something else. Remember you do not have to play all of the Treasures from your hand each turn (just all the ones you want producing money for you). You do not get additional chances to play Treasure cards between buys in the Buy phase; first you play Treasures, then you buy cards. When you play Mint, you reveal a Treasure card from your hand and gain a copy of it from the Supply. The gained card goes into your discard pile. The revealed card stays in your hand. The Treasure card can also have other types, like Harem (from Intrigue). If you buy a Mint and use Watchtower to put it on top of your deck or trash it, you still trash all of your Treasures from play. However, if you buy a Mint with Royal Seal in play, the Royal Seal will be gone before you can use it to put Mint on your deck.",
+        "name": "Mint",
+        "raw_wikitext": "You may reveal a Treasure card from your hand. Gain a copy of it.{{divline}}When you gain this, trash all non-Duration Treasures you have in play.",
+        "wikitext": "You may reveal a Treasure card from your hand. Gain a copy of it.<line>When you gain this, trash all non-Duration Treasures you have in play."
+    },
+    "Mirror": {
+        "description": "+1 Buy<br>The next time you gain an Action card this turn, gain a copy of it.",
+        "extra": "This is cumulative; if you buy Mirror three times and then buy an Action, you'll gain three extra copies of it.",
+        "name": "Mirror",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>The next time you gain an Action card this turn, gain a copy of it.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>The next time you gain an Action card this turn, gain a copy of it."
+    },
+    "Miser": {
+        "description": "Choose one: Put a Copper from your hand onto your Tavern mat; or +1 Coin per Copper on your Tavern mat.",
+        "extra": "You may choose to put a Copper from your hand on your mat even if you have no Coppers in hand; nothing will happen. You may also choose to get +1 Coin per Copper on your mat if there are no Coppers on your mat; nothing will happen. Putting a Copper from your hand on your mat is not trashing it; Coppers on your mat are not in play, but count as part of your deck when scoring at the end.",
+        "name": "Miser",
+        "raw_wikitext": "Choose one: Put a Copper from your hand onto your Tavern mat; or {{Costplus|1}} per Copper on your Tavern mat.",
+        "wikitext": "Choose one: Put a Copper from your hand onto your Tavern mat; or +1 Coin per Copper on your Tavern mat."
+    },
+    "Miserable": {
+        "description": "-2 <*VP*>",
+        "name": "Miserable",
+        "raw_wikitext": "{{VP|-2|l}}"
+    },
+    "Miserable / Twice Miserable": {
+        "description": "This is a double-sided card.<left><u>Miserable</u>:</left><center>-2 <*VP*></center><left><u>Twice Miserable</u>:</left><center>-4 <*VP*></center>",
+        "extra": "Miserable: When scoring at the end of the game, you lose 2 <VP> . This does nothing until then, it just sits in front of you.\nTwice Miserable: When scoring at the end of the game, you lose 4 <VP> . This does nothing until then, it just sits in front of you.",
+        "name": "Miserable / Twice Miserable"
+    },
+    "Misery": {
+        "description": "If this is your first Misery this game, take Miserable.<br>Otherwise, flip it over to Twice Miserable.",
+        "extra": "If this hits you for a third time in a game, nothing will happen; you stay at Twice Miserable.",
+        "name": "Misery",
+        "raw_wikitext": "If this is your first Misery this game, take Miserable. Otherwise, flip it over to Twice Miserable.",
+        "wikitext": "If this is your first Misery this game, take Miserable. Otherwise, flip it over to Twice Miserable."
+    },
+    "Mission": {
+        "description": "Once per turn: If the previous turn wasn't yours, take another turn after this one, in which you can't buy cards.",
+        "extra": "You can only buy this once per turn. When you do, if the previous turn was not yours - if it was another player's turn before this turn - you take another turn after this turn ends. The extra turn is completely normal except that you cannot buy cards during it. You can still buy Events, and play cards, and gain cards in ways other than buying them (such as gaining a Silver from Amulet), and exchange Travellers. Buying Mission during a turn granted by Mission will not give you another turn, because the previous turn was yours.",
+        "name": "Mission",
+        "raw_wikitext": "Take an extra turn after this one (but not a 3rd turn in a row), during which you can't buy cards.<br>''(You can still buy Events.)''",
+        "wikitext": "Take an extra turn after this one (but not a 3rd turn in a row), during which you can't buy cards.<br><i>(You can still buy Events.)</i>"
+    },
+    "Moat": {
+        "description": "+2 Cards<line>When another player plays an Attack card, you may reveal this from your hand. If you do, you are unaffected by that Attack.",
+        "extra": "An attack card is one that says \"Attack\" on the bottom line (usually, \"Action - Attack\"). When someone else plays an Attack card, you may reveal the Moat by showing it from your hand to the other players and then returning it to your hand (before the Attack card resolves). You are then unaffected by that Attack card. You won't gain a Curse because of a Witch or reveal a card to a Spy, and so on. Moat doesn't stop anything an Attack does to other players or to the player of the Attack; for example, if everyone else Moats a Witch, the person who played it still gets to draw 2 cards. Moat can also be played on your turn as an Action to draw 2 cards.",
+        "name": "Moat",
+        "raw_wikitext": "'''+2&nbsp;Cards'''{{Divline}}When another player plays an Attack card, you may first reveal this from your hand, to be unaffected by it.",
+        "wikitext": "<b>+2&nbsp;Cards</b><line>When another player plays an Attack card, you may first reveal this from your hand, to be unaffected by it."
+    },
+    "Modify": {
+        "description": "Trash a card from your hand. Choose one: +1 Card and +1 Action; or gain a card costing up to 2 Coins more than the trashed card.",
+        "extra": "First trash a card from your hand. Then, choose whether to take +1 Card and +1 Action, or to gain a card costing up to 2 Coins more than the trashed card.",
+        "name": "Modify",
+        "raw_wikitext": "Trash a card from your hand. Choose one: '''+1&nbsp;Card''' and '''+1&nbsp;Action'''; or gain a card costing up to {{Cost|2}} more than the trashed card.",
+        "wikitext": "Trash a card from your hand. Choose one: <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>; or gain a card costing up to 2 Coins more than the trashed card."
+    },
+    "Monastery": {
+        "description": "For each card you’ve gained this turn, you may trash a card from your hand or a Copper you have in play.",
+        "extra": "For example if you have gained three cards, you may trash up to three cards, with each being either a card from your hand or a Copper you have in play, in any combination. Normally, bought cards are then gained, but cards exchanged for (such as Vampire exchanging for Bat) are not gained.",
+        "name": "Monastery",
+        "raw_wikitext": "For each card you've gained this turn, you may trash a card from your hand or a Copper you have in play.",
+        "wikitext": "For each card you've gained this turn, you may trash a card from your hand or a Copper you have in play."
+    },
+    "Moneylender": {
+        "description": "You may trash a Copper from your hand for +3 Coins.<n>[Trash a Copper from your hand. If you do, +3 Coins.]",
+        "extra": "If you do not have a Copper in your hand to trash, you don't get the +3 Coins to spend in the Buy phase.",
+        "name": "Moneylender",
+        "raw_wikitext": "You may trash a Copper from your hand for {{Costplus|3}}.",
+        "wikitext": "You may trash a Copper from your hand for +3 Coins."
+    },
+    "Monkey": {
+        "description": "Until your next turn, when the player to your right gains a card,<br>+1 Card.<br><br>At the start of your next turn,<br>+1 Card.",
+        "extra": "This includes cards that the player gains on other players' turns, such as a Curse they gain on your turn via <i>Witch</i>.<br>When another player gains a card, they resolve any of their on-gain effects before you draw a card (which could matter vs <i>Skirmisher</i>).<br>If Monkey draws a <i>Reaction</i> that can react to the card they gained (such as <i>Falconer</i>), you can immediately use it.<br>If you play this with <i>Way of the Chameleon</i>, and the player to your right gains a card on the same turn, you'll get +1 Coin. Afterwards, you'll get +1 Card when they gain a card.",
+        "name": "Monkey",
+        "raw_wikitext": "<p>Until your next turn, when the player to your right gains a card, '''+1&nbsp;Card'''.</p>At the start of your next turn, '''+1&nbsp;Card'''.",
+        "wikitext": "Until your next turn, when the player to your right gains a card, <b>+1&nbsp;Card</b>.<n>At the start of your next turn, <b>+1&nbsp;Card</b>."
+    },
+    "Monument": {
+        "description": "+2 Coins<br>+1 <VP>",
+        "extra": "When a player takes <VP> tokens, he takes a player mat to put them on. <VP> tokens are not private and anyone can count them. <VP> tokens come in 1 <VP> and 5 <VP> denominations and players can make change as needed. Tokens are unlimited and if they run out, use something else to track any further tokens. At the end of the game, players add the total value of their <VP> tokens to their score.",
+        "name": "Monument",
+        "raw_wikitext": "{{Costplus|2}}<br>{{VP|'''+1'''}}",
+        "wikitext": "+2 Coins<br>{{VP|<b>+1</b>}}"
+    },
+    "Mountain Folk": {
+        "description": "At the start of your turn, you may spend 5 Favors for +3 Cards.",
+        "extra": "",
+        "name": "Mountain Folk",
+        "raw_wikitext": "At the start of your turn, you may spend '''5&nbsp;Favors''' for '''+3&nbsp;Cards'''.",
+        "wikitext": "At the start of your turn, you may spend <b>5&nbsp;Favors</b> for <b>+3&nbsp;Cards</b>."
+    },
+    "Mountain Pass": {
+        "description": "When you are the first player to gain a Province, after that turn, each player bids once, up to 40 Debt, ending with you. High bidder gets +8 <VP> and takes the Debt they bid.",
+        "extra": "This only happens the first time a player gains a Province; it does not matter if the Province was bought or not, or if Provinces have left the pile earlier due to Salt the Earth.<n>This happens between turns; Possession (from Alchemy) will not be in effect.<n>The player to the left of the player who got the Province bids first, then the player to their left and so on, ending with the player who got the Province.<n>Each bid can be a pass, or a higher bid than the previous bid.<n>Bids are in amounts of Debt, from 1 Debt to 40 Debt; a bid of 40 Debt cannot be beaten.<n>The player who bid the highest (if any) gets +8 <VP> and takes the amount of Debt of their bid.",
+        "name": "Mountain Pass",
+        "raw_wikitext": "When you are the first player to gain a Province, each player bids once, up to {{Debt|40}}, ending with you. High bidder gets {{VP|'''+8'''}} and takes the {{Debt}} they bid.",
+        "wikitext": "When you are the first player to gain a Province, each player bids once, up to {{Debt|40}}, ending with you. High bidder gets {{VP|<b>+8</b>}} and takes the {{Debt}} they bid."
+    },
+    "Mountain Shrine": {
+        "description": "+1 SunToken<br>+2 Coins<br><br>You may trash a card from your hand. Then, if there are any Action cards in the trash, +2 Cards.",
+        "extra": "This costs 5 Debt; see the Debt section. It doesn't matter who trashed an Action or when, just that there is one in the trash. The Action in the trash can be one you just trashed with the same play of Mountain Shrine.",
+        "name": "Mountain Shrine",
+        "raw_wikitext": "{{Sunplus}}<br>{{Costplus|2}}<p>You may trash a card from your hand. Then if there are any Action cards in the trash, '''+2&nbsp;Cards'''.</p>",
+        "wikitext": "{{Sunplus}}<br>+2 Coins<n>You may trash a card from your hand. Then if there are any Action cards in the trash, <b>+2&nbsp;Cards</b>."
+    },
+    "Mountain Village": {
+        "description": "+2 Actions<br><n>Look through your discard pile and put a card from it into your hand; if you can't, +1 Card.",
+        "extra": "If your discard pile has any cards in it, you have to take one of them, you cannot choose to draw a card instead. You get to look through your discard pile to pick the card to take. It does not matter what order you leave your discard pile in.",
+        "name": "Mountain Village",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Look through your discard pile and put a card from it into your hand; if you can't, '''+1&nbsp;Card'''.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Look through your discard pile and put a card from it into your hand; if you can't, <b>+1&nbsp;Card</b>."
+    },
+    "Mountebank": {
+        "description": "+2 Coins<n>Each other player may discard a Curse. If he doesn't, he gains a Curse and a Copper.",
+        "extra": "This hits the other players in turn order when that matters (such as when the Curse or Copper pile is low). Each of the other players in turn chooses whether or not to discard a Curse card from his hand, and if he does not, gains a Curse and a Copper from the Supply, putting them into his discard pile. If either the Curse or Copper pile is empty, he still gains the other one. If both are empty, he does not gain either, but can still discard Curse if he wants to. A player using Moat (from Dominion) on this may not discard a Curse, and doesn't gain a Curse or Copper - you cannot Moat just part of the attack. A player using Watchtower on this can use it just to trash the Curse, just to trash the Copper, or to trash both.",
+        "name": "Mountebank",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player may discard a Curse. If they don't, they gain a Curse and a Copper.</p>",
+        "wikitext": "+2 Coins<n>Each other player may discard a Curse. If they don't, they gain a Curse and a Copper."
+    },
+    "Museum": {
+        "description": "When scoring, 2 <VP> per differently named card you have.",
+        "extra": "Multiple cards from the same pile can score for this as long as they have different names.",
+        "name": "Museum",
+        "raw_wikitext": "When scoring, {{VP|'''2'''}} per differently named card you have.",
+        "wikitext": "When scoring, 2 <VP> per differently named card you have."
+    },
+    "Mystic": {
+        "description": "+1 Action<br>+2 Coins<n>Name a card.<n>Reveal the top card of your deck.<n>If it's the named card, put it into your hand.",
+        "extra": "You get +1 Action and +2 Coins. Then name a card (\"Copper,\" for example - not \"Treasure\") and reveal the top card of your deck; if you named the same card you revealed, put the revealed card into your hand. If you do not name the right card, put the revealed card back on top. You do not need to name a card being used this game. Names need to match exactly for you to get the card; for example Sir Destry and Sir Martin do not match. You do not need to name a card available in the Supply.",
+        "name": "Mystic",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|2}}<p>Name a card, then reveal the top card of your deck. If you named it, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+2 Coins<n>Name a card, then reveal the top card of your deck. If you named it, put it into your hand."
+    },
+    "Native Village": {
+        "description": "+2 Actions<n>Choose one: Set aside the top card of your deck face down on your Native Village mat; or put all the cards from your mat into your hand.<n>You may look at the cards on your mat at any time; return them to your deck at the end of the game.",
+        "extra": "When you first gain one of these, take a Native Village player mat to put cards from this on. When you play Native Village, either take all of the set aside cards from your Native Village player mat and put them into your hand, or set aside the top card of your deck face down (shuffling first if needed) on the Native Village player mat. You may choose either option even if you have no cards on your mat or no cards in your deck. You may look at the cards on your Native Village player mat at any time. At the end of the game, any cards still on your mat return to your deck for scoring. Native Village itself does not get set aside; it goes to your discard pile during the Clean-up phase.",
+        "name": "Native Village",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Choose one: Put the top card of your deck face down on your Native Village mat (you may look at those cards at any time); or put all the cards from your mat into your hand.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Choose one: Put the top card of your deck face down on your Native Village mat (you may look at those cards at any time); or put all the cards from your mat into your hand."
+    },
+    "Navigator": {
+        "description": "+2 Coins<n>Look at the top 5 cards of your deck. Either discard all of them, or put them back on top of your deck in any order.",
+        "extra": "You discard all 5 cards or none of them. If you don't discard them, put them back in any order. If there aren't 5 cards left in your deck, look at as many as you can, then shuffle your discard pile (not including the cards you are currently looking at), and look at the rest. If there still aren't 5, you just look at however many are left, and put them back or discard them.",
+        "name": "Navigator",
+        "raw_wikitext": "{{Costplus|2}}<p>Look at the top 5&nbsp;cards of your deck. Either discard them all, or put them back in any order.</p>",
+        "wikitext": "+2 Coins<n>Look at the top 5&nbsp;cards of your deck. Either discard them all, or put them back in any order."
+    },
+    "Nearby": {
+        "description": "When you gain a Nearby card, +1 Buy.",
+        "extra": "Each time you gain a Nearby card, you get +1 Buy.",
+        "name": "Nearby",
+        "raw_wikitext": "When you gain a Nearby card, '''+1&nbsp;Buy'''.",
+        "wikitext": "When you gain a Nearby card, <b>+1&nbsp;Buy</b>."
+    },
+    "Necromancer": {
+        "description": "Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.<line>Setup: Put the 3 Zombies into the trash.",
+        "extra": "Setup:  Put the three Zombies into the trash.<br><br>This plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.",
+        "name": "Necromancer",
+        "raw_wikitext": "Choose a face up, non-Duration Action card in the trash. Turn it face down for the turn, and play it, leaving it there.{{Divline}}Setup: Put the 3&nbsp;Zombies into the trash.",
+        "wikitext": "Choose a face up, non-Duration Action card in the trash. Turn it face down for the turn, and play it, leaving it there.<line>Setup: Put the 3&nbsp;Zombies into the trash."
+    },
+    "Necromancer - Zombies": {
+        "description": "<left><u>Necromancer</u>:</left><center>Play a face-up, non-Duration Action card from the trash, leaving it there and turning it face down for the turn.</center><line>Setup: Put the 3 Zombies into the trash.<left><u>Zombie Apprentice</u>:</left><center>You may trash an Action card from your hand for +3 Cards and +1 Action.</center><left><u>Zombie Mason</u>:</left><center>Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.</center><left><u>Zombie Spy</u>:</left><center>+1 Card</center><center>+1 Action</center><center>Look at the top card of your deck. Discard it or put it back.</center>",
+        "extra": "Setup:  Put the three Zombies into the trash.\nNecromancer plays a non-Duration Action card from the trash. Normally it can at least play one of the three Zombies, since they start the game in the trash. It can play other Action cards that make their way into the trash too. The played cards are turned over, to track that each can only be used once per turn this way; at end of turn, turn them back face up. Necromancer can play another Necromancer, though normally that will not be useful. The Action card stays in the trash; if an effect tries to move it, such as Encampment (from Empires) returning to the Supply, it will fail to move it. Necromancer can be used on a card that trashes itself when played; if the card checks to see if it was trashed (such as Pixie), it was not, but if the card does not check (such as Tragic Hero), it will function normally. Since the played card is not in play, 'while this is in play' abilities (such as Tracker's) will not do anything.\n<u>Zombie Apprentice</u>: If you trash an Action card from your hand, you draw three cards and get +1 Action.\n<u>The Zombie Mason</u>: Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card. Usually if it is not something you want to trash, you can gain a copy of it back from the Supply.\n<u>Zombie Spy</u>: You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
+        "name": "Necromancer / Zombies"
+    },
+    "Necropolis": {
+        "description": "+2 Actions",
+        "extra": "This is a Shelter; see Preparation. It is never in the Supply. It is an Action card; when you play it, you get +2 Actions.",
+        "name": "Necropolis",
+        "raw_wikitext": "'''+2&nbsp;Actions'''",
+        "wikitext": "<b>+2&nbsp;Actions</b>"
+    },
+    "Night Watchman": {
+        "description": "Look at the top 5 cards of your deck, discard any number, and put the rest back in any order.<line>This is gained to your hand (instead of your discard pile).",
+        "extra": "Since Night is after the Buy phase, normally you can play this the turn you buy it.",
+        "name": "Night Watchman",
+        "raw_wikitext": "Look at the top 5&nbsp;cards of your deck, discard any number, and put the rest back in any order.{{Divline}}This is gained to your hand (instead of your discard pile).",
+        "wikitext": "Look at the top 5&nbsp;cards of your deck, discard any number, and put the rest back in any order.<line>This is gained to your hand (instead of your discard pile)."
+    },
+    "Ninja": {
+        "description": "+1 Card<br><br>Each other player discards down to 3 cards in hand.<line>You can play this from your deck as if in your hand.",
+        "extra": "See the Shadows section. When you play Ninja, you draw a card, and each other player discards down to 3 cards in hand.",
+        "name": "Ninja",
+        "raw_wikitext": "'''+1&nbsp;Card'''<p>Each other player discards down to 3&nbsp;cards in hand.</p>{{Divline}}You can play this from your deck as if in your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><n>Each other player discards down to 3&nbsp;cards in hand.<n><line>You can play this from your deck as if in your hand."
+    },
+    "Noble Brigand": {
+        "description": "+1 Coin<n>Each other player reveals the top 2 cards of their deck, trashes a revealed Silver or Gold you choose, discards the rest, and gains a Copper if they didn't reveal a Treasure. You gain the trashed cards.<line>When you buy this, do its attack.",
+        "extra": "When you play this, you get +1 coin. When you play this and also when you buy it, each other player reveals the top two cards of his deck, trashes a Silver or Gold he revealed that you choose, and discards the rest. Each of these players that did not reveal a Treasure at all gains a Copper from the Supply, putting it into his discard pile. Finally, you gain all of the Silvers and Golds trashed this way. This cannot trash any Treasures except Silver or Gold. Gaining a Noble Brigand without buying it does not cause this ability to happen. Noble Brigand is an Attack card, and when you play it, players can use cards like Moat from Dominion or Secret Chamber from Intrigue in response. However, buying a Noble Brigand is not \"playing an Attack card,\" and so cards like Moat cannot respond to that.",
+        "name": "Noble Brigand",
+        "raw_wikitext": "{{Costplus|1}}<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes a revealed Silver or Gold you choose, discards the rest, and gains a Copper if they didn't reveal a Treasure. You gain the trashed cards.{{Divline}}When you buy this, do its attack.</p>",
+        "wikitext": "+1 Coin<n>Each other player reveals the top 2&nbsp;cards of their deck, trashes a revealed Silver or Gold you choose, discards the rest, and gains a Copper if they didn't reveal a Treasure. You gain the trashed cards.<line>When you buy this, do its attack."
+    },
+    "Nobles": {
+        "description": "Choose one: +3 Cards, or +2 Actions.<line>2 <*VP*>",
+        "extra": "This is both an Action card and a Victory card. When you play it, you choose either to draw 3 cards or to get 2 more Actions to use; you cannot mix and match. At the end of the game, this is worth 2 <VP>. <line>Use 8 Nobles for games with 2 players, 12 for games with 3 or more players.",
+        "name": "Nobles",
+        "raw_wikitext": "Choose one: '''+3&nbsp;Cards'''; or '''+2&nbsp;Actions'''.{{Divline}}{{VP|2|l}}",
+        "wikitext": "Choose one: <b>+3&nbsp;Cards</b>; or <b>+2&nbsp;Actions</b>.<line>2 <*VP*>"
+    },
+    "Nomad Camp": {
+        "description": "+1 Buy<br>+2 Coins<line>When you gain this, put it on top of your deck.",
+        "extra": "When you gain this card, it goes on top of your deck rather than into your discard pile. This is true whether you gained it due to buying it or gained it some other way. If there were no cards in your deck, it becomes the only card in your deck.",
+        "name": "Nomad Camp",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|2}}{{Divline}}This is gained onto your deck (instead of to your discard pile).",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+2 Coins<line>This is gained onto your deck (instead of to your discard pile)."
+    },
+    "Nomads": {
+        "description": "+1 Buy<br>+2 Coin<line>When you gain or trash this, +2 Coin.",
+        "extra": "",
+        "name": "Nomads",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|2}}{{Divline}}When you gain or trash this, {{Costplus|2}}.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+2 Coins<line>When you gain or trash this, +2 Coins."
+    },
+    "Oasis": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coins<br>Discard a card.",
+        "extra": "You draw before discarding. You can discard the card you drew. If you are unable to draw a card (due to having no cards in your deck, and none in your discard pile to shuffle), you still discard a card if able.",
+        "name": "Oasis",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>Discard a card.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>Discard a card."
+    },
+    "Obelisk": {
+        "description": "When scoring, 2 <VP> per card you have from the chosen pile.<line>Setup: Choose a random Action Supply pile.",
+        "extra": "All cards from the chosen pile count, even if they have different names (such as when it is a split pile).<n>Ruins (from Dark Ages), when used, can be the pile.",
+        "name": "Obelisk",
+        "raw_wikitext": "When scoring, {{VP|'''2'''}} per card you have from the chosen pile.{{Divline}}Setup: Choose a random Action Supply pile.",
+        "wikitext": "When scoring, 2 <VP> per card you have from the chosen pile.<line>Setup: Choose a random Action Supply pile."
+    },
+    "Odysseys": {
+        "description": "This pile starts the game with 4 copies each of Old Map, Voyage, Sunken Treasure, and Distant Shore, in that order. Only the top card can be gained or bought.",
+        "extra": "Old Map: Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.<n>Voyage: This doesn't stop you from playing cards that aren't in your hand. On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not. This limits plays of all types of cards, including Treasures like Copper.<n>Sunken Treasure: If there's no such Action in the Supply, you don't gain one.<n>Distant Shore: Gaining an Estate isn't optional. If the Estate pile is empty you still get +2 Cards and +1 Action.",
+        "name": "Odysseys"
+    },
+    "Old Map": {
+        "description": "+1 Card<br>+1 Action<n>Discard a card. +1 Card.<br>You may rotate the Odysseys",
+        "extra": "Everything happens in the order listed: first you get +1 Card and +1 Action; then you discard a card; then you draw a card; then you choose whether or not to rotate the Odysseys.",
+        "name": "Old Map",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Discard a card. '''+1&nbsp;Card'''.</p>You may rotate the Odysseys.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Discard a card. <b>+1&nbsp;Card</b>.<n>You may rotate the Odysseys."
+    },
+    "Old Witch": {
+        "description": "+3 Cards<br><br>Each other player gains a Curse and may trash a Curse from their hand.",
+        "extra": "After the Curse pile is empty, playing this still lets each other player trash a Curse from their hand. A player who is unaffected by Old Witch, such as due to Moat, neither gains a Curse nor may trash one.",
+        "name": "Old Witch",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>Each other player gains a Curse and may trash a Curse from their hand.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>Each other player gains a Curse and may trash a Curse from their hand."
+    },
+    "Opulent Castle": {
+        "description": "Discard any number of Victory cards, revealed. +2 Coins per card discarded.<line>3 <*VP*>",
+        "name": "Opulent Castle",
+        "raw_wikitext": "Discard any number of Victory cards, revealed. {{Costplus|2}} per card discarded.{{Divline}}{{VP|3|l}}"
+    },
+    "Oracle": {
+        "description": "Each player (including you) reveals the top 2 cards of their deck, and discards them or puts them back, your choice (they choose the order). Then, +2 Cards.",
+        "extra": "First, each player including you, reveals the top two cards of his deck, and either discards both of them or puts both of them back on top, your choice. A player putting the cards back puts them back in an order he chooses, and without needing to reveal that order. Then, you draw two cards. So if you put back the cards you revealed, you will draw them.",
+        "name": "Oracle",
+        "raw_wikitext": "Each player (including you) reveals the top 2&nbsp;cards of their deck, and discards them or puts them back, your choice (they choose the order). Then, '''+2&nbsp;Cards'''.",
+        "wikitext": "Each player (including you) reveals the top 2&nbsp;cards of their deck, and discards them or puts them back, your choice (they choose the order). Then, <b>+2&nbsp;Cards</b>."
+    },
+    "Orb": {
+        "description": "Look through your discard pile. Choose one: Play an Action or Treasure from it; or +1 Buy and +3 Coin.",
+        "extra": "First look through your discard pile; then choose either to play an Action or Treasure from it, or to get +1 Buy and +3 Coin.",
+        "name": "Orb",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "Look through your discard pile. Choose one: Play an Action or Treasure from it; or '''+1&nbsp;Buy''' and {{Costplus|3}}.",
+        "wikitext": "Look through your discard pile. Choose one: Play an Action or Treasure from it; or <b>+1&nbsp;Buy</b> and +3 Coins."
+    },
+    "Orchard": {
+        "description": "When scoring, 4 <VP> per differently named Action card you have 3 or more copies of.",
+        "extra": "Having 6 or more copies of a card confers no additional bonus.",
+        "name": "Orchard",
+        "raw_wikitext": "When scoring, {{VP|'''4'''}} per differently named Action card you have 3&nbsp;or more copies of.",
+        "wikitext": "When scoring, 4 <VP> per differently named Action card you have 3&nbsp;or more copies of."
+    },
+    "Order of Astrologers": {
+        "description": "When shuffling, you may pick one card per Favor you spend to go on top.",
+        "extra": "",
+        "name": "Order of Astrologers",
+        "raw_wikitext": "When shuffling, you may pick one card per '''Favor''' you spend to go on top.",
+        "wikitext": "When shuffling, you may pick one card per <b>Favor</b> you spend to go on top."
+    },
+    "Order of Masons": {
+        "description": "When shuffling, you may pick up to 2 cards per Favor you spend to put into your discard pile.",
+        "extra": "",
+        "name": "Order of Masons",
+        "raw_wikitext": "When shuffling, you may pick up to 2&nbsp;cards per '''Favor''' you spend to put into your discard pile.",
+        "wikitext": "When shuffling, you may pick up to 2&nbsp;cards per <b>Favor</b> you spend to put into your discard pile."
+    },
+    "Outpost": {
+        "description": "You only draw 3 cards (instead of 5) in this turn's Clean-up phase. Take an extra turn after this one. This can't cause you to take more than two consecutive turns.",
+        "extra": "The extra turn is completely normal except that your starting hand for it is only 3 cards. This means that you only drew 3 cards instead of 5 cards during the Clean-up phase of the turn when you played Outpost. Leave Outpost in front of you until the end of the extra turn. If you play Outpost as well as a \"Now and at the start of your next turn\" card, such as Merchant Ship, the turn from Outpost will be that next turn, so you'll get those coins then. If you manage to play Outpost twice in one turn, you will still only get one extra turn. If you play Outpost during an extra turn, it won't give you another turn.",
+        "name": "Outpost",
+        "raw_wikitext": "You only draw 3&nbsp;cards for your next hand. Take an extra turn after this one (but not a 3rd turn in a row).",
+        "wikitext": "You only draw 3&nbsp;cards for your next hand. Take an extra turn after this one (but not a 3rd turn in a row)."
+    },
+    "Overgrown Estate": {
+        "description": "0 <*VP*><line>When you trash this, +1 Card.",
+        "extra": "This is a Shelter; see Preparation. It is never in the Supply. It is a Victory card despite being worth 0 Victory. If this is trashed, you draw a card, right then, even in the middle of resolving another card. For example, if you use Altar to trash Overgrown Estate, you first draw a card, then gain a card costing up to 5 Coins. This card does not give you a way to trash itself, it merely does something if you manage to trash it.",
+        "name": "Overgrown Estate",
+        "raw_wikitext": "{{VP|0|l}}{{Divline}}When you trash this, '''+1&nbsp;Card'''.",
+        "wikitext": "0 <*VP*><line>When you trash this, <b>+1&nbsp;Card</b>."
+    },
+    "Overlord": {
+        "description": "Play a non-Command Action card from the Supply costing up to 5 Coin, leaving it there.",
+        "extra": "When you play this, you pick a non-Command Action card from the Supply that costs up to 5 Coin, and play it.<br>The Action card stays in the Supply; it does not move to the play area and if an effect tries to move it, such as Encampment returning to the Supply, it will fail to move it.<br>Normally this will just mean that you follow the instructions on the card you picked.<br>For example, with Village in the Supply, you could have the Overlord play the Village and get +1 Card and +2 Actions.<br>If you have an Overlord play a Duration card, or a Throne Room on a Duration card, Overlord will stay in play the same way the Duration card or Throne Room would.<br>If you play an Overlord multiple times such as via a Throne Room, you will pick what to play with it each time; the choices can be different.<br>Overlord can only play a visible card in the Supply, and the top card of a pile; it cannot play a card from an empty pile, or a card that has not been uncovered from a split pile, or a card from a split pile that has been bought out, or a non-Supply card (like Mercenary from Dominion: Dark Ages).<br>Overlord cannot play a Crown during a Buy phase, since normally Overlord itself is not a Treasure and so cannot normally be played in Buy phases.",
+        "name": "Overlord",
+        "raw_wikitext": "Play a non-Command non-Duration Action card from the Supply costing up to {{Cost|5}}, leaving it there.",
+        "wikitext": "Play a non-Command non-Duration Action card from the Supply costing up to 5 Coins, leaving it there."
+    },
+    "Paddock": {
+        "description": "+2 Coin<br>Gain 2 Horses.<br>+1 Action per empty Supply pile.",
+        "extra": "This only checks how many piles are empty when you play it; how many +Actions you got does not change if a pile becomes empty later in the turn (or non-empty, such as due to Ambassador from Seaside).<n>This only counts Supply piles, not non-Supply piles like Horse.",
+        "name": "Paddock",
+        "raw_wikitext": "{{Costplus|2}}<p>Gain 2&nbsp;Horses.</p>'''+1&nbsp;Action''' per empty Supply pile.",
+        "wikitext": "+2 Coins<n>Gain 2&nbsp;Horses.<n><b>+1&nbsp;Action</b> per empty Supply pile."
+    },
+    "Page": {
+        "description": "+1 Card<br>+1 Action<line>When you discard this from play, you may exchange it for a Treasure Hunter.",
+        "extra": "See the section on Travellers. When you play Page, you get +1 Card and +1 Action. When you discard it from play, you may return it to its pile and take a Treasure Hunter, putting it into your discard pile.",
+        "name": "Page",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''{{Divline}}When you discard this from play, you may exchange it for a Treasure Hunter.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><line>When you discard this from play, you may exchange it for a Treasure Hunter."
+    },
+    "Page -> Champion": {
+        "description": "<justify>Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion.</justify><left><u>Page</u>: +1 Card; +1 Action</left><left><u>Treasure Hunter</u>: +1 Action; +1 Coin; Gain a Silver per card the player to your right gained in his last turn.<br><u>Warrior</u>: +2 Cards; For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<br><u>Hero</u>: +2 Coins; Gain a Treasure.<br><u>Champion</u>: +1 Action; For the rest of the game, when another player plays an Attack, it doesn't affect you, and when you play an Action, +1 Action. (This stays in play. <i>This is not in the Supply.</i>)</left>",
+        "extra": "Page is a Kingdom card that is a Traveller. These cards have an arrow over the text box to remind players of their ability to upgrade into another card. Page is exchanged for Treasure Hunter, which is exchanged for Warrior, which is exchanged for Hero, which is exchanged for Champion. Champion is not a Traveller; it cannot be exchanged for anything. Page can be bought or otherwise gained when being used in a game, but the other cards cannot, they are not in the Supply. When a non-Supply pile is empty, that does not count as an empty pile for the game ending condition or for City (from Prosperity).<n><n>When a player discards a Traveller from play, they may exchange it for the card indicated; they return the card being exchanged to its pile, takes the card they are exchanging it for, and puts that card into their discard pile. Exchanging is not trashing or gaining, and so does not trigger abilities like Travelling Fair's. It is optional. It only happens when the card is discarded from play; discarding it from hand, such as due to not playing it, will not trigger it. It only happens if the card being exchanged for has any copies available. If multiple cards do something when discarded from play, the player picks the order.",
+        "name": "Page → Champion"
+    },
+    "Pageant": {
+        "description": "At the end of your Buy phase, you may pay 1 Coin for +1 Coffers.",
+        "extra": "If you have at least 1 Coin that you did not spend, you can spend 1 Coin for +1 Coffers. This only works once per turn.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Pageant",
+        "raw_wikitext": "At the end of your Buy phase, you may pay {{Cost|1}} for '''+1&nbsp;Coffers'''.",
+        "wikitext": "At the end of your Buy phase, you may pay 1 Coin for <b>+1&nbsp;Coffers</b>."
+    },
+    "Palace": {
+        "description": "When scoring, 3 <VP> per set you have of Copper - Silver - Gold.",
+        "extra": "For example, if you had 7 Coppers, 5 Silvers, and 2 Golds, that would be two sets of Copper - Silver - Gold, for 6 <VP> total.",
+        "name": "Palace",
+        "raw_wikitext": "When scoring, {{VP|'''3'''}} per set you have of Copper - Silver - Gold.",
+        "wikitext": "When scoring, 3 <VP> per set you have of Copper - Silver - Gold."
+    },
+    "Panic": {
+        "description": "When you play a Treasure, <b>+2&nbsp;Buys</b>, and when you discard one from play, return it to its pile.",
+        "name": "Panic",
+        "raw_wikitext": "When you play a Treasure, '''+2&nbsp;Buys''', and when you discard one from play, return it to its pile."
+    },
+    "Pasture": {
+        "description": "1 <*COIN*><br><line><br>Worth 1 <VP> per Estate you have.",
+        "extra": "For example if you have three Estates, then Pasture is worth 3 <VP>.",
+        "name": "Pasture",
+        "raw_wikitext": "{{Cost|1|l}}{{Divline}}Worth {{VP|'''1'''}} per Estate you have.",
+        "wikitext": "1 <*COIN*><line>Worth 1 <VP> per Estate you have."
+    },
+    "Pathfinding": {
+        "description": "Move your +1 Card token to an Action Supply pile (when you play a card from that pile, you first get +1 Card).",
+        "extra": "When you buy this, you move your +1 Card token to any Action Supply pile. This token gives you +1 Card whenever you play a card from that pile; see the Tokens section.",
+        "name": "Pathfinding",
+        "raw_wikitext": "Move your +1&nbsp;Card token to an Action Supply pile. (When you play a card from that pile, you first get '''+1&nbsp;Card'''.)",
+        "wikitext": "Move your +1&nbsp;Card token to an Action Supply pile. (When you play a card from that pile, you first get <b>+1&nbsp;Card</b>.)"
+    },
+    "Patient": {
+        "description": "At the start of your Clean-up phase, you may set aside Patient cards from your hand to play them at the start of your next turn.",
+        "extra": "You can set aside multiple Patient cards at once; play them all at the start of your next turn, in any order.<br>If this plays a card that can't normally be played, like Territory (from Allies), that card goes into play but doesn't do anything else then.",
+        "name": "Patient",
+        "raw_wikitext": "At the start of your Clean-up phase, you may set aside Patient cards from your hand to play them at the start of your next turn.",
+        "wikitext": "At the start of your Clean-up phase, you may set aside Patient cards from your hand to play them at the start of your next turn."
+    },
+    "Patrician": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top card of your deck. If it costs 5 Coin or more, put it into your hand.",
+        "extra": "Cards costing Debt do not cost 5 Coin or more unless they also have a Coin cost of 5 Coin or more. So Fortune does but City Quarter does not.",
+        "name": "Patrician",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If it costs {{Cost|5}} or more, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If it costs 5 Coins or more, put it into your hand."
+    },
+    "Patrician - Emporium": {
+        "description": "<left><u>Patrician</u>:</left><n>+1 Card<br>+1 Action<n>Reveal the top card of your deck. If it costs 5 Coin or more, put it into your hand.<n><left><u>Emporium</u>:</left><n>+1 Card<br>+1 Action<br>+1 Coin<line>When you gain this, if you have at least 5 Action cards in play, +2 <VP>.",
+        "extra": "Cards costing Debt do not cost 5 Coin or more unless they also have a Coin cost of 5 Coin or more. So Fortune does but City Quarter does not. Emporium: This counts Action cards in play, including Action cards played this turn, Duration cards in play from previous turns, and Reserve cards (from Adventures) called into play this turn.",
+        "name": "Patrician / Emporium"
+    },
+    "Patrol": {
+        "description": "+3 Cards<n>Reveal the top 4 cards of your deck. Put the Victory cards and Curses into your hand. Put the rest back in any order.",
+        "extra": "First draw 3 cards, then reveal the top 4 cards of your deck.<n>Put the revealed Victory cards and Curses into your hand; you have to take them all.<n>Put the rest of the cards back on your deck in any order you choose.",
+        "name": "Patrol",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>Reveal the top 4&nbsp;cards of your deck. Put the Victory cards and Curses into your hand. Put the rest back in any order.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>Reveal the top 4&nbsp;cards of your deck. Put the Victory cards and Curses into your hand. Put the rest back in any order."
+    },
+    "Patron": {
+        "description": "+1 Villager<br>+2 Coin<line>When something causes you to reveal this (using the word \"reveal\"), +1 Coffers.",
+        "extra": "Anything that causes you to reveal a Patron, and specifically uses the word \"reveal,\" causes you to get +1 Coffers. For example if you play a Border Guard and reveal two Patrons, you will get +2 Coffers. Other players seeing a card, without the word \"reveal\" being used, is not enough; for example if another player plays a Villain and you discard a Patron, you do not get +1 Coffers.",
+        "name": "Patron",
+        "raw_wikitext": "'''+1&nbsp;Villager'''<br>{{Costplus|2}}{{Divline}}When something causes you to reveal this (using the word \"reveal\") in an Action phase, '''+1&nbsp;Coffers'''.",
+        "wikitext": "<b>+1&nbsp;Villager</b><br>+2 Coins<line>When something causes you to reveal this (using the word \"reveal\") in an Action phase, <b>+1&nbsp;Coffers</b>."
+    },
+    "Pawn": {
+        "description": "Choose two: +1 Card, +1 Action, +1 Buy, +1 Coin.<br>The choices must be different.",
+        "extra": "First pick any 2 of the 4 options. You cannot pick the same option twice. After picking both, do both, in either order. You may not choose to draw a card, look at the card drawn, and then make your second choice.",
+        "name": "Pawn",
+        "raw_wikitext": "Choose two: '''+1&nbsp;Card'''; '''+1&nbsp;Action'''; '''+1&nbsp;Buy'''; {{Costplus|1}}. The choices must be different.",
+        "wikitext": "Choose two: <b>+1&nbsp;Card</b>; <b>+1&nbsp;Action</b>; <b>+1&nbsp;Buy</b>; +1 Coin. The choices must be different."
+    },
+    "Peaceful Cult": {
+        "description": "At the start of your Buy phase, you may spend any number of Favors to trash that many cards from your hand.",
+        "extra": "",
+        "name": "Peaceful Cult",
+        "raw_wikitext": "At the start of your Buy phase, you may spend any number of '''Favors''' to trash that many cards from your hand.",
+        "wikitext": "At the start of your Buy phase, you may spend any number of <b>Favors</b> to trash that many cards from your hand."
+    },
+    "Pearl Diver": {
+        "description": "+1 Card<br>+1 Action<n>Look at the bottom card of your deck. You may put it on top.",
+        "extra": "Draw a card before you look at the bottom card of your deck. If placing the card on top of your deck, be sure not to look at the next card on the bottom of your deck while moving the card. If you have no cards left when it's time to look at the bottom, you shuffle first.",
+        "name": "Pearl Diver",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Look at the bottom card of your deck. You may put it on top.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Look at the bottom card of your deck. You may put it on top."
+    },
+    "Peasant": {
+        "description": "+1 Buy<br>+1 Coin<line>When you discard this from play, you may exchange it for a Soldier.",
+        "extra": "See the section on Travellers. When you play Peasant, you get +1 Buy and +1 Coin. When you discard it from play, you may return it to its pile and take a Soldier, putting it into your discard pile.",
+        "name": "Peasant",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}{{Divline}}When you discard this from play, you may exchange it for a Soldier.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<line>When you discard this from play, you may exchange it for a Soldier."
+    },
+    "Peasant -> Teacher": {
+        "description": "<justify>Peasant is exchanged for Soldier, which is exchanged for Fugitive, which is exchanged for Disciple, which is exchanged for Teacher.</justify><n><left><u>Peasant</u>: +1 Buy; +1 Coin</left><left><u>Soldier</u>: +2 Coins; +1 Coin per other Attack you have in play. Each other player with 4 or more cards in hand discards a card.<br><u>Fugitive</u>: +2 Cards; +1 Action; Discard a card.<br><u>Disciple</u>: You may play an Action card from your hand twice. Gain a copy of it.<br><u>Teacher</u>: Put this on your Tavern mat. At the start of your turn, you may call this, to move your +1 Card, +1 Action, +1 Buy, or +1 Coin token to an Action Supply pile you have no tokens on (when you play a card from that pile, you first get that bonus). <i>(This is not in the Supply.)</i></left>",
+        "extra": "Peasant is a Kingdom card that is a Traveller. These cards have an arrow over the text box to remind players of their ability to upgrade into another card. Peasant is exchanged for Soldier, which is exchanged for Fugitive, which is exchanged for Disciple, which is exchanged for Teacher. Teacher is not a Traveller; it cannot be exchanged for anything. Peasant can be bought or otherwise gained when being used in a game, but the other cards cannot, they are not in the Supply. When a non-Supply pile is empty, that does not count as an empty pile for the game ending condition or for City (from Prosperity).<n><n>When a player discards a Traveller from play, they may exchange it for the card indicated; they return the card being exchanged to its pile, takes the card they are exchanging it for, and puts that card into their discard pile. Exchanging is not trashing or gaining, and so does not trigger abilities like Travelling Fair's. It is optional. It only happens when the card is discarded from play; discarding it from hand, such as due to not playing it, will not trigger it. It only happens if the card being exchanged for has any copies available. If multiple cards do something when discarded from play, the player picks the order.",
+        "name": "Peasant → Teacher"
+    },
+    "Peddler": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<line>During a player's Buy phase, this costs 2 Coins less per Action card they have in play.",
+        "extra": "Most of the time, this costs 8 coins. During Buy phases, this costs 2 coins less per Action card you have in play. This cost applies to all Peddler cards, including ones in hands and decks. It never costs less than 0 coins. If you play King's Court on Worker's Village, for example, that is just two Action cards you have in play, even though you played the Worker's Village three times. Buying cards using the promotional card Black Market is something that does not happen during a Buy phase, so Peddler still costs 8 coins then.",
+        "name": "Peddler",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}{{divline}}During a player's Buy phase, this costs {{Cost|2}} less per Action card they have in play.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<line>During a player's Buy phase, this costs 2 Coins less per Action card they have in play."
+    },
+    "Pendant": {
+        "description": "+1 Coin per differently named Treasure you have in play.",
+        "extra": "This counts itself. For example if you had three Copper, an Astrolabe played last turn, and the Pendant in play, it would make +3 Coin.",
+        "name": "Pendant",
+        "raw_wikitext": "{{Costplus|1}} per differently named Treasure you have in play.",
+        "wikitext": "+1 Coin per differently named Treasure you have in play."
+    },
+    "Peril": {
+        "description": "You may trash an Action card from your hand to gain a Loot.",
+        "extra": "You only gain a Loot if you trashed an Action card.",
+        "name": "Peril",
+        "raw_wikitext": "You may trash an Action card from your hand to gain a Loot.",
+        "wikitext": "You may trash an Action card from your hand to gain a Loot."
+    },
+    "Philosopher's Stone": {
+        "description": "When you play this, count your deck and discard pile.<n>Worth 1 Coin per 5 cards total between them (rounded down).",
+        "extra": "This is a Treasure card. It is a Kingdom card; it will only be in games where it is randomly dealt out as one of the 10 Kingdom cards, or otherwise selected to be one of them. It is played during your Buy phase, like other Treasure cards. When you play it, count the number of cards in your deck and discard pile combined, divide by 5, and round down. That is how many coins this produces for you. Once played, the amount of coins you get does not change even if the number of cards changes later in the turn. The next time you play it, count again. If you play multiple copies, obviously the number will be the same for all of them. It does not matter what order your discard pile is in, but the order your deck is in matters. Do not change that order while counting! You will get to look through your discard pile as you count it. You only get to count your deck and discard pile, not your hand or cards in play or set aside cards. You cannot play more Treasures after buying something in your buy phrase; so for example you cannot buy a card, then play Philosopher's Stone, then buy another card.",
+        "name": "Philosopher's Stone",
+        "raw_wikitext": "Count your deck and discard pile. {{Costplus|1}} per 5&nbsp;cards total between them (round down).",
+        "wikitext": "Count your deck and discard pile. +1 Coin per 5&nbsp;cards total between them (round down)."
+    },
+    "Piazza": {
+        "description": "At the start of your turn, reveal the top card of your deck.  If it's an Action, play it.",
+        "extra": "Once you have claimed this ability, it is not optional. If the revealed card is not an Action, return it to the top of your deck.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Piazza",
+        "raw_wikitext": "At the start of your turn, reveal the top card of your deck. If it's an Action, play it.",
+        "wikitext": "At the start of your turn, reveal the top card of your deck. If it's an Action, play it."
+    },
+    "Pickaxe": {
+        "description": "1 <*COIN*><br><br>Trash a card from your hand. If it costs 3 Coin or more, gain a Loot to your hand.",
+        "extra": "Trashing is mandatory, if you have any cards left in hand. Remember that you have to reveal the gained Loot.",
+        "name": "Pickaxe",
+        "raw_wikitext": "{{Cost|1|l}}<p>Trash a card from your hand. If it costs {{Cost|3}} or more, gain a Loot to your hand.</p>",
+        "wikitext": "1 <*COIN*><n>Trash a card from your hand. If it costs 3 Coins or more, gain a Loot to your hand."
+    },
+    "Pilgrim": {
+        "description": "+4 Cards<br>Put a card from your hand onto your deck.",
+        "extra": "The card you put on top doesn't have to be one of the 4 you just drew.",
+        "name": "Pilgrim",
+        "raw_wikitext": "'''+4&nbsp;Cards'''<p>Put a card from your hand onto your deck.</p>",
+        "wikitext": "<b>+4&nbsp;Cards</b><n>Put a card from your hand onto your deck."
+    },
+    "Pilgrimage": {
+        "description": "Once per turn: Turn your Journey token over (it starts face up); then if it's face up, choose up to 3 differently named cards you have in play and gain a copy of each.",
+        "extra": "At the start of the game, place your Journey token (the one with the boot) face up. You can only buy this once per turn. When you do, turn your Journey token over. Then if it is face down, nothing more happens. If it is face up, choose up to 3 cards you have in play with different names and gain a copy of each. The copies you gain come from the Supply and are put into your discard pile. So, every other time you buy this, you will gain up to 3 cards. It does not matter what turned over the Journey token; you could turn it face down with Ranger, then face up with Pilgrimage.",
+        "name": "Pilgrimage",
+        "raw_wikitext": "Once per turn: Turn your Journey token over (it starts face up); then if it's face up, choose up to 3&nbsp;differently named cards you have in play and gain a copy of each.",
+        "wikitext": "Once per turn: Turn your Journey token over (it starts face up); then if it's face up, choose up to 3&nbsp;differently named cards you have in play and gain a copy of each."
+    },
+    "Pillage": {
+        "description": "Trash this. If you did, gain 2 Spoils, and each other player with 5 or more cards in hand reveals their hand and discards a card that you choose.",
+        "extra": "First trash Pillage. If you did trash it, then you gain two Spoils cards and each other player with 5 or more cards in hand reveals his hand and discards a card of your choice. This happens in turn order, starting with the player to your left. The two Spoils cards come from the Spoils pile, which is not part of the Supply, and are put into your discard pile. If there are no Spoils cards left, you do not get one; if there is only one, you just get one.",
+        "name": "Pillage",
+        "raw_wikitext": "Trash this. If you did, gain 2&nbsp;Spoils, and each other player with 5&nbsp;or more cards in hand reveals their hand and discards a card that you choose.",
+        "wikitext": "Trash this. If you did, gain 2&nbsp;Spoils, and each other player with 5&nbsp;or more cards in hand reveals their hand and discards a card that you choose."
+    },
+    "Pious": {
+        "description": "When you gain a Pious card, you may trash a card from your hand.",
+        "extra": "Each time you gain a Pious card, you may optionally trash a card from your hand.",
+        "name": "Pious",
+        "raw_wikitext": "When you gain a Pious card, you may trash a card from your hand.",
+        "wikitext": "When you gain a Pious card, you may trash a card from your hand."
+    },
+    "Pirate": {
+        "description": "At the start of your next turn, gain a Treasure costing up to 6 Coin to your hand.<line>When any player gains a Treasure, you may play this from your hand.",
+        "extra": "You can play this when you gain a Treasure, or when another player gains a Treasure.<br>If you play this during another player's turn, your following turn is when your <i>Pirate</i> gains you a Treasure.<br>The Treasure you gain comes from the Supply and goes directly to your hand.<br>This plays like the Reactions in <i>Menagerie</i>.<br>If you have <i>Capitalism</i>, gaining an Action with +_ Coin in its text will let all players play <i>Pirates</i> from their hand.",
+        "name": "Pirate",
+        "raw_wikitext": "At the start of your next turn, gain a Treasure costing up to {{Cost|6}} to your hand.{{Divline}}When any player gains a Treasure, you may play this from your hand.",
+        "wikitext": "At the start of your next turn, gain a Treasure costing up to 6 Coins to your hand.<line>When any player gains a Treasure, you may play this from your hand."
+    },
+    "Pirate Ship": {
+        "description": "Choose one: Each other player reveals the top 2 cards of his deck, trashes a revealed Treasure that you choose, discards the rest, and if anyone trashed a Treasure you +1 Coffers (take a Coin token); or, +1 Coin per Coin token you've taken with Pirate Ships this game.",
+        "extra": "When you first take this card, take a Pirate Ship player mat. If you use the Pirate Ship to trash treasures, a player with just one card left reveals that last card and then shuffles to get the other card to reveal (without including the revealed card); a player with no cards left shuffles to get both of them. A player who still doesn't have two cards to reveal after shuffling just reveals what he can. Each player trashes one Treasure card at most, of the attacker's choice from the two revealed cards. As long as you trashed at least one Treasure card in this way, place a Coin token on your Pirate Ship player mat. You can't get more than one Coin token each time you play Pirate Ship, no matter how many treasures it trashes. If you choose not to try to trash treasures from the other players, the Pirate Ship is worth one coin for each Coin token on your Pirate Ship player mat. The Coin tokens are cumulative, so after you have used your Pirate Ships to trash coins 3 times (and you trash at least one Treasure card each time), any Pirate Ship you play could be worth 3 coins. Pirate Ship is an Action- Attack and players can reveal Secret Chamber even if you choose to use Pirate Ship for the coin value. [You make your choice on how to use Pirate Ship after other players are done revealing Reactions.]",
+        "name": "Pirate Ship",
+        "raw_wikitext": "Choose one: {{Costplus|1}} per Coin token on your Pirate Ship mat; or each other player reveals the top 2&nbsp;cards of their deck, trashes one of those Treasures that you choose, and discards the rest, and then if anyone trashed a Treasure, you add a Coin token to your Pirate Ship mat.",
+        "wikitext": "Choose one: +1 Coin per Coin token on your Pirate Ship mat; or each other player reveals the top 2&nbsp;cards of their deck, trashes one of those Treasures that you choose, and discards the rest, and then if anyone trashed a Treasure, you add a Coin token to your Pirate Ship mat."
+    },
+    "Pixie": {
+        "description": "+1 Card<br>+1 Action<br>Discard the top Boon. You may trash this to receive that Boon twice.<br><br><i>Heirloom: Goat</i>",
+        "extra": "If you receive a Boon that says to keep it until Clean-up, move it to in front of you, and remember that you get it twice. In games using Pixie, replace one of your starting Coppers with a Goat.",
+        "name": "Pixie",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Discard the top Boon. You may trash this to receive that Boon twice.</p>''Heirloom: Goat''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Discard the top Boon. You may trash this to receive that Boon twice.<n><i>Heirloom: Goat</i>"
+    },
+    "Pixie - Goat": {
+        "description": "<left><u>Pixie</u>:</left><center>+1 Card<br>+1 Action<br>Discard the top Boon. You may trash this to receive that Boon twice.</center><left><i>Heirloom: Goat</i></left><left><u>Goat</u>:</left><center>1 <*COIN*></center><n><n>When you play this, you may trash a card from your hand.",
+        "extra": "For Pixie: If you receive a Boon that says to keep it until Clean-up, move it to in front of you, and remember that you get it twice.\nIn games using Pixie, replace one of your starting Coppers with a Goat.\nFor Goat: Trashing a card is optional.",
+        "name": "Pixie / Goat"
+    },
+    "Plague": {
+        "description": "Gain a Curse to your hand.",
+        "extra": "",
+        "name": "Plague",
+        "raw_wikitext": "Gain a Curse to your hand.",
+        "wikitext": "Gain a Curse to your hand."
+    },
+    "Plan": {
+        "description": "Move your Trashing token to an Action Supply pile (when you buy a card from that pile, you may trash a card from your hand.)",
+        "extra": "When you buy this, you move your Trashing token (the one depicting a tombstone) to any Action Supply pile. This token will let you trash a card from your hand when buying a card from that pile; see the Tokens section.",
+        "name": "Plan",
+        "raw_wikitext": "Move your Trashing token to an Action Supply pile. (When you gain a card from that pile, you may trash a card from your hand.)",
+        "wikitext": "Move your Trashing token to an Action Supply pile. (When you gain a card from that pile, you may trash a card from your hand.)"
+    },
+    "Plateau Shepherds": {
+        "description": "When scoring, pair up your Favors with cards you have costing 2 Coins, for 2 <VP> per pair.",
+        "extra": "",
+        "name": "Plateau Shepherds",
+        "raw_wikitext": "When scoring, pair up your '''Favors''' with cards you have costing {{Cost|2}}, for {{VP|'''2'''}} per pair.",
+        "wikitext": "When scoring, pair up your <b>Favors</b> with cards you have costing 2 Coins, for 2 <VP> per pair."
+    },
+    "Platinum": {
+        "description": "5 <*COIN*>",
+        "extra": "This is not a Kingdom card. You do not use it every game. It is a Treasure worth 5 coins. If only Kingdom cards from Prosperity are being used this game, then the Platinum and Colony piles are added to the Basic cards in the Supply for the game. If a mix of Kingdom cards from Prosperity and other sets are being used, then the inclusion of Platinum and Colony in the Supply should be determined randomly, based on the proportion of Prosperity and non-Prosperity cards in use. For example, choose a random Kingdom card being used - such as the first card dealt out from the Randomizer deck [this is equivalent to rolling a d10 or choosing a card at random after all 10 have been selected] - and if it is from Prosperity, add Platinum and Colony to the Supply. Platinum and Colony are not Kingdom cards; when those are included, there are 10 Kingdom cards, plus Copper, Silver, Gold, Platinum, Estate, Duchy, Province, Colony, and Curse, in the Supply. Use 8 Colonies for a 2-player game, or 12 Colonies for a game with 3 or more players. [Use all 12 Platinum regardless of the number of players. Platinum and Colony are meant to be used together and both or neither should be used, not one or the other.]",
+        "name": "Platinum",
+        "raw_wikitext": "{{Cost|5|xl}}",
+        "wikitext": "5 <*COIN*>"
+    },
+    "Plaza": {
+        "description": "+1 Card<br>+2 Actions<n>You may discard a Treasure card. If you do, +1 Coffers (take a Coin token).",
+        "extra": "First you get +1 card and +2 Actions; then you may discard a Treasure. You can discard the card you drew if it is a Treasure. If you discarded a Treasure card, you +1 Coffers (take a Coin token). Cards with multiple types, one of which is Treasure (such as Harem from Intrigue), are Treasures.",
+        "name": "Plaza",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>You may discard a Treasure for '''+1&nbsp;Coffers'''.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>You may discard a Treasure for <b>+1&nbsp;Coffers</b>."
+    },
+    "Plunder": {
+        "description": "+2 Coin<br>+1 <VP>",
+        "extra": "This gives you a <VP> token every time you play it.",
+        "name": "Plunder",
+        "raw_wikitext": "{{Cost|2|l}}<p>{{VP|'''+1'''}}</p>",
+        "wikitext": "2 <*COIN*><n>{{VP|<b>+1</b>}}"
+    },
+    "Poacher": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>Discard a card per empty Supply pile.",
+        "extra": "You draw your one card before discarding.<n>If there are no empty piles, you do not discard.<n>If there is one empty pile, you discard one card; if there are two empty piles, you discard two cards, and so on.<n>This includes all Supply piles, including Curses, Coppers, Poacher itself, etc.<n>If you do not have enough cards to discard, just discard the rest of your hand.<n><n>Non-Supply piles, such as Spoils, do not matter to Poacher.",
+        "name": "Poacher",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>Discard a card per empty Supply pile.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>Discard a card per empty Supply pile."
+    },
+    "Poet": {
+        "description": "+1 SunToken<br>+1 Card<br>+1 Action<br><br>Reveal the top card of your deck. If it costs 3 Coins or less, put it into your hand",
+        "extra": "Cards with Debt in their costs do not cost \"3 Coins or less.\" The card goes back on top of your deck if it doesn't get put into your hand.",
+        "name": "Poet",
+        "raw_wikitext": "{{Sunplus}}<br>'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If it costs {{Cost|3}} or less, put it into your hand.</p>",
+        "wikitext": "{{Sunplus}}<br><b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If it costs 3 Coins or less, put it into your hand."
+    },
+    "Pooka": {
+        "description": "You may trash a Treasure other than Cursed Gold from your hand for +4 Cards.<br><br><i>Heirloom: Cursed Gold</i>",
+        "extra": "In games using Pooka, replace one of your starting Coppers with a Cursed Gold.",
+        "name": "Pooka",
+        "raw_wikitext": "<p>You may trash a Treasure other than Cursed Gold from your hand, for '''+4&nbsp;Cards'''.</p>''Heirloom: Cursed Gold''",
+        "wikitext": "You may trash a Treasure other than Cursed Gold from your hand, for <b>+4&nbsp;Cards</b>.<n><i>Heirloom: Cursed Gold</i>"
+    },
+    "Pooka - Cursed Gold": {
+        "description": "<left><u>Pooka</u>:</left><center>You may trash a Treasure other than Cursed Gold from your hand for +4 Cards.</center><left><i>Heirloom: Cursed Gold</i></left><left><u>Cursed Gold</u>:</left><center>3 <*COIN*></center><n><n>When you play this, gain a Curse.",
+        "extra": "In games using Pooka, replace one of your starting Coppers with a Cursed Gold.\nYou can choose not to play Cursed Gold, and thus not gain a Curse.",
+        "name": "Pooka / Cursed Gold"
+    },
+    "Poor House": {
+        "description": "+4 Coins<n>Reveal your hand. -1 Coin per Treasure card in your hand, to a minimum of 0 Coins.",
+        "extra": "First you get +4 Coins. Then you reveal your hand, and lose 1 Coin per Treasure card in it. You can lose more than 4 Coins this way, but the amount of coins you have available to spend can never go below 0 Coins. Cards with two types, one of which is Treasure (such as Harem from Intrigue) are Treasure cards.",
+        "name": "Poor House",
+        "raw_wikitext": "{{Costplus|4}}<p>Reveal your hand. –{{Cost|1}} per Treasure card in your hand. (You can't go below {{Cost|0}}.)</p>",
+        "wikitext": "+4 Coins<n>Reveal your hand. –1 Coin per Treasure card in your hand. (You can't go below 0 Coins.)"
+    },
+    "Populate": {
+        "description": "Gain one card from each Action Supply pile.",
+        "extra": "You gain the top card from each Action pile in the Supply; you do not gain non-supply cards like Horse, or non-Action cards like Stockpile.<n>If there are different cards in an Action pile, like the Knights (from Dark Ages), you just get the top one.<n>If a pile is empty, you do not gain one of those.<n>You choose the order to gain the cards, which sometimes matters; normally you can pick up a card from each pile and then choose what order to gain them in.<n>For piles with different cards, the pile is an Action pile if the randomizer is an Action; so, Castles (from Empires) are not one.<n>If you gain Cavalry or Villa (from Empires) with Populate, you return to your Action phase right then, but still finish gaining cards from Populate before doing more things.",
+        "name": "Populate",
+        "raw_wikitext": "Gain one card from each Action Supply pile.",
+        "wikitext": "Gain one card from each Action Supply pile."
+    },
+    "Port": {
+        "description": "+1 Card<br>+2 Actions<line>When you buy this, gain another Port.",
+        "extra": "When you buy a Port, you gain another Port. If you gain a Port some other way, you do not get an extra Port. There are 12 Ports in the pile; use all 12.",
+        "name": "Port",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, gain another Port (that doesn't come with another).",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, gain another Port (that doesn't come with another)."
+    },
+    "Possession": {
+        "description": "The player to your left takes an extra turn after this one, in which you can see all cards he can and make all decisions for him. Any cards he would gain on that turn, you gain instead; any cards of his that are trashed are set aside and returned to his discard pile at end of turn.",
+        "extra": "You are not taking a turn with the deck of the player to your left; that player is taking a turn, with you making the decisions and gaining the cards. This is a crucial difference to keep in mind when considering card interactions - the \"you\" in all cards still refers to the player being Possessed, not the player doing the Possessing. Possession has several pieces to it: -You can see the Possessed player's cards for the entire turn, which means you will see his next hand during Clean-up. You will also see any cards he is entitled to see due to card rules; for example, you can look at cards he has set aside with Native Village (from Seaside). You can count any cards he can count. -Any cards the Possessed player would have gained in any way, you gain instead; this includes cards bought, as well as cards gained due to Actions. The cards you gain this way go to your discard pile, even if they would have gone to that player's hand or the top of his deck or somewhere else. [Possession also gives the Possessing player all tokens the Possessed player would get, including _ Coins, <VP>, and Debt tokens.]",
+        "name": "Possession",
+        "raw_wikitext": "The player to your left takes an extra turn after this one (but not a 2nd extra turn in a row), in which you can see all cards they can and make all decisions for them. Any cards or {{Debt}} they would gain on that turn, you gain instead; any cards of theirs that are trashed are set aside and put in their discard pile at end of turn.",
+        "wikitext": "The player to your left takes an extra turn after this one (but not a 2nd extra turn in a row), in which you can see all cards they can and make all decisions for them. Any cards or {{Debt}} they would gain on that turn, you gain instead; any cards of theirs that are trashed are set aside and put in their discard pile at end of turn."
+    },
+    "Possession 2/2": {
+        "description": "<justify>During the Possessed turn, whenever one of that player's cards is trashed, set it aside, and that player puts it into his discard pile at the end of the turn, after Clean-up. This counts as the card being trashed, so, for example, you could trash a Mining Village (from Intrigue) and get the 2 coins. Getting those cards back at end of turn does not count as those cards being gained (so for example, you won't get them). Other players' cards that are trashed during that turn are not returned.<n>-If you make another player play an Attack via Possession, that Attack will hit you like it would normally. If you want to use a Reaction in response to that Attack (such as Secret Chamber from Intrigue), you would be the one revealing the Reaction, not the player being Possessed.<n>-Possession is cumulative; if you play it twice in one turn, there will be two extra turns after this one.<n>-Cards passed with Masquerade (from Intrigue) are not being gained or trashed, and so are passed normally. Cards returned to the Supply with Ambassador (from Seaside) are also not being trashed, and so return to the Supply normally.</justify>",
+        "extra": "Possession causes an extra turn to be played, like the card Outpost does (from Seaside). The extra turn happens only after this turn is completely over - you will have discarded everything and drawn your next hand. Outpost only prevents itself from giving a player two consecutive turns, it does not prevent other cards or the rules from doing so. So, for example, if you play Possession in a two player game, then after the Possession turn, that player still gets his normal turn. If he played Outpost during that turn though, it would not give him an extra turn. If you play both Outpost and Possession in the same turn, the Outpost turn happens first. If you make someone play Outpost during a turn in which you Possessed them, that player will get the extra turn and make decisions during it and so forth, not you; if you make someone play Possession during a turn in which you Possessed them, that will make that player Possess the player to his left, rather than you getting to Possess anyone further. Possession turns (and other extra turns) do not count for the tiebreaker. Once the game ends, no further turns are played, including extra turns from Possession and Outpost. -Unlike Outpost, Possession is not a Duration card. It is discarded in the Clean-up phase of the turn you played it. [Possession also gives the Possessing player all tokens the Possessed player would get, including _ Coins, <VP>, and Debt tokens.]",
+        "name": "Possession 2/2",
+        "notes": [
+            "This card is currently not used."
+        ]
+    },
+    "Potion": {
+        "description": "1 <*POTION*>",
+        "extra": "This is a basic Treasure card. It costs 4 Coins and produces Potion. It is not a Kingdom card. After you choose 10 Kingdom cards for the Supply, if any of them have Potion in the cost, add the Potion pile to the Supply. Also add the Potion pile if you are using the promotional card Black Market, and the Black Market deck includes at least one card with Potion in the cost. If you don't have any cards with Potion in the cost in the Supply or the Black Market deck, do not use the Potion pile in this game. When you have a Potion pile, put all 16 Potions in it, no matter how many players there are. In games using this pile, if the pile becomes empty, that will count towards the game ending condition.",
+        "name": "Potion",
+        "raw_wikitext": "{{Cost||xl||P}}",
+        "wikitext": "{{Cost||xl||P}}"
+    },
+    "Pouch": {
+        "description": "1 <*COIN*><br><br>+1 Buy",
+        "extra": "This simply gives you 1 Coin and +1 Buy when you play it.",
+        "name": "Pouch",
+        "raw_wikitext": "{{Cost|1|l}}<p>'''+1&nbsp;Buy'''</p>",
+        "wikitext": "1 <*COIN*><n><b>+1&nbsp;Buy</b>"
+    },
+    "Poverty": {
+        "description": "Discard down to 3 cards in hand.",
+        "extra": "",
+        "name": "Poverty",
+        "raw_wikitext": "Discard down to 3&nbsp;cards in hand.",
+        "wikitext": "Discard down to 3&nbsp;cards in hand."
+    },
+    "Practice": {
+        "description": "You may play an Action card from your hand twice.",
+        "name": "Practice",
+        "raw_wikitext": "You may play an Action card from your hand twice."
+    },
+    "Prepare": {
+        "description": "Set aside your hand face up.<br>At the start of your next turn, play those Actions and Treasures in any order, then discard the rest.",
+        "extra": "Once you've set the cards aside, playing all of those Actions and Treasures next turn is mandatory.",
+        "name": "Prepare",
+        "raw_wikitext": "Set aside your hand face up. At the start of your next turn, play those Actions and Treasures in any order, then discard the rest.",
+        "wikitext": "Set aside your hand face up. At the start of your next turn, play those Actions and Treasures in any order, then discard the rest."
+    },
+    "Priest": {
+        "description": "+2 Coin<br><n>Trash a card from your hand. For the rest of this turn, when you trash a card, +2 Coin.",
+        "extra": "When you play this, you get +2 Coin, trash a card from your hand (mandatory), and then for the rest of the turn, trashing a card from your hand will give you +2 Coin. This is cumulative, even if the same Priest is played multiple times (such as with Scepter). For example if you play two Priests and trash two Coppers, you will get +6 Coin total: +2 Coin from each play of Priest, and +2 Coin that the first Priest give you for the second Priest trashing a card. The bonus works even if the card was not trashed from your hand; for example you will get +2 Coin for trashing an Acting Troupe due to playing it, or for trashing a card from the Supply with Lurker (from Intrigue).",
+        "name": "Priest",
+        "raw_wikitext": "{{Costplus|2}}<p>Trash a card from your hand. For the rest of this turn, when you trash a card, {{Costplus|2}}.</p>",
+        "wikitext": "+2 Coins<n>Trash a card from your hand. For the rest of this turn, when you trash a card, +2 Coins."
+    },
+    "Prince": {
+        "description": "You may set this aside. If you do, set aside an Action card from your hand costing up to 4 coins. At the start of each of your turns, play that Action, setting it aside again when you discard it from play. (Stop playing it if you fail to set it aside on a turn you play it).",
+        "extra": "Prince has you play the same cheap action every turn for the rest of the game. The turn you play Prince, you set it aside with an Action from your hand costing 4 coins or less; then every turn after that you play the Action at the start of the turn, and then set it aside again when you discard it from play. If you don't discard the Action then you stop playing it with Prince; Prince at that point is just set aside doing nothing for the rest of the game. That won't normally happen but will happen for example if the Action is a Feast or Mining Village and you trashed it, or if it's a Duration card and so it stayed in play, or if it's a Madman and was returned to its pile, or if it's an Island and was set aside, or if it's a card you put back on your deck with Scheme. The set aside Action technically goes back and forth from being in play to being set aside each turn, but in practice it's easier to leave it sitting on the Prince and just announce resolving it each turn.",
+        "name": "Prince",
+        "raw_wikitext": "You may set aside (on this) a non-Duration, non-Command Action card from your hand costing up to {{Cost|4}}.<br>At the start of each of your turns, play that card, leaving it set aside.",
+        "wikitext": "You may set aside (on this) a non-Duration, non-Command Action card from your hand costing up to 4 Coins.<br>At the start of each of your turns, play that card, leaving it set aside."
+    },
+    "Princess": {
+        "description": "+1 Buy<line>While this is in play, cards cost 2 Coins less, but not less than 0 Coins.<n><i>(This is not in the Supply.)</i>",
+        "extra": "This makes all cards cheaper (to a minimum of 0 coins) as long as it is in play. When it leaves play, it stops making cards cheaper. This applies to cards everywhere - cards in the Supply, cards in hand, cards in decks. For example if you played Princess, then Remake, trashing a Copper, you could gain a Silver, as Silver would cost 1 coin while Copper would still cost 0 coins. Using Throne Room (from Dominion) on Princess will not make cards cost less, as there is still only one copy of Princess in play. This is a Prize; see the Additional Rules.",
+        "name": "Princess",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>This turn, cards cost {{Cost|2}} less.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>This turn, cards cost 2 Coins less.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Prize Goat": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>You may trash a card from your hand.",
+        "extra": "Trashing a card is optional.",
+        "name": "Prize Goat",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>You may trash a card from your hand.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>You may trash a card from your hand."
+    },
+    "Procession": {
+        "description": "You may play a non-Duration Action card from your hand twice. Trash it. Gain an Action card costing exactly 1 Coin more than it.",
+        "extra": "Playing an Action card from your hand is optional. If you do play one, you then play it a second time, then trash it, then gain an Action card costing exactly 1 Coin more than it (even if somehow you failed to trash it). Gaining a card is not optional once you choose to play an Action card, but will fail to happen if no card in the Supply costs the exact amount needed. If something happens due to trashing the card - for example drawing 3 cards due to trashing a Cultist - that will resolve before you gain a card. The gained card comes from the Supply and is put into your discard pile. This does not use up any extra Actions you were allowed to play due to cards like Fortress - Procession itself uses up one Action and that is it. You cannot play any other cards in between resolving the Procession-ed Action card multiple times, unless that Action card specifically tells you to (such as Procession itself does). If you Procession a Procession, you will play one Action twice, trash it, gain an Action card costing 1 Coin more, then play another Action twice, trash it, gain an Action card costing 1 Coin more, then trash the Procession and gain an Action costing 1 Coin more than it. If you Procession a card that gives you +1 Action, such as Vagrant, you will end up with 2 Actions to use afterwards, rather than the one you would have left if you just played two Vagrants. If you use Procession on a Duration card (from Seaside), Procession will stay out until your next turn and the Duration card will have its effect twice on your next turn, even though the Duration card is trashed.",
+        "name": "Procession",
+        "raw_wikitext": "You may play a non-Duration Action card from your hand twice. Trash it. Gain an Action card costing exactly {{Cost|1}} more than it.",
+        "wikitext": "You may play a non-Duration Action card from your hand twice. Trash it. Gain an Action card costing exactly 1 Coin more than it."
+    },
+    "Progress": {
+        "description": "When you gain a card, put it onto your deck.",
+        "name": "Progress",
+        "raw_wikitext": "When you gain a card, put it onto your deck."
+    },
+    "Prosper": {
+        "description": "Gain a Loot, plus any number of differently named Treasures.",
+        "extra": "Gain the Loot first. Then, one at a time, you can choose differently named Treasures to gain, resolving each gain in turn.<br>You don't have to gain any Treasures you don't want (after the Loot).",
+        "name": "Prosper",
+        "raw_wikitext": "Gain a Loot, plus any number of differently named Treasures.",
+        "wikitext": "Gain a Loot, plus any number of differently named Treasures."
+    },
+    "Province": {
+        "description": "6 <*VP*>",
+        "extra": "Put 8 in the Supply in a game with two players. Put 12 in the Supply in a game with three or four players. Put 15 in the Supply in a game with five players. Put 18 in the Supply in a game with six players.",
+        "name": "Province",
+        "raw_wikitext": "{{VP|6|xl}}",
+        "wikitext": "6 <*VP*>"
+    },
+    "Pursue": {
+        "description": "+1 Buy<n>Name a card. Reveal the top 4 cards from your deck. Put the matches back and discard the rest.",
+        "extra": "You can name a card that is not in the game; all four cards will be discarded.",
+        "name": "Pursue",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Name a card.  Reveal the top 4&nbsp;cards from your deck.  Put the matches back and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Name a card.  Reveal the top 4&nbsp;cards from your deck.  Put the matches back and discard the rest."
+    },
+    "Puzzle Box": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>You may set aside a card from your hand face down. Put it into your hand at end of turn.",
+        "extra": "If you set aside a card, the Puzzle Box itself is still discarded normally that turn.<br>The set-aside card goes into your hand after drawing for the next turn.",
+        "name": "Puzzle Box",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>You may set aside a card from your hand face down. Put it into your hand at end of turn.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>You may set aside a card from your hand face down. Put it into your hand at end of turn."
+    },
+    "Quarry": {
+        "description": "1 <*COIN*><line>While this is in play, Action cards cost 2 Coins less.",
+        "extra": "This is a Treasure worth 1 coin, like Copper. While it is in play, Action cards cost 2 coins less, to a minimum of 0 coins. It is cumulative; if you play two Quarries during your Buy phase, then King's Court will only cost 3 coins, rather than the usual 7 coins. It affects the costs of cards that are Actions plus another type, such as Nobles (an Action - Victory card in Intrigue). It is also cumulative with other effects that modify costs; if you play Worker's Village in your Action phase, then two Quarries in your Buy phase, Peddler will cost 2 coins. It affects the costs of cards everywhere, such as cards in players' hands.",
+        "name": "Quarry",
+        "raw_wikitext": "{{Cost|1|l}}<p>This turn, Actions cost {{Cost|2}} less.</p>",
+        "wikitext": "1 <*COIN*><n>This turn, Actions cost 2 Coins less."
+    },
+    "Quartermaster": {
+        "description": "At the start of each of your turns for the rest of the game, choose one: Gain a card costing up to 4 Coin, setting it aside on this; or put a card from this into your hand.",
+        "extra": "Quartermaster stays in play for the rest of the game.<br>Each turn you either gain a card and put it on the Quartermaster, or take one of the cards you've already gained with that Quartermaster and put it into your hand.<br>If you play two Quartermasters, they each have their own set of cards. However if you Throne Room a Quartermaster, you just have one set of cards for it, and twice on each of your turns, either add one or take one.",
+        "name": "Quartermaster",
+        "raw_wikitext": "At the start of each of your turns for the rest of the game, choose one: Gain a card costing up to {{Cost|4}}, setting it aside on this; or put a card from this into your hand.",
+        "wikitext": "At the start of each of your turns for the rest of the game, choose one: Gain a card costing up to 4 Coins, setting it aside on this; or put a card from this into your hand."
+    },
+    "Quest": {
+        "description": "You may discard an Attack, two Curses, or six cards. If you do, gain a Gold.",
+        "extra": "You may either discard an Attack to gain a Gold, or discard two Curses to gain a Gold, or discard any 6 cards to gain a Gold. The gained Gold is put into your discard pile. You may choose to discard 6 cards despite not having enough cards in hand; you will discard everything and not gain a Gold. You may choose to discard two Curses despite only having one; you will discard that Curse and not gain a Gold.",
+        "name": "Quest",
+        "raw_wikitext": "You may discard an Attack, two Curses, or six cards. If you do, gain a Gold.",
+        "wikitext": "You may discard an Attack, two Curses, or six cards. If you do, gain a Gold."
+    },
+    "Rabbits": {
+        "description": "+1 Card<n>+1 Action<br>All other players put a victory card from their hand on their deck.<br>If it's the <b>2nd Rabbits card</b> played (in this turn), players must also search through their discard pile for Victory cards if they have none in hand.<br>If it's the <b>3rd Rabbits card</b> (rabbit plague), all other players must put <b>all</b> Victory cards from their hand and discard pile on their deck.<br><b>Rabbits can only be defended against by Yard Dog.</b>",
+        "extra": "",
+        "name": "Rabbits",
+        "notes": [
+            "Fan expansion: Animals"
+        ]
+    },
+    "Rabble": {
+        "description": "+3 Cards<n>Each other player reveals the top 3 cards of his deck, discards the revealed Actions and Treasures, and puts the rest back on top in any order he chooses.",
+        "extra": "The other players shuffle if necessary to get 3 cards to reveal, and just reveal what they can if they still have fewer than 3 cards. They discard revealed Treasures and Actions and put the rest back on top in whatever order they want. Cards with more than one type match all of their types; for example if a player reveals Nobles from Intrigue, it is an Action - Victory card, which means it is an Action, so he discards it.",
+        "name": "Rabble",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>Each other player reveals the top 3&nbsp;cards of their deck, discards the Actions and Treasures, and puts the rest back in any order they choose.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>Each other player reveals the top 3&nbsp;cards of their deck, discards the Actions and Treasures, and puts the rest back in any order they choose."
+    },
+    "Raid": {
+        "description": "Gain a Silver per Silver you have in play. Each other player puts his -1 Card token on his deck.",
+        "extra": "This Event is like an Attack, but buying it is not playing an Attack, and so cannot be responded to with cards like Moat and Caravan Guard. When you buy this, you gain a Silver for each Silver you have in play; for example, with four Silvers in play, you would gain four Silvers. The Silvers go to your discard pile; if there aren't enough left, just take what is left. Then each other player puts his -1 Card token on top of his deck, which will cause those players to draw one less card the next time they draw cards; see the Tokens section.",
+        "name": "Raid",
+        "raw_wikitext": "Gain a Silver per Silver you have in play. Each other player puts their {{nowrap|–1 Card}} token on their deck.",
+        "wikitext": "Gain a Silver per Silver you have in play. Each other player puts their –1&nbsp;Card token on their deck."
+    },
+    "Raider": {
+        "description": "Each other player with 5 or more cards in hand discards a copy of a card you have in play (or reveals they can’t).<br>At the start of your next turn, +3 Coins.",
+        "extra": "For example if your cards in play are 3 Coppers, a Silver, and a Raider, then each other player with at least 5 cards in hand has to discard a Copper, Silver, or Raider, or reveal their hand to show that they did not have any of those cards.",
+        "name": "Raider",
+        "raw_wikitext": "<p>Each other player with 5&nbsp;or more cards in hand discards a copy of a card you have in play (or reveals they can't).</p>At the start of your next turn, {{Costplus|3}}.",
+        "wikitext": "Each other player with 5&nbsp;or more cards in hand discards a copy of a card you have in play (or reveals they can't).<n>At the start of your next turn, +3 Coins."
+    },
+    "Ranger": {
+        "description": "+1 Buy<n>Turn your Journey token over (it starts face up). If it's face up, +5 Cards.",
+        "extra": "At the start of the game, place your Journey token (the one with the boot) face up. When you play this, you get +1 Buy, and turn the token over. Then if it is face down, nothing more happens. If it is face up, you draw 5 cards. So, every other time you play a Ranger, you will draw 5 cards. It does not matter what turned over the Journey token; you could turn it face down with Giant, then face up with Ranger.",
+        "name": "Ranger",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Turn your Journey token over (it starts face up). Then if it's face up, '''+5&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Turn your Journey token over (it starts face up). Then if it's face up, <b>+5&nbsp;Cards</b>."
+    },
+    "Rapid Expansion": {
+        "description": "When you gain an Action or Treasure, set it aside, and play it at the start of your next turn.",
+        "name": "Rapid Expansion",
+        "raw_wikitext": "When you gain an Action or Treasure, set it aside, and play it at the start of your next turn."
+    },
+    "Ratcatcher": {
+        "description": "+1 Card<br>+1 Action<n>Put this on your Tavern mat.<line>At the start of your turn, you may call this, to trash a card from your hand.",
+        "extra": "When you play this, you get +1 Card and +1 Action, and put it on your Tavern mat. It stays on your mat until you call it at the start of one of your turns. If multiple things can happen at the start of your turn, you can do them in any order. When you call Ratcatcher, you move it from the mat into play, and you trash a card from your hand. Ratcatcher is discarded that turn with your other cards in play.",
+        "name": "Ratcatcher",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Put this on your Tavern mat.</p>{{Divline}}At the start of your turn, you may call this to trash a card from your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Put this on your Tavern mat.<n><line>At the start of your turn, you may call this to trash a card from your hand."
+    },
+    "Rats": {
+        "description": "+1 Card<br>+1 Action<n>Gain a Rats. Trash a card from your hand other than a Rats (or reveal a hand of all Rats).<line>When you trash this, +1 Card.",
+        "extra": "Follow the instructions in order. First draw a card; then gain a Rats from the Supply, putting it into your discard pile; then trash a card from your hand that is not a Rats card. If there are no Rats cards left, you do not gain one. If you have no cards in your hand other than Rats, reveal your hand and you do not trash a card. If Rats is trashed, you draw a card. This happens whether it is your turn or another player's, and regardless of which player has the card that trashed Rats. There are 20 copies of Rats, rather than the usual 10; the pile starts with all 20, regardless of the number of players.",
+        "name": "Rats",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Gain a Rats. Trash a card from your hand other than a Rats (or reveal a hand of all Rats).</p>{{Divline}}When you trash this, '''+1&nbsp;Card'''.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Gain a Rats. Trash a card from your hand other than a Rats (or reveal a hand of all Rats).<n><line>When you trash this, <b>+1&nbsp;Card</b>."
+    },
+    "Raze": {
+        "description": "+1 Action<n>Trash this or a card from your hand. Look at the number of cards from the top of your deck equal to the cost in _ Coins of the trashed card. Put one into your hand and discard the rest.",
+        "extra": "If you trash a card costing 0 Coins with this, you do not get any cards. If you trash a card costing 1 Coin or more, you look at a number of cards from the top of your deck equal to the cost in Coins of the trashed card, take one into your hand, and discard the rest. For example if you trash an Estate, you look at the top two cards of your deck, put one into your hand, and discard the other one. You can trash the Raze itself; normally it costs 2 Coins, so you would look at two cards. Costs may be affected by cards like Bridge Troll. Raze is unaffected by the -1 Card token; if it is on top of your deck, replace it after resolving Raze.",
+        "name": "Raze",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Trash this or a card from your hand. Look at one card from the top of your deck per {{Cost|1}} the trashed card costs. Put one of them into your hand and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Trash this or a card from your hand. Look at one card from the top of your deck per 1 Coin the trashed card costs. Put one of them into your hand and discard the rest."
+    },
+    "Reap": {
+        "description": "Gain a Gold. Set it aside. If you do, at the start of your next turn, play it.",
+        "extra": "This means you will start your next turn with a Gold in play and +3 Coin from it.<n>You discard the Gold that turn as normal.<n>If multiple things happen at the start of your turn, you can order them.<n>This does not skip your Action phase.",
+        "name": "Reap",
+        "raw_wikitext": "Gain a Gold, setting it aside. At the start of your next turn, play it.",
+        "wikitext": "Gain a Gold, setting it aside. At the start of your next turn, play it."
+    },
+    "Rebuild": {
+        "description": "+1 Action<n>Name a card. Reveal cards from the top of your deck until you reveal a Victory card that is not the named card. Discard the other cards. Trash the Victory card and gain a Victory card costing up to 3 Coins more than it.",
+        "extra": "You can name any card, whether or not it is being used this game or is a Victory card. Then reveal cards from your deck until you reveal a Victory card that is not what you named. If you run out of cards, shuffle your discard pile and continue, without shuffling in the revealed cards. If you run out of cards with no cards left in your discard pile, stop there, discard everything, and nothing more happens. If you did find a Victory card that was not what you named, you discard the other revealed cards, trash the Victory card, and gain a Victory card costing up to 3 Coins more than the trashed card. The card you gain comes from the Supply and is put into your discard pile.",
+        "name": "Rebuild",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Name a card. Reveal cards from your deck until you reveal a Victory card you did not name. Discard the rest, trash the Victory card, and gain a Victory card costing up to {{Cost|3}} more than it.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Name a card. Reveal cards from your deck until you reveal a Victory card you did not name. Discard the rest, trash the Victory card, and gain a Victory card costing up to 3 Coins more than it."
+    },
+    "Receive Tribute": {
+        "description": "If you've gained at least 3&nbsp;cards this turn, gain up to 3&nbsp;differently named Action cards you don't have copies of in play.",
+        "name": "Receive Tribute",
+        "raw_wikitext": "If you've gained at least 3&nbsp;cards this turn, gain up to 3&nbsp;differently named Action cards you don't have copies of in play."
+    },
+    "Reckless": {
+        "description": "Follow the instructions of played Reckless cards twice. When discarding one from play, return it to its pile.",
+        "extra": "Reckless does two things, at different times. When you play a Reckless card, you follow its instructions an extra time - follow them entirely, then follow them again - and when you discard one from play, you return it to its Supply pile.<br>With Duration cards those may not happen on the same turn.<br>If you skip following the instructions of the card - for example by using a Way (from Menagerie) instead - then you don't follow them an extra time, but still return the card when discarding it from play.",
+        "name": "Reckless",
+        "raw_wikitext": "Follow the instructions of played Reckless cards twice. When discarding one from play, return it to its pile.",
+        "wikitext": "Follow the instructions of played Reckless cards twice. When discarding one from play, return it to its pile."
+    },
+    "Recruiter": {
+        "description": "+2 Cards<br><n>Trash a card from your hand. +1 Villager per 1 Coin it costs.",
+        "extra": "First you draw 2 cards, then you trash a card from your hand. Trashing is not optional. For each 1 Coin the trashed card costs, you get +1 Villager; for example if you trash a Silver, you get +3 Villagers. You do not get any for Potion or Debt amounts, just for _ Coin.",
+        "name": "Recruiter",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Trash a card from your hand. '''+1&nbsp;Villager''' per {{Cost|1}} it costs.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Trash a card from your hand. <b>+1&nbsp;Villager</b> per 1 Coin it costs."
+    },
+    "Relic": {
+        "description": "2 <*COIN*><n>When you play this, each other player puts his -1 Card token on his deck.",
+        "extra": "This is a Treasure worth 2 Coins. You play it in your Buy phase, like other Treasures. When you play it, you also make each other player put his -1 Card token on his deck, which will cause those players to draw one less card the next time they draw cards; see the Tokens section. Relic is an Attack despite not being an Action; it can be blocked with Moat and responded to with Caravan Guard and so on. A player responding to Relic with Caravan Guard first plays Caravan Guard, including drawing a card, and then puts his -1 Card token on his deck.",
+        "name": "Relic",
+        "raw_wikitext": "{{Cost|2|l}}<p>Each other player puts their {{nowrap|–1 Card}} token on their deck.</p>",
+        "wikitext": "2 <*COIN*><n>Each other player puts their –1&nbsp;Card token on their deck."
+    },
+    "Remake": {
+        "description": "Do this twice: Trash a card from your hand then gain a card costing exactly 1 more than the trashed card.",
+        "extra": "Trash a card from your hand, and gain a card costing exactly 1 coin more than it; then trash another card from your hand, and gain a card costing exactly 1 coin more than that card. If you have no cards in hand, you do not trash anything or gain anything; if you have only one card in hand, trash it and gain a card costing 1 coin more than it. Gained cards come from the Supply and are put into your discard pile. If there is no card at the exact cost needed, you do not gain a card for that trashed card. For example you could use Remake to trash an Estate, gaining a Silver, then trash a Copper, gaining nothing.",
+        "name": "Remake",
+        "raw_wikitext": "Do this twice: Trash a card from your hand, then gain a card costing exactly {{Cost|1}} more than it.",
+        "wikitext": "Do this twice: Trash a card from your hand, then gain a card costing exactly 1 Coin more than it."
+    },
+    "Remodel": {
+        "description": "Trash a card from your hand. Gain a card costing up to 2 Coins more than the trashed card.",
+        "extra": "You cannot trash the Remodel as it isn't in your hand when you resolve it (you can trash a different Remodel card from your hand). If you do not have a card to trash, you cannot gain a card from the Remodel. The gained card goes in your Discard pile. You can only gain cards from the Supply. The gained card need not cost exactly 2 Coins more than the trashed card; it can cost that much or any amount less. You cannot use coins from Treasures or previous Actions (like the Market) to increase the cost of the card you gain. You can trash a card to gain a copy of the same card.",
+        "name": "Remodel",
+        "raw_wikitext": "Trash a card from your hand. Gain a card costing up to {{Cost|2}} more than it.",
+        "wikitext": "Trash a card from your hand. Gain a card costing up to 2 Coins more than it."
+    },
+    "Renown": {
+        "description": "+1 Buy<br><br>This turn, cards cost 2 coin less.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": "Costs can't go below 0 coin. This applies to all cards everywhere - cards in the Supply, cards in hand, cards in decks. For example if you play Renown and then Remake, trashing a Copper, you could gain a Silver, as Silver would cost 1 coin while Copper would still cost 0 coin. Using a card like Throne Room on Renown will make cards cost 4 coin less.",
+        "name": "Renown",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>This turn, cards cost {{Cost|2}} less.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>This turn, cards cost 2 Coins less.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Replace": {
+        "description": "Trash a card from your hand. Gain a card costing up to 2 Coins more than it. If the gained card is an Action or Treasure, put it onto your deck; if it's a Victory card, each other player gains a Curse.",
+        "extra": "Like Remodel, you first trash a card from your hand, then gain a card from the Supply costing up to 2 Coin more than the trashed card, putting the gained card into your discard pile.<n>Replace gives you an additional bonus based on the types of the gained card; if it is an Action or Treasure you move it to the top of your deck, and if it is a Victory card the other players each gain a Curse.<n>It is possible to get both bonuses; if you gain Harem, Mill, or Nobles with Replace, it both goes on your deck and causes the other players to each gain a Curse.",
+        "name": "Replace",
+        "raw_wikitext": "Trash a card from your hand. Gain a card costing up to {{Cost|2}} more than it. If the gained card is an Action or Treasure, put it onto your deck; if it's a Victory card, each other player gains a Curse.",
+        "wikitext": "Trash a card from your hand. Gain a card costing up to 2 Coins more than it. If the gained card is an Action or Treasure, put it onto your deck; if it's a Victory card, each other player gains a Curse."
+    },
+    "Research": {
+        "description": "+1 Action<br><br>Trash a card from your hand. Per 1 Coin it costs, set aside a card from your deck face down (on this). At the start of your next turn, put those cards into your hand.",
+        "extra": "For each 1 Coin the trashed card costs, you set aside the top card of your deck for next turn; for example if you trash a Silver, you set aside the top 3 cards for next turn. If there are not enough cards, just set aside as many as you can. The cards are set aside face down; you can look at them and other players cannot.",
+        "name": "Research",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Trash a card from your hand. Per {{Cost|1}} it costs, set aside a card from your deck face down (on this). At the start of your next turn, put those cards into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Trash a card from your hand. Per 1 Coin it costs, set aside a card from your deck face down (on this). At the start of your next turn, put those cards into your hand."
+    },
+    "Rice": {
+        "description": "+1 Buy<br><br>+1 Coin per different type among cards you have in play.",
+        "extra": "For example, if you had a Daimyo, a Litter, a Fishmonger, three Coppers, and Rice in play, the types would be Action, Command, Shadow, and Treasure, so Rice would make +4 Coins.",
+        "name": "Rice",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>{{Costplus|1}} per different type among cards you have in play.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>+1 Coin per different type among cards you have in play."
+    },
+    "Rice Broker": {
+        "description": "+1 Action<br><br>Trash a card from your hand. If it's a Treasure, +2 Cards. If it's an Action, +5 Cards.",
+        "extra": "If you trash a card that's both a Treasure and an Action, you get +2 Cards and then +5 Cards. If you trash a card with neither type, such as Province, you don't draw any cards.",
+        "name": "Rice Broker",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Trash a card from your hand. If it's a Treasure, '''+2&nbsp;Cards'''. If it's an Action, '''+5&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Trash a card from your hand. If it's a Treasure, <b>+2&nbsp;Cards</b>. If it's an Action, <b>+5&nbsp;Cards</b>."
+    },
+    "Rich": {
+        "description": "When you gain a Rich card, gain a Silver.",
+        "extra": "Each time you gain a Rich card, you also gain a Silver.",
+        "name": "Rich",
+        "raw_wikitext": "When you gain a Rich card, gain a Silver.",
+        "wikitext": "When you gain a Rich card, gain a Silver."
+    },
+    "Ride": {
+        "description": "Gain a Horse.",
+        "extra": "You simply gain a Horse.",
+        "name": "Ride",
+        "raw_wikitext": "Gain a Horse.",
+        "wikitext": "Gain a Horse."
+    },
+    "Ritual": {
+        "description": "Gain a Curse. If you do, trash a card from your hand. +1 <VP> per 1 Coin it cost.",
+        "extra": "This does nothing once the Curse pile is empty.<n>This only gives you +1 <VP> per 1 Coin the trashed card cost; it does not give anything for Debt or Potion in costs.",
+        "name": "Ritual",
+        "raw_wikitext": "Gain a Curse. If you do, trash a card from your hand. {{VP|'''+1'''}} per {{Cost|1}} it costs.",
+        "wikitext": "Gain a Curse. If you do, trash a card from your hand. {{VP|<b>+1</b>}} per 1 Coin it costs."
+    },
+    "River Shrine": {
+        "description": "+1 SunToken<br><br>Trash up to 2 cards from your hand.  At the start of Clean-up, if you didn't gain any cards in your Buy phase this turn, gain a card costing up to 4 Coin.",
+        "extra": "It doesn't matter if you gained cards in your Action phase, only if you did in your Buy phase. If you play multiple River Shrines, they can all gain a card, provided you don't gain a card in your Buy phase. Trashing cards with this is optional; you can gain a card even if you didn't trash any cards. If you have multiple Buy phases, such as via Continue, River Shrine only gains you a card if you didn't gain a card in any of those Buy phases.",
+        "name": "River Shrine",
+        "raw_wikitext": "{{Sunplus}}<p>Trash up to 2&nbsp;cards from your hand. At the start of Clean-up, if you didn't gain any cards in your Buy phase this turn, gain a card costing up to {{Cost|4}}.</p>",
+        "wikitext": "{{Sunplus}}<n>Trash up to 2&nbsp;cards from your hand. At the start of Clean-up, if you didn't gain any cards in your Buy phase this turn, gain a card costing up to 4 Coins."
+    },
+    "Riverboat": {
+        "description": "At the start of your next turn, play the set aside card, leaving it there.<line>Setup: Set-aside an unused non-Duration Action card costing 5 Coins.",
+        "extra": "In setup, choose a non-Duration Action card costing exactly that isn't being used this game, and set a copy of it aside. You can use the randomizers to find such a card. If that card also requires setup, do that setup too. When you play Riverboat, it plays the set aside card at the start of your next turn. This doesn't move the set aside card; it stays set aside, even if it has instructions on it that would move it. Riverboat is normally discarded in your next turn's Clean-up, but it stays in play as long as the card it plays would have, which sometimes is longer (such as a Crown, from Empires, used on a Duration card).",
+        "name": "Riverboat",
+        "raw_wikitext": "At the start of your next turn, play the set aside card, leaving it there.{{Divline}}'''Setup:''' Set aside an unused non-Duration Action card costing {{Cost|5}}.",
+        "wikitext": "At the start of your next turn, play the set aside card, leaving it there.<line><b>Setup:</b> Set aside an unused non-Duration Action card costing 5 Coins."
+    },
+    "Road Network": {
+        "description": "When another player gains a Victory card, +1 Card.",
+        "extra": "This happens every time another player gains a Victory card, whether bought or gained another way, and even if it is your turn.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Road Network",
+        "raw_wikitext": "When another player gains a Victory card, '''+1&nbsp;Card'''.",
+        "wikitext": "When another player gains a Victory card, <b>+1&nbsp;Card</b>."
+    },
+    "Rocks": {
+        "description": "+1 Coin<line>When you gain or trash this, gain a Silver; if it is your Buy phase, put the Silver on your deck, otherwise put it into your hand.",
+        "extra": "If it is another player's turn, then it is not your Buy phase, so the Silver goes to your hand.",
+        "name": "Rocks",
+        "raw_wikitext": "{{Cost|1|l}}{{Divline}}When you gain or trash this: If it's your Buy phase, gain a Silver onto your deck, otherwise gain a Silver to your hand.",
+        "wikitext": "1 <*COIN*><line>When you gain or trash this: If it's your Buy phase, gain a Silver onto your deck, otherwise gain a Silver to your hand."
+    },
+    "Rogue": {
+        "description": "+2 Coins<n>If there are any cards in the trash costing from 3 Coins to 6 Coins, gain one of them. Otherwise, each other player reveals the top 2 cards of his deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest.",
+        "extra": "If there is a card in the trash costing from 3 Coins to 6 Coins, you have to gain one of them; it is not optional. You can look through the trash at any time. The other players get to see what card you took. The gained card goes into your discard pile. Cards with Potion in the cost (from Alchemy) do not cost from 3 Coins to 6 Coins. If there was no card in the trash costing from 3 Coins to 6 Coins, you instead have each other player reveal the top 2 cards of his deck, trash one of them of his choice that costs from 3 Coins to 6 Coins (if possible), and discard the rest. Go in turn order, starting with the player to your left.",
+        "name": "Rogue",
+        "raw_wikitext": "{{Costplus|2}}<p>If there are any cards in the trash costing from {{Cost|3}} to {{Cost|6}}, gain one of them. Otherwise, each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest.</p>",
+        "wikitext": "+2 Coins<n>If there are any cards in the trash costing from 3 Coins to 6 Coins, gain one of them. Otherwise, each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest."
+    },
+    "Ronin": {
+        "description": "Draw until you have 7 cards in hand.<line>You can play this from your deck as if in your hand.",
+        "extra": "See the Shadows section. When you play this, you draw cards one at a time until you have 7 cards in hand, or can't draw any more; if you already had 7 or more cards in hand, you don't draw any.",
+        "name": "Ronin",
+        "raw_wikitext": "Draw until you have 7&nbsp;cards in hand.{{Divline}}You can play this from your deck as if in your hand.",
+        "wikitext": "Draw until you have 7&nbsp;cards in hand.<line>You can play this from your deck as if in your hand."
+    },
+    "Root Cellar": {
+        "description": "+3 Cards<br>+1 Actions<br>+3 Debt",
+        "extra": "This works even if you already had Debt; see the Debt section.",
+        "name": "Root Cellar",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Action'''<br>{{Debtplus|3}}",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Action</b><br>{{Debtplus|3}}"
+    },
+    "Rope": {
+        "description": "1 <*COIN*><br><br>+1 Buy<br>At the start of your next turn, +1 Card and you may trash a card from your hand.",
+        "extra": "When you play this, you get +1 Coin and +1 Buy, and at the start of your next turn, you first draw a card, then may trash a card from your hand.",
+        "name": "Rope",
+        "raw_wikitext": "{{Cost|1|l}}<br>'''+1&nbsp;Buy'''<p>At the start of your next turn, '''+1&nbsp;Card''' and you may trash a card from your hand.</p>",
+        "wikitext": "1 <*COIN*><br><b>+1&nbsp;Buy</b><n>At the start of your next turn, <b>+1&nbsp;Card</b> and you may trash a card from your hand."
+    },
+    "Royal Blacksmith": {
+        "description": "+5 Cards<n>Reveal your hand; discard the Coppers.",
+        "extra": "You discard both Coppers that were in your hand already, and Coppers drawn in the +5 Cards.",
+        "name": "Royal Blacksmith",
+        "raw_wikitext": "'''+5&nbsp;Cards'''<p>Reveal your hand; discard the Coppers.</p>",
+        "wikitext": "<b>+5&nbsp;Cards</b><n>Reveal your hand; discard the Coppers."
+    },
+    "Royal Carriage": {
+        "description": "+1 Action<n>Put this on your Tavern mat.<line>Directly after resolving an Action, if it's still in play, you may call this, to replay that Action.",
+        "extra": "When you play this, you get +1 Action and put it on your Tavern mat. It stays on your mat until you call it, directly after resolving a played Action card that is still in play. Royal Carriage cannot respond to Actions that are no longer in play, such as a Reserve card that was put on the Tavern mat, or a card that trashed itself (like a Raze used to trash itself). When called, Royal Carriage causes you to replay the card you just played. You can call multiple Royal Carriages to replay the same Action multiple times (provided the Action is still in play). You completely resolve the Action before deciding whether or not to use Royal Carriage on it. If you use Royal Carriage to replay a Duration card, Royal Carriage will stay in play until the Duration card is discarded from play, to track the fact that the Duration card has been played twice.",
+        "name": "Royal Carriage",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Put this on your Tavern mat.</p>{{Divline}}After you play an Action card, if it's still in play, you may call this, to replay that Action.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Put this on your Tavern mat.<n><line>After you play an Action card, if it's still in play, you may call this, to replay that Action."
+    },
+    "Royal Galley": {
+        "description": "+1 Card<n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.",
+        "extra": "Playing a non-Duration Action card via this is optional. If you do play one, you resolve the card completely, then set it aside. If it moved elsewhere somehow (for example, if it trashed itself), you fail to set it aside, and Royal Galley is discarded that turn normally.<n>If you do set the card aside, then Royal Galley stays in play with it this turn, and at the start of your next turn you play the card again. Royal Galley and the card are both discarded that turn.<n>Playing a card via Royal Galley does not use up an Action play (though playing Royal Galley itself does).",
+        "name": "Royal Galley",
+        "raw_wikitext": "'''+1&nbsp;Card'''<p>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><n>You may play a non-Duration Action card from your hand. Set it aside; if you did, then at the start of your next turn, play it."
+    },
+    "Royal Seal": {
+        "description": "2 <*COIN*><line>While you have this in play, when you gain a card, you may put that card onto your deck.",
+        "extra": "This is a Treasure worth 2 coins, like Silver. If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. If you use this ability and there are no cards left in your deck, you do not shuffle; the card you gained becomes the only card in your deck. Royal Seal applies to all cards you gain while it is in play, whether bought or gained other ways. If you play the Alchemy card Possession, and during the extra turn you have the possessed played play Royal Seal, he cannot put the card on his deck - he is not gaining the card, you are.",
+        "name": "Royal Seal",
+        "raw_wikitext": "{{Cost|2|l}}{{divline}}While you have this in play, when you gain a card, you may put that card onto your deck.",
+        "wikitext": "2 <*COIN*><line>While you have this in play, when you gain a card, you may put that card onto your deck."
+    },
+    "Ruined Library": {
+        "description": "+1 Card",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Ruined Library",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "'''+1&nbsp;Card'''",
+        "wikitext": "<b>+1&nbsp;Card</b>"
+    },
+    "Ruined Market": {
+        "description": "+1 Buy",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Ruined Market",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "'''+1&nbsp;Buy'''",
+        "wikitext": "<b>+1&nbsp;Buy</b>"
+    },
+    "Ruined Village": {
+        "description": "+1 Action",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Ruined Village",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "'''+1&nbsp;Action'''",
+        "wikitext": "<b>+1&nbsp;Action</b>"
+    },
+    "Ruins": {
+        "description": "<left><u>Abandoned Mine</u>: +1 Coin</left><left><u>Ruined Library</u>: +1 Card</left><left><u>Ruined Market</u>: +1 Buy</left><left><u>Ruined Village</u>: +1 Action</left><left><u>Survivors</u>: Look at the top 2 cards of your deck. Discard them or put them back in any order.</left>",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Ruins"
+    },
+    "Rush": {
+        "description": "+1 Buy<br>The next time you gain an Action card this turn, play it.",
+        "extra": "If you Rush twice in a row, you'll still only play the Action once. You can however Rush, buy an Action and play it, Rush again, and buy another Action and play it.",
+        "name": "Rush",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>The next time you gain an Action card this turn, play it.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>The next time you gain an Action card this turn, play it."
+    },
+    "Rustic Village": {
+        "description": "+1 SunToken<br>+1 Cards<br>+2 Actions<br><br>You may discard 2 cards for +1 Card.",
+        "extra": "First the +1 SunToken happens, which may trigger a Prophecy; then you get +1 Card, +2 Actions, and may discard 2 cards (including the one just drawn) for another +1 Card.",
+        "name": "Rustic Village",
+        "raw_wikitext": "{{Sunplus}}<br>'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>You may discard 2&nbsp;cards for '''+1&nbsp;Card'''.</p>",
+        "wikitext": "{{Sunplus}}<br><b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>You may discard 2&nbsp;cards for <b>+1&nbsp;Card</b>."
+    },
+    "Saboteur": {
+        "description": "Each other player reveals cards from the top of his deck until revealing one costing 3 Coins or more. He trashes that card and may gain a card costing at most 2 Coins less than it. He discards the other revealed cards.",
+        "extra": "Each other player turns over the top cards of his deck until he reveals one costing 3 coins or more. If a player needs to shuffle to continue revealing cards, he does not shuffle in the already revealed cards. If he goes through all of his cards without finding a card costing 3 coins or more, he just discards everything revealed and is done. If he does find a card costing 3 coins or more, he trashes it, and then may choose to gain a card costing at most 2 coins less than the trashed card. For example, if he trashed a card costing 5 coins, he may gain a card costing up to 3 coins. The gained card must be from the Supply and is put into his discard pile, as are his revealed cards. Costs of cards are affected by Bridge.",
+        "name": "Saboteur",
+        "raw_wikitext": "Each other player reveals cards from the top of their deck until revealing one costing {{Cost|3}} or more. They trash that card and may gain a card costing at most {{Cost|2}} less than it. They discard the other revealed cards.",
+        "wikitext": "Each other player reveals cards from the top of their deck until revealing one costing 3 Coins or more. They trash that card and may gain a card costing at most 2 Coins less than it. They discard the other revealed cards."
+    },
+    "Sack of Loot": {
+        "description": "1 <*COIN*><br><br>+1 Buy<br>Gain a Loot.",
+        "extra": "When you play this, you get +1 Coin and +1 Buy, and gain a Loot.",
+        "name": "Sack of Loot",
+        "raw_wikitext": "{{Cost|1|l}}<br>'''+1&nbsp;Buy'''<p>Gain a Loot.</p>",
+        "wikitext": "1 <*COIN*><br><b>+1&nbsp;Buy</b><n>Gain a Loot."
+    },
+    "Sacred Grove": {
+        "description": "+1 Buy<br>+3 Coins<br>Receive a Boon. If it doesn’t give +1 Coins, each other player may receive it.",
+        "extra": "You have to receive the Boon; the other players can choose to receive it. The Field's Gift and The Forest's Gift are not shared. The River's Gift means that each player choosing to receive it draws a card at the end of your turn, at the same time as you.",
+        "name": "Sacred Grove",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|3}}<p>Receive a Boon. If it doesn't give {{Costplus|1}}, each other player may receive it.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+3 Coins<n>Receive a Boon. If it doesn't give +1 Coin, each other player may receive it."
+    },
+    "Sacrifice": {
+        "description": "Trash a card from your hand.<n>If it's an...<n>Action card, +2 Cards, +2 Actions<n>Treasure card, +2 Coin<n>Victory card, +2 <VP>",
+        "extra": "If you trash a card with multiple types, you get all relevant bonuses; for example if you trash Crown, you get +2 Cards, +2 Actions, and +2 Coin. If you trash a card with no relevant types (such as Curse), you get nothing.",
+        "name": "Sacrifice",
+        "raw_wikitext": "<p>Trash a card from your hand.<br>If it's an&hellip;</p>Action card, '''+2&nbsp;Cards''' and '''+2&nbsp;Actions'''<br>Treasure card, {{Costplus|2}}<br>Victory card, {{VP|'''+2'''}}",
+        "wikitext": "Trash a card from your hand.<br>If it's an&hellip;<n>Action card, <b>+2&nbsp;Cards</b> and <b>+2&nbsp;Actions</b><br>Treasure card, +2 Coins<br>Victory card, {{VP|<b>+2</b>}}"
+    },
+    "Sage": {
+        "description": "+1 Action<n>Reveal cards from the top of your deck until you reveal one costing 3 Coins or more. Put that card into your hand and discard the rest.",
+        "extra": "If you run out of cards while revealing cards, shuffle your discard pile (not including the revealed cards) and continue. If you run out of cards to reveal and have no cards in your discard pile, stop there; discard everything revealed, and you do not get a card. If you find a card costing 3 Coins or more, put that one into your hand and discard the rest. For example you might reveal Copper, then Copper, then Curse, then Province; Province costs 8 Coins, so you would stop there, put Province in your hand, and discard the two Coppers and the Curse.",
+        "name": "Sage",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Reveal cards from the top of your deck until you reveal one costing {{Cost|3}} or more. Put that card into your hand and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Reveal cards from the top of your deck until you reveal one costing 3 Coins or more. Put that card into your hand and discard the rest."
+    },
+    "Sailor": {
+        "description": "+1 Action<br>Once this turn, when you gain a Duration card, you may play it.<br><br>At the start of your next turn, +2 Coin and you may trash a card from your hand.",
+        "extra": "If you gain a Duration card the turn you play <i>Sailor</i>, playing it is optional.<br>This is cumulative; if you play two <i>Sailors</i>, you can play up to two gained Duration cards. However two <i>Sailors</i> cannot play the same gained Duration card twice.<br><i>Sailor</i> applies to cards gained due to being bought, or gained other ways, such as with <i>Workshop</i>.<br>If you gain a Duration card in your Buy phase, <i>Sailor</i> can play it, even though it's your Buy phase. If such a card gives you +Actions, that doesn't let you play more Action cards in your Buy phase; if it draws Treasure cards, you can only play them if you haven't bought any cards yet.<br>The ability to play Duration cards only happens the turn you play <i>Sailor</i>; on your next turn, you just get +2 Coin and may trash a card from your hand.<br>The Duration doesn't need to be an Action, meaning that you can play Night-Durations when you gain them (like <i>Cobbler</i>).<br>If you exchange a <i>Hero</i> for a <i>Champion</i>, you aren't gaining it, so you can't play it.<br>If you gain a <i>Garrison</i> and play it, you'll immediately add a token to <i>Garrison</i>.<br>This can play a gained Duration even if it was gained to somewhere other than your discard pile (such as a <i>Guardian</i>, or a card gained with <i>Blockade</i>), or if another card is trying to move it at the same time (such as <i>Gatekeeper</i>). But if the gained card has already gotten moved (e.g. by another <i>Sailor</i>), then this can't play it.",
+        "name": "Sailor",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Once this turn, when you gain a Duration card, you may play it.</p>At the start of your next turn, {{Costplus|2}} and you may trash a card from your hand.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Once this turn, when you gain a Duration card, you may play it.<n>At the start of your next turn, +2 Coins and you may trash a card from your hand."
+    },
+    "Salt the Earth": {
+        "description": "+1 <VP><n>Trash a Victory card from the Supply.",
+        "extra": "If the trashed card does something when trashed (such as Crumbling Castle), you do that thing.",
+        "name": "Salt the Earth",
+        "raw_wikitext": "{{VP|'''+1'''}}<p>Trash a Victory card from the Supply.</p>",
+        "wikitext": "{{VP|<b>+1</b>}}<n>Trash a Victory card from the Supply."
+    },
+    "Salvager": {
+        "description": "+1 Buy<br>Trash a card from your hand.<br>+_ Coins  equal to its cost.",
+        "extra": "If you have at least one card in your hand, then you must trash one. If you don't have a card in hand left to trash, you get no coins, but still get the +1 Buy.",
+        "name": "Salvager",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Trash a card from your hand. {{Costplus|1}} per {{Cost|1}} it costs.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Trash a card from your hand. +1 Coin per 1 Coin it costs."
+    },
+    "Samurai": {
+        "description": "Each other player discards down to 3 cards in hand (once).<br><br>At the start of each of your turns this game, +1 Coin.<br><i>(This stays in play.)</i>",
+        "extra": "When you play a Samurai, each other player discards down to 3 cards in hand. After that the Samurai stays in play, and produces +1 Coin at the start of each of your turns for the rest of the game. It doesn't make players discard again.",
+        "name": "Samurai",
+        "raw_wikitext": "Each other player discards down to 3&nbsp;cards in hand (once).<p>At the start of each of your turns this game, {{Costplus|1}}.</p>''(This stays in play.)''",
+        "wikitext": "Each other player discards down to 3&nbsp;cards in hand (once).<n>At the start of each of your turns this game, +1 Coin.<n><i>(This stays in play.)</i>"
+    },
+    "Sanctuary": {
+        "description": "+1 Card<br>+1 Action<br>+1 Buy<br>You may Exile a card from your hand.",
+        "extra": "Exiling a card is optional.",
+        "name": "Sanctuary",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Buy'''<p>You may Exile a card from your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Buy</b><n>You may Exile a card from your hand."
+    },
+    "Sauna": {
+        "description": "+1 Card<br>+1 Action<br>You may play an Avanto from your hand.<line>While this is in play, when you play a Silver, you may trash a card from your hand.",
+        "extra": "Sauna is a promotional Action card. It's a cantrip that allows you to trash a card when you play a Silver. It is a split pile card, with five copies of Sauna sitting on top of five copies of Avanto.",
+        "name": "Sauna",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may play an Avanto from your hand.</p>This turn, when you play a Silver, you may trash a card from your hand.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may play an Avanto from your hand.<n>This turn, when you play a Silver, you may trash a card from your hand."
+    },
+    "Sauna - Avanto": {
+        "description": "<left><u>Sauna</u>:</left><n>+1 Card<br>+1 Action<n>You may play an Avanto from your hand.<n>While this is in play, when you play a Silver, you may trash a card from your hand.<n><left><u>Avanto</u>:</left><n>+3 Cards<n>You may play a Sauna from your hand.",
+        "extra": "Sauna / Avanto is a split pile with five copies of Sauna placed on top of five copies of Avanto during setup. Sauna is a cantrip that allows you to trash a card when you play a Silver. Avanto is a terminal draw card that can potentially become non-terminal if you have a Sauna in your hand to play.",
+        "name": "Sauna / Avanto"
+    },
+    "Save": {
+        "description": "+1 Buy<n>Once per turn: Set aside a card from your hand, and put it into your hand at end of turn (after drawing).",
+        "extra": "You can only buy this once per turn. When you do, you get +1 Buy (letting you buy another Event or a card afterwards), set aside a card from your hand face down (the other players do not get to see it), and put it into your hand at the end of the turn, after drawing your hand for the next turn. For example you might set aside an unplayed Copper, and then after drawing your 5 cards for next turn, add the Copper to your hand.",
+        "name": "Save",
+        "raw_wikitext": "Once per turn: '''+1&nbsp;Buy'''. Set aside a card from your hand, and put it into your hand at end of turn (after drawing).",
+        "wikitext": "Once per turn: <b>+1&nbsp;Buy</b>. Set aside a card from your hand, and put it into your hand at end of turn (after drawing)."
+    },
+    "Scavenger": {
+        "description": "+2 Coins<n>You may put your deck into your discard pile. Look through your discard pile and put one card from it on top of your deck.",
+        "extra": "Putting your deck into your discard pile is optional, but putting a card from your discard pile on top of your deck is not; you do it unless there are no cards in your discard pile. Putting your deck into your discard pile will not trigger Tunnel (from Hinterlands). If your deck has no cards in it, such as from putting them into your discard pile, then the card you put on top of your deck will be the only card in your deck.",
+        "name": "Scavenger",
+        "raw_wikitext": "{{Costplus|2}}<p>You may put your deck into your discard pile. Put a card from your discard pile onto your deck.</p>",
+        "wikitext": "+2 Coins<n>You may put your deck into your discard pile. Put a card from your discard pile onto your deck."
+    },
+    "Scepter": {
+        "description": "When you play this, choose one:<br>+2 Coin; or replay an Action card you played this turn that's still in play.",
+        "extra": "This cannot replay a Duration card you played on previous turn, but can replay one played the same turn (in which case Scepter will stay in play until the Duration card leaves play). This can cause you to get +Actions in your Buy phase, but that does not let you play Action cards in your Buy phase (though Scepter itself replays one). If this causes you to draw cards and some of them are Treasures, you can still play those Treasures.",
+        "name": "Scepter",
+        "raw_wikitext": "Choose one: {{Costplus|2}}; or replay an non-Command Action card you played this turn that's still in play.",
+        "wikitext": "Choose one: +2 Coins; or replay an non-Command Action card you played this turn that's still in play."
+    },
+    "Scheme": {
+        "description": "+1 Card<br>+1 Action<n>At the start of Clean-up this turn, you may choose an Action card you have in play. If you discard it from play this turn, put it on your deck.",
+        "extra": "When you play this, you get +1 card and +1 Action, and set up an effect to happen later in the turn, at the start of Clean- up. At that time, you may optionally choose an Action card you have in play. If you discard that Action card from play this turn, as you normally do, you will put it on top of your deck. This happens before you draw cards for next turn. The Action card you choose can be Scheme itself, or any other Action card you have in play, which might have been played before or after you played Scheme. If the Action card is not discarded during Clean-up, for example due to being a Duration card from Seaside that was played this turn, then it does not get put on top of your deck.",
+        "name": "Scheme",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>This turn, you may put one of your Action cards onto your deck when you discard it from play.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>This turn, you may put one of your Action cards onto your deck when you discard it from play."
+    },
+    "Scholar": {
+        "description": "Discard your hand.<n>+7 Cards.",
+        "extra": "If drawing causes you to shuffle, you will shuffle in the discarded cards.",
+        "name": "Scholar",
+        "raw_wikitext": "Discard your hand. '''+7&nbsp;Cards'''.",
+        "wikitext": "Discard your hand. <b>+7&nbsp;Cards</b>."
+    },
+    "Scout": {
+        "description": "+1 Action<n>Reveal the top 4 cards of your deck. Put the revealed Victory cards into your hand. Put the other cards on top of your deck in any order.",
+        "extra": "If there are fewer than 4 cards left in your deck, reveal all the cards in your deck, shuffle your discard pile (which does not include currently revealed cards), and then reveal the remainder needed. Action - Victory cards are Victory cards. Curse cards are not Victory cards. Take all revealed Victory cards into your hand; you cannot choose to leave some on top. You do not have to reveal the order that you put the cards back in.",
+        "name": "Scout",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Reveal the top 4&nbsp;cards of your deck. Put the revealed Victory cards into your hand. Put the other cards on top of your deck in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Reveal the top 4&nbsp;cards of your deck. Put the revealed Victory cards into your hand. Put the other cards on top of your deck in any order."
+    },
+    "Scouting Party": {
+        "description": "+1 Buy<n>Look at the top 5 cards of your deck. Discard 3 of them and put the rest back on top of your deck in any order.",
+        "extra": "When you buy this you get +1 Buy (letting you buy another Event or a card afterwards). Then look at the top 5 cards of your deck, discarding 3 and putting the rest on top of your deck in any order. If there are fewer than 5 cards even after shuffling, you still discard 3 of them; if there are only 3 cards left between your deck and discard pile, all 3 will be discarded. Scouting Party is unaffected by the -1 Card token; if it is on top of your deck, replace it after resolving Scouting Party.",
+        "name": "Scouting Party",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Look at the top 5&nbsp;cards of your deck. Discard 3&nbsp;and put the rest back in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Look at the top 5&nbsp;cards of your deck. Discard 3&nbsp;and put the rest back in any order."
+    },
+    "Scrap": {
+        "description": "Trash a card from your hand.<n>Choose a different thing per 1 Coin it costs: +1 Card; +1 Action; +1 Buy; +1 Coin; gain a Silver; gain a Horse.",
+        "extra": "First trash a card, then choose a different bonus per 1 Coin the card cost, then do them in the order listed.<n>So you might trash an Estate, choose +1 Card and \"gain a Horse,\" then draw a card and then gain the Horse.",
+        "name": "Scrap",
+        "raw_wikitext": "Trash a card from your hand. Choose a different thing per {{Cost|1}} it costs: '''+1&nbsp;Card'''; '''+1&nbsp;Action'''; '''+1&nbsp;Buy'''; {{Costplus|1}}; gain a Silver; gain a Horse.",
+        "wikitext": "Trash a card from your hand. Choose a different thing per 1 Coin it costs: <b>+1&nbsp;Card</b>; <b>+1&nbsp;Action</b>; <b>+1&nbsp;Buy</b>; +1 Coin; gain a Silver; gain a Horse."
+    },
+    "Scrounge": {
+        "description": "Choose one: Trash a card from your hand;<br>or gain an Estate from the trash, and if you did, gain a card costing up to 5 Coin.",
+        "extra": "You may either trash a card from your hand, or may gain an Estate from the trash.<br>If you gained an Estate, you then also gain a card costing up to 5 Coin from the Supply.",
+        "name": "Scrounge",
+        "raw_wikitext": "Choose one: Trash a card from your hand; or gain an Estate from the trash, and if you did, gain a card costing up to {{Cost|5}}.",
+        "wikitext": "Choose one: Trash a card from your hand; or gain an Estate from the trash, and if you did, gain a card costing up to 5 Coins."
+    },
+    "Scrying Pool": {
+        "description": "+1 Action<n>Each player (including you) reveals the top card of his deck and either discards it or puts it back, your choice. Then reveal cards from the top of your deck until revealing one that isn't an Action.<n>Put all of your revealed cards into your hand.",
+        "extra": "First you reveal the top card of each player's deck, and either have them discard it or have them put it back. After you finish making those decisions, reveal cards from the top of your deck until you reveal a card that isn't an Action card. If you run out of cards without revealing an Action card, shuffle your discard pile and keep going. If you have no discard pile left either, stop there. Put all of the revealed Action cards into your hand, plus that first non-Action you revealed. If the very first card you revealed was not an Action, that card goes into your hand. Cards with multiple types, one of which is Action, are Actions. The only cards that go into your hand are the ones revealed as part of the revealing cards until finding a non-Action; you do not get discarded cards from the first part of what Scrying Pool did, or cards from other players' decks.",
+        "name": "Scrying Pool",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Each player (including you) reveals the top card of their deck and either discards it or puts it back, your choice. Then reveal cards from your deck until revealing one that isn't an Action. Put all of those revealed cards into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Each player (including you) reveals the top card of their deck and either discards it or puts it back, your choice. Then reveal cards from your deck until revealing one that isn't an Action. Put all of those revealed cards into your hand."
+    },
+    "Sculptor": {
+        "description": "Gain a card to your hand costing up to 4 Coin. If it's a Treasure, +1 Villager.",
+        "extra": "The card is gained to your hand; that is not optional. If you gain a Nomad Camp (from Hinterlands) with this, it goes to your hand.",
+        "name": "Sculptor",
+        "raw_wikitext": "Gain a card to your hand costing up to {{Cost|4}}. If it's a Treasure, '''+1&nbsp;Villager'''.",
+        "wikitext": "Gain a card to your hand costing up to 4 Coins. If it's a Treasure, <b>+1&nbsp;Villager</b>."
+    },
+    "Sea Chart": {
+        "description": "+1 Card<br>+1 Action<br><br>Reveal the top card of your deck. If you have a copy of it in play, put it into your hand.",
+        "extra": "If you have a copy of the revealed card in play - including the just played <i>Sea Chart</i>, or a Duration card that you have in play from a previous turn - then you put the revealed card into your hand; otherwise, you leave the card on top of your deck.",
+        "name": "Sea Chart",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If you have a copy of it in play, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If you have a copy of it in play, put it into your hand."
+    },
+    "Sea Hag": {
+        "description": "Each other player discards the top card of his deck, then gains a Curse card, putting it on top of his deck.",
+        "extra": "A player with no cards left in his deck shuffles first in order to get a card to discard. If he still has no cards, he doesn't discard one. A player discarding his last card to this has the gained Curse become the only card in his deck. If there aren't enough Curses left to go around, deal them out in turn order, starting with the player to the left of the player who played Sea Hag.",
+        "name": "Sea Hag",
+        "raw_wikitext": "Each other player discards the top card of their deck, then gains a Curse onto their deck.",
+        "wikitext": "Each other player discards the top card of their deck, then gains a Curse onto their deck."
+    },
+    "Sea Trade": {
+        "description": "<b>+1&nbsp;Card</b> per Action card you have in play. Trash up to that many cards from your hand.",
+        "name": "Sea Trade",
+        "raw_wikitext": "'''+1&nbsp;Card''' per Action card you have in play. Trash up to that many cards from your hand."
+    },
+    "Sea Witch": {
+        "description": "+2 Cards<br>Each other player gains a Curse.<br><br>At the start of your next turn, +2 Cards, then discard 2 cards.",
+        "extra": "When you play this, you draw 2 cards and each other player gains a Curse; then at the start of your next turn, you draw 2 cards and then discard 2 cards.",
+        "name": "Sea Witch",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each other player gains a Curse.</p>At the start of your next turn, '''+2&nbsp;Cards''', then discard 2&nbsp;cards.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Each other player gains a Curse.<n>At the start of your next turn, <b>+2&nbsp;Cards</b>, then discard 2&nbsp;cards."
+    },
+    "Search": {
+        "description": "+2 Coin<br>The next time a Supply pile empties, trash this and gain a Loot.",
+        "extra": "If you Throne Room a Search, Throne Room will stay out with Search until a pile empties, and then you'll trash Search once but gain two Loots (and discard Throne Room that turn).",
+        "name": "Search",
+        "raw_wikitext": "{{Costplus|2}}<p>The next time a Supply pile empties, trash this and gain a Loot.</p>",
+        "wikitext": "+2 Coins<n>The next time a Supply pile empties, trash this and gain a Loot."
+    },
+    "Seaway": {
+        "description": "Gain an Action card costing up to 4 Coin. Move your +1 Buy token to its pile (when you play a card from that pile, you first get +1 Buy).",
+        "extra": "When you buy this, first you gain an Action card costing up to 4 Coins. The Action card comes from the Supply and is put into your discard pile. Then move your +1 Buy token to the pile the Action card came from. The token gives you +1 Buy when playing a card from that pile; see the Tokens section. It only matters how much the card costs that you gain; the cost is not checked later. For example you can play Bridge Troll, then use Seaway to gain a Bridge Troll (currently costing 4 Coins due to its own effect), and the token will stay there even when Bridge Troll costs 5 Coins later. You can use Seaway to gain Sir Martin (from Dark Ages) when he's on top of the Knights pile; then your +1 Buy token will be on the Knights pile, even though any remaining Knights will cost 5 Coins. You cannot use Seaway on an empty pile just to move the +1 Buy token; you have to pick a card you can gain.",
+        "name": "Seaway",
+        "raw_wikitext": "Gain an Action card costing up to {{Cost|4}}. Move your +1&nbsp;Buy token to its pile. (When you play a card from that pile, you first get '''+1&nbsp;Buy'''.)",
+        "wikitext": "Gain an Action card costing up to 4 Coins. Move your +1&nbsp;Buy token to its pile. (When you play a card from that pile, you first get <b>+1&nbsp;Buy</b>.)"
+    },
+    "Secluded Shrine": {
+        "description": "+1 Coin<br>The next time you gain a Treasure, trash up to 2 cards from your hand.",
+        "extra": "This can trigger on any player's turn.<br>It triggers even if the player can't or doesn't want to trash anything; they don't have to trash anything, but Secluded Shrine is done, and is discarded that turn.",
+        "name": "Secluded Shrine",
+        "raw_wikitext": "{{Costplus|1}}<p>The next time you gain a Treasure, trash up to 2&nbsp;cards from your hand.</p>",
+        "wikitext": "+1 Coin<n>The next time you gain a Treasure, trash up to 2&nbsp;cards from your hand."
+    },
+    "Secret Cave": {
+        "description": "+1 Card<br>+1 Action<br>You may discard 3 cards. If you did, then at the start of your next turn, +3 Coin.<br><br><i>Heirloom: Magic Lamp</i>",
+        "extra": "If you do not discard three cards, Secret Cave is discarded from play at end of turn. If you do discard three cards, Secret Cave stays out until the Cleanup of your next turn, and you get +3 Coins at the start of that turn. You can choose to discard three cards even with fewer cards in hand, and will discard your remaining cards, but will not get the bonus. In games using Secret Cave, replace one of your starting Coppers with a Magic Lamp.",
+        "name": "Secret Cave",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may discard 3&nbsp;cards. If you did, then at the start of your next turn, {{Costplus|3}}.</p>''Heirloom: Magic Lamp''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may discard 3&nbsp;cards. If you did, then at the start of your next turn, +3 Coins.<n><i>Heirloom: Magic Lamp</i>"
+    },
+    "Secret Cave - Magic Lamp": {
+        "description": "<left><u>Secret Cave</u>:</left><center>+1 Card</center><center>+1 Action</center><left>You may discard 3 cards. If you did, then at the start of your next turn, +3 Coin.</left><left><i>Heirloom: Magic Lamp</i></left><left><u>Magic Lamp</u>:</left><center>1 <*COIN*></center><n><n>When you play this, if there are at least 6 cards that you have exactly 1 copy of in play, trash this. If you do, gain 3 Wishes from their pile.",
+        "extra": "If you do not discard three cards, Secret Cave is discarded from play at end of turn. If you do discard three cards, Secret Cave stays out until the Cleanup of your next turn, and you get +3 Coins at the start of that turn. You can choose to discard three cards even with fewer cards in hand, and will discard your remaining cards, but will not get the bonus.\nIn games using Secret Cave, replace one of your starting Coppers with a Magic Lamp.\nMagic Lamp itself counts as one of the six cards. A card you have two or more copies of in play does not count; you have to have exactly one copy in play to count a card. You can play more Treasures after trashing Magic Lamp, and still got 1 Coin from it for that turn.",
+        "name": "Secret Cave / Magic Lamp"
+    },
+    "Secret Chamber": {
+        "description": "Discard any number of cards. +1 Coin per card discarded.<line>When another player plays an Attack card, you may reveal this from your hand. If you do, +2 cards, then put 2 cards from your hand on top of your deck.",
+        "extra": "When you play this as an Action on your turn, you first discard any number of cards from your hand, then get 1 coin per card you discarded. You may choose to discard zero cards, but then you will get zero additional coins. The other ability does nothing at that time as it is only used as a Reaction. When someone else plays an Attack card, you may reveal Secret Chamber from your hand. If you do, first you draw 2 cards, then you put at 2 cards from your hand on top of your deck (in any order). The cards you put back do not have to be the ones you drew. You can put Secret Chamber itself on top of your deck; it's still on your hand when you reveal it. Revealing Secret Chamber happens prior to resolving what an Attack does to you. For example, if another player plays Thief, you can reveal Secret Chamber, draw 2 cards, put 2 back, and then you resolve getting hit by the Thief. You can reveal Secret Chamber whenever another player plays an Attack card, even if that Attack would not affect you. Also, you can reveal more than one Reaction card in response to an Attack. For example, after revealing the Secret Chamber in response to an Attack and resolving the effect of the Secret Chamber, you can still reveal a Moat to avoid the Attack completely.",
+        "name": "Secret Chamber",
+        "raw_wikitext": "Discard any number of cards. {{Costplus|1}} per card discarded.{{Divline}}When another player plays an Attack card, you may reveal this from your hand. If you do, +2&nbsp;Cards, then put 2&nbsp;cards from your hand on top of your deck.",
+        "wikitext": "Discard any number of cards. +1 Coin per card discarded.<line>When another player plays an Attack card, you may reveal this from your hand. If you do, +2&nbsp;Cards, then put 2&nbsp;cards from your hand on top of your deck."
+    },
+    "Secret Passage": {
+        "description": "+2 Cards<br>+1 Action<n>Take a card from your hand and put it anywhere in your deck.",
+        "extra": "First draw 2 cards and get +1 Action; then put a card from your hand anywhere in your deck.<n>The card can be one you just drew or any other card from your hand.<n>It can go on top of your deck, on the bottom, or anywhere in-between; you can count out a specific place to put it, e.g. four cards down.<n>If there are no cards left in your deck, the card put back becomes the only card in your deck.<n>Where you put the card is public knowledge.<n>You don't have to put the card into a specific spot, you can just shove it into your deck if you want.",
+        "name": "Secret Passage",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Take a card from your hand and put it anywhere in your deck.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Take a card from your hand and put it anywhere in your deck."
+    },
+    "Seer": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top 3 cards of your deck. Put the ones costing from 2 Coin to 4 Coin into your hand. Put the rest back in any order.",
+        "extra": "Cards with Potion (from Alchemy) or Debt (from Empires) in their cost do not cost from 2 Coin to 4 Coin.",
+        "name": "Seer",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top 3&nbsp;cards of your deck. Put the ones costing from {{Cost|2}} to {{Cost|4}} into your hand. Put the rest back in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top 3&nbsp;cards of your deck. Put the ones costing from 2 Coins to 4 Coins into your hand. Put the rest back in any order."
+    },
+    "Seize the Day": {
+        "description": "Once per game: Take an extra turn after this one.",
+        "extra": "The extra turn is like a normal turn, except that it does not count for the tiebreaker.",
+        "name": "Seize the Day",
+        "raw_wikitext": "Once per game: Take an extra turn after this one.",
+        "wikitext": "Once per game: Take an extra turn after this one."
+    },
+    "Sentinel": {
+        "description": "Look at the top 5 cards of your deck. You may trash up to 2 of them. Put the rest back in any order.",
+        "extra": "Shuffle as needed; if you don't have five cards even after shuffling, you look at all of them.",
+        "name": "Sentinel",
+        "raw_wikitext": "Look at the top 5&nbsp;cards of your deck. You may trash up to 2&nbsp;of them. Put the rest back in any order.",
+        "wikitext": "Look at the top 5&nbsp;cards of your deck. You may trash up to 2&nbsp;of them. Put the rest back in any order."
+    },
+    "Sentry": {
+        "description": "+1 Card<br>+1 Action<n>Look at the top 2 cards of your deck. Trash and/or discard any number of them.<n>Put the rest back on top in any order.",
+        "extra": "First you draw a card and get +1 Action.<n>Then you look at the top 2 cards of your deck.<n>You can trash both, or discard both, or put both back in either order; or you can trash one and discard one, or trash one and put one back, or discard one and put one back.",
+        "name": "Sentry",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Look at the top 2&nbsp;cards of your deck. Trash and/or discard any number of them. Put the rest back on top in any order.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Look at the top 2&nbsp;cards of your deck. Trash and/or discard any number of them. Put the rest back on top in any order."
+    },
+    "Settlers": {
+        "description": "+1 Card<br>+1 Action<n>Look through your discard pile. You may reveal a Copper from it and put it into your hand.",
+        "extra": "You can look through your discard pile even if you know there is no Copper in it.",
+        "name": "Settlers",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may reveal a Copper from your discard pile and put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may reveal a Copper from your discard pile and put it into your hand."
+    },
+    "Settlers - Bustling Village": {
+        "description": "<left><u>Settlers</u>:</left><n>+1 Card<br>+1 Action<n>Look through your discard pile. You may reveal a Copper from it and put it into your hand.<br><left><u>Bustling Village</u>:</left><n>+1 Card<br>+3 Actions<n>Look through your discard pile. You may reveal a Settlers from it and put it into your hand.",
+        "extra": "<u>Settlers</u>: You can look through your discard pile even if you know there is no Copper in it.<n><u>Bustling Village</u>: You can look through your discard pile even if you know there are no Settlers in it.",
+        "name": "Settlers / Bustling Village"
+    },
+    "Sewers": {
+        "description": "When you trash a card other than with this, you may trash a card from your hand.",
+        "extra": "This works however you trash the card. For example it works when trashing a card to Priest, when trashing a Curse to Old Witch, when trashing Acting Troupe when playing it, and when trashing a card from the Supply with Lurker (from Intrigue). the card you trash with Sewers must be from your hand, and can be any card in your hand, even if the thing that triggered Sewers could only trash certain cards.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Sewers",
+        "raw_wikitext": "When you trash a card other than with this, you may trash a card from your hand.",
+        "wikitext": "When you trash a card other than with this, you may trash a card from your hand."
+    },
+    "Sextant": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>Look at the top 5 cards of your deck. Discard any number. Put the rest back in any order.",
+        "extra": "You can put all 5 cards back, or discard all 5, or anything in between.",
+        "name": "Sextant",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>Look at the top 5&nbsp;cards of your deck. Discard any number. Put the rest back in any order.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>Look at the top 5&nbsp;cards of your deck. Discard any number. Put the rest back in any order."
+    },
+    "Shadows": {
+        "description": "These cards all have unique backs, and can be played from your deck.",
+        "extra": "<br> • When shuffling Shadow cards, put them on the bottom. If you have multiple Shadow cards, they can go in any order at the bottom. They can also be mixed with any other cards you specifically put on the bottom, such as Fated cards from Plunder.<br> • You may wish to turn your Shadow cards sideways at the bottom of your deck, so that it is easy to remember that they are there.<br> • Shadow cards will not necessarily stay on the bottom of your deck; they are just put there when shuffling them.<br> • Shadow cards are not put on the bottom when gained, or at any time other than when shuffling them.<br> • You can look through your deck at the card backs at any time, and see where your Shadow cards are.<br> • Whenever you can normally play an Action card, you can play a Shadow card from your deck. It can be anywhere in your deck. You play it exactly as if playing it from your hand; it goes into play and you follow its instructions.<br> • When a card like Throne Room tells you to play a card from your hand, you can use that opportunity to play a Shadow card from your deck.<br> • You can play Shadow cards from your deck as if in your hand, but this does not mean the Shadow card is in your hand; for example you cannot discard it to an ability like Alley's (unless it is actually in your hand).",
+        "name": "Shadows"
+    },
+    "Shaman": {
+        "description": "+1 Action<br>+1 Coin<br>You may trash a card from your hand.<line>In games using this, at the start of your turn, gain a card from the trash costing up to 6 Coin.",
+        "extra": "In games using Shaman, for the whole game, at the start of each of your turns (including extra turns), you gain a card from the trash costing up to 6 Coin. This is mandatory.<br>If there's no such card, you don't gain one.<br>This applies even on your first turn (relevant with Necromancer, from Nocturne).<br>It applies even if no-one ever gets a Shaman.<br>The gained card goes into your discard pile. It's a card you gained, and can trigger things that care about that; for example gaining a Treasure would trigger Secluded Shrine ability.",
+        "name": "Shaman",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>You may trash a card from your hand.</p>{{Divline}}In games using this, at the start of your turn, gain a card from the trash costing up to {{Cost|6}}.",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+1 Coin<n>You may trash a card from your hand.<n><line>In games using this, at the start of your turn, gain a card from the trash costing up to 6 Coins."
+    },
+    "Shanty Town": {
+        "description": "+2 Actions<n>Reveal your hand. If you have no Action cards in hand, +2 Cards.",
+        "extra": "You get 2 more Actions to use no matter what else happens. Then you must reveal your hand. If you have no Action cards in hand, you draw 2 cards. If the first card you draw is an Action card, you still draw the second card. Action - Victory cards are Action cards.",
+        "name": "Shanty Town",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>Reveal your hand. If you have no Action cards in hand, '''+2&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>Reveal your hand. If you have no Action cards in hand, <b>+2&nbsp;Cards</b>."
+    },
+    "Sheepdog": {
+        "description": "+2 Cards<line>When you gain a card, you may play this from your hand.",
+        "extra": "You can use this when gaining a card due to buying it, when gaining a card some other way such as due to Falconer, and even when gaining a card on another player's turn, such as due to Black Cat.<n>Remember that when you buy a card, you can no longer play Treasures in that Buy phase.<n>If you gain a Sheepdog to your hand - such as via Falconer - you can react to that gain and play the Sheepdog.<n>f you gain a card with a \"when you gain\" clause, you can choose to resolve that before or after reacting with Sheepdog, for example, if you gain Hostelry, you can choose to discard Treasures for Horses before or after reacting with Sheepdog.",
+        "name": "Sheepdog",
+        "raw_wikitext": "'''+2&nbsp;Cards'''{{Divline}}When you gain a card, you may play this from your hand.",
+        "wikitext": "<b>+2&nbsp;Cards</b><line>When you gain a card, you may play this from your hand."
+    },
+    "Shelters": {
+        "description": "<left><u>Hovel</u>: When you buy a Victory card, you may trash this from your hand.</left><left><br><u>Necropolis</u>: +2 Actions</left><left><u>Overgrown Estate</u>: 0 <VP>; when you trash this, +1 Card.</left>",
+        "extra": " See Preparation. A shelter is never in the supply. <u>Hovel</u>: When you buy a Victory card, if Hovel is in your hand, you may trash the Hovel. A card with multiple types, one of which is Victory, is a Victory card. You do not get anything for trashing Hovel; you just get to get rid of it. <u>Overgrown Estate</u>: It is a Victory card despite being worth 0<VP>. If this is trashed, you draw a card, right then, even in the middle of resolving another card. For example, if you use Altar to trash Overgrown Estate, you first draw a card, then gain a card costing up to 5 Coins. This card does not give you a way to trash itself, it merely does something if you manage to trash it. <u>Necropolis</u>: This is an Action card; when you play it, you get +2 Actions. ",
+        "name": "Shelters"
+    },
+    "Shepherd": {
+        "description": "+1 Action<br>Discard any number of Victory cards, revealing them.<br>+2 Cards per card discarded.<br><br><i>Heirloom: Pasture</i>",
+        "extra": "For example, you could discard three Victory cards to draw six cards.<br>In games using Shepherd, replace one of your starting Coppers with a Pasture.",
+        "name": "Shepherd",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Discard any number of Victory cards, revealing them. '''+2&nbsp;Cards''' per card discarded.</p>''Heirloom: Pasture''",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Discard any number of Victory cards, revealing them. <b>+2&nbsp;Cards</b> per card discarded.<n><i>Heirloom: Pasture</i>"
+    },
+    "Shepherd - Pasture": {
+        "description": "<left><u>Shepherd</u>:</left><center>+1 Action<br>Discard any number of Victory cards, revealing them.</center><center>+2 Cards per card discarded.</center><left><i>Heirloom: Pasture</i></left><left><u>Pasture</u>:</left><center>1 <*COIN*></center><n><line><n>Worth 1 <VP> per Estate you have.",
+        "extra": "<u>Shepherd</u>: For example, you could discard three Victory cards to draw six cards.\nIn games using Shepherd, replace one of your starting Coppers with a Pasture.\n<u>Pasture</u>: For example if you have three Estates, then Pasture is worth 3 <VP>.",
+        "name": "Shepherd / Pasture"
+    },
+    "Shield": {
+        "description": "3 <*COIN*><br><br>+1 Buy<line>When another player plays an Attack, you may first reveal this from your hand to be unaffected.",
+        "extra": "You can reveal this when another player plays an Attack card to be unaffected by it, exactly as with Moat.<br>You do this before the Attack card has done anything, and can use Shield against multiple Attacks in a turn.<br>Shield stays in your hand and can still be played for +3 Coin and +1 Buy on your turn.",
+        "name": "Shield",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''{{Divline}}When another player plays an Attack, you may first reveal this from your hand to be unaffected.",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><line>When another player plays an Attack, you may first reveal this from your hand to be unaffected."
+    },
+    "Shop": {
+        "description": "+1 Card<br>+1 coin<br><br>You may play an Action card from your hand that you don’t have a copy of in play.",
+        "extra": "This lets you play an Action card from your hand, provided that you do not have a copy of that card in play. It does not matter if you played a copy of that Action that turn, only that it is not in play when you play Shop.",
+        "name": "Shop",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>{{Costplus|1}}<p>You may play an Action card from your hand that you don't have a copy of in play.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br>+1 Coin<n>You may play an Action card from your hand that you don't have a copy of in play."
+    },
+    "Shy": {
+        "description": "At the start of your turn, you may discard one Shy card for +2 Cards.",
+        "extra": "You can only discard one Shy card per turn this way.",
+        "name": "Shy",
+        "raw_wikitext": "At the start of your turn, you may discard one Shy card for '''+2&nbsp;Cards'''.",
+        "wikitext": "At the start of your turn, you may discard one Shy card for <b>+2&nbsp;Cards</b>."
+    },
+    "Sibyl": {
+        "description": "+4 Cards<br>+1 Action<n>Put a card from your hand on top of your deck, and another on the bottom.",
+        "extra": "If after drawing your deck has no cards in it, the first card you put back will become the top card of it.",
+        "name": "Sibyl",
+        "raw_wikitext": "'''+4&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Put a card from your hand on top of your deck, and another on the bottom.</p>",
+        "wikitext": "<b>+4&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Put a card from your hand on top of your deck, and another on the bottom."
+    },
+    "Sickness": {
+        "description": "At the start of your turn, choose one: Gain a Curse onto your deck; or discard 3&nbsp;cards.",
+        "name": "Sickness",
+        "raw_wikitext": "At the start of your turn, choose one: Gain a Curse onto your deck; or discard 3&nbsp;cards."
+    },
+    "Silk Merchant": {
+        "description": "+2 Cards<br>+1 Buy<n><line>When you gain or trash this, +1 Coffers and +1 Villager.",
+        "extra": "When you play this, you get +2 Cards and +1 Buy; when you trash it or gain it, you get +1 Coffers and +1 Villager. If Silk Merchant is trashed, the player trashing it takes the +1 Coffers and +1 Villager, regardless of whose turn it is.",
+        "name": "Silk Merchant",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Buy'''{{Divline}}When you gain or trash this, '''+1&nbsp;Coffers''' and '''+1&nbsp;Villager'''.",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Buy</b><line>When you gain or trash this, <b>+1&nbsp;Coffers</b> and <b>+1&nbsp;Villager</b>."
+    },
+    "Silk Road": {
+        "description": "Worth 1 <VP> for every 4 Victory cards in your deck (round down).",
+        "extra": "This is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point for every four Victory cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Silk Roads count themselves. Round down; if you have 11 Victory cards, Silk Road is worth 2 victory points. During set-up, put all 12 Silk Roads in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game. Cards with multiple types, one of which is Victory, are Victory cards and so are counted by Silk Road.",
+        "name": "Silk Road",
+        "raw_wikitext": "Worth {{VP|'''1'''}} for every 4&nbsp;Victory cards you have (round down).",
+        "wikitext": "Worth 1 <VP> for every 4&nbsp;Victory cards you have (round down)."
+    },
+    "Silos": {
+        "description": "At the start of your turn, discard any number of Coppers, revealed, and draw that many cards.",
+        "extra": "First you discard the Coppers, then you draw. So if drawing causes you to shuffle, you will shuffle in the Coppers.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Silos",
+        "raw_wikitext": "At the start of your turn, discard any number of Coppers, revealed, and draw that many cards.",
+        "wikitext": "At the start of your turn, discard any number of Coppers, revealed, and draw that many cards."
+    },
+    "Silver": {
+        "description": "2 <*COIN*>",
+        "extra": "40 cards per game.",
+        "name": "Silver",
+        "raw_wikitext": "{{Cost|2|xl}}",
+        "wikitext": "2 <*COIN*>"
+    },
+    "Silver Mine": {
+        "description": "Gain a Treasure costing less than this to your hand.",
+        "extra": "This can gain Silver, but also other Treasures costing less than Silver Mine, when in the Supply: Gondola, Jewelled Egg, and so on.",
+        "name": "Silver Mine",
+        "raw_wikitext": "Gain a Treasure costing less than this to your hand.",
+        "wikitext": "Gain a Treasure costing less than this to your hand."
+    },
+    "Sinister Plot": {
+        "description": "At the start of your turn, add a token here, or remove your tokens here for +1 Card each.",
+        "extra": "Each player has a separate pile of coin tokens on Sinister Plot; keep yours by your cube. Each turn you either add a token (an unused one, not one from a mat), or remove all of your tokens to draw as many cards.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Sinister Plot",
+        "raw_wikitext": "At the start of your turn, add a token here, or remove your tokens here for '''+1&nbsp;Card''' each.",
+        "wikitext": "At the start of your turn, add a token here, or remove your tokens here for <b>+1&nbsp;Card</b> each."
+    },
+    "Sir Bailey": {
+        "description": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Sir Bailey",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this.</p>"
+    },
+    "Sir Destry": {
+        "description": "<b>+2&nbsp;Cards</b><n>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Sir Destry",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this.</p>"
+    },
+    "Sir Martin": {
+        "description": "<b>+2&nbsp;Buys</b><n>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Sir Martin",
+        "raw_wikitext": "'''+2&nbsp;Buys'''<p>Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this.</p>"
+    },
+    "Sir Michael": {
+        "description": "Each other player discards down to 3&nbsp;cards in hand. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.",
+        "name": "Sir Michael",
+        "raw_wikitext": "Each other player discards down to 3&nbsp;cards in hand. Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{Cost|6}}, and discards the rest. If a Knight is trashed by this, trash this."
+    },
+    "Sir Vander": {
+        "description": "Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from 3 Coins to 6 Coins, and discards the rest. If a Knight is trashed by this, trash this.<line>When you trash this, gain a Gold.",
+        "name": "Sir Vander",
+        "raw_wikitext": "Each other player reveals the top 2&nbsp;cards of their deck, trashes one of them costing from {{Cost|3}} to {{nowrap|{{Cost|6}},}} and discards the rest. If a Knight is trashed by this, trash this.{{Divline}}When you trash this, gain a Gold."
+    },
+    "Siren": {
+        "description": "Each other player gains a Curse. At the start of your next turn, draw until you have 8 cards in hand.<line>When you gain this, trash it unless you trash an Action from your hand.",
+        "extra": "When you gain a Siren, it's immediately trashed unless you trash an Action card from your hand.<br>However if you manage to move the Siren from where it was gained (whether it was gained to your discard pile or somewhere else) before resolving this ability - for example putting it on top of your deck with Insignia - then it will fail to be trashed (though you can still trash an Action card if you want).",
+        "name": "Siren",
+        "raw_wikitext": "Each other player gains a Curse. At the start of your next turn, draw until you have 8&nbsp;cards in hand.{{Divline}}When you gain this, trash it unless you trash an Action from your hand.",
+        "wikitext": "Each other player gains a Curse. At the start of your next turn, draw until you have 8&nbsp;cards in hand.<line>When you gain this, trash it unless you trash an Action from your hand."
+    },
+    "Skirmisher": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3 cards in hand.",
+        "extra": "When played, Skirmisher sets up an ability for the rest of the turn; any time you gain an Attack card, each other player discards down to 3 cards in hand.<n>Revealing Moat when Skirmisher is played stops the attack; you can't reveal Moat when an Attack card is gained later.",
+        "name": "Skirmisher",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>This turn, when you gain an Attack card, each other player discards down to 3&nbsp;cards in hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>This turn, when you gain an Attack card, each other player discards down to 3&nbsp;cards in hand."
+    },
+    "Skulk": {
+        "description": "+1 Buy<br>Each other player receives the next Hex.<line>When you gain this, gain a Gold.",
+        "extra": "You gain the Gold whether you gained Skulk due to buying it, or gained it some other way.",
+        "name": "Skulk",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Each other player receives the next Hex.</p>{{Divline}}When you gain this, gain a Gold.",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Each other player receives the next Hex.<n><line>When you gain this, gain a Gold."
+    },
+    "Sleigh": {
+        "description": "Gain 2 Horses.<line>When you gain a card, you may discard this, to put that card into your hand or onto your deck.",
+        "extra": "You can move the gained card from your discard pile even though you discarded Sleigh on top of it.<n>If a gained card goes directly to somewhere other than your discard pile (for example, the Silver gained from Bureaucrat), Sleigh can still move it to your hand or the top of your deck.<n>If something else has moved the card since it was gained, Sleigh cannot move it.",
+        "name": "Sleigh",
+        "raw_wikitext": "Gain 2&nbsp;Horses.{{Divline}}When you gain a card, you may discard this, to put that card into your hand or onto your deck.",
+        "wikitext": "Gain 2&nbsp;Horses.<line>When you gain a card, you may discard this, to put that card into your hand or onto your deck."
+    },
+    "Small Castle": {
+        "description": "Trash this or a Castle from your hand. If you do, gain a Castle.<line>2 <*VP*>",
+        "name": "Small Castle",
+        "raw_wikitext": "Trash this or a Castle from your hand. If you do, gain a Castle.{{Divline}}{{VP|2|l}}"
+    },
+    "Smithy": {
+        "description": "+3 Cards",
+        "extra": "Draw three cards.",
+        "name": "Smithy",
+        "raw_wikitext": "'''+3&nbsp;Cards'''",
+        "wikitext": "<b>+3&nbsp;Cards</b>"
+    },
+    "Smugglers": {
+        "description": "Gain a copy of a card costing up to 6 Coins that the player to your right gained on his last turn.",
+        "extra": "This looks at the most recent turn of the player to your right, even if you've taken multiple turns in a row. If that player gained no cards, or nothing costing 6 or less, then Smugglers does nothing. If that player gained multiple cards costing 6 or less, you choose which one to gain a copy of. Gained cards must come from the supply. They can be any card gained, whether bought or otherwise gained; you can even gain a card that the previous player gained with Smugglers. If the previous player gained a card via Black Market, you will not be able to gain a copy of it (no copies of it in the supply.) This is not an Attack; Lighthouse and Moat can't stop it. You cannot gain cards with Potion in the cost with Smugglers.",
+        "name": "Smugglers",
+        "raw_wikitext": "Gain a copy of a card costing up to {{Cost|6}} that the player to your right gained on their last turn.",
+        "wikitext": "Gain a copy of a card costing up to 6 Coins that the player to your right gained on their last turn."
+    },
+    "Snake Witch": {
+        "description": "+1 Card<br>+1 Action<br>If your hand has no duplicate cards, you may reveal it and return this to its pile, to have each other player gain a Curse.",
+        "extra": "Revealing your hand, if all of the cards in it have different names, is optional. If you do, you return Snake Witch to its pile, and if you did, each other player gains a Curse. If you can't return Snake Witch to its pile for some reason, the other players do not gain a Curse. Note that you reveal your hand after getting the +1 Card from Snake Witch. If you have no cards in hand, you have no duplicates.",
+        "name": "Snake Witch",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>If your hand has no duplicate cards, you may reveal it and return this to its pile, to have each other player gain a Curse.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>If your hand has no duplicate cards, you may reveal it and return this to its pile, to have each other player gain a Curse."
+    },
+    "Snowy Village": {
+        "description": "+1 Card<br>+4 Actions<br>+1 Buy<br><n>Ignore any further +Actions you get this turn.",
+        "extra": "Any extra Actions you already had before playing this do not go away; for example, if you play Village and then Snowy Village, you can play 5 more Actions after that.<n>Any further +Actions you would get that turn, you do not, including from playing another Snowy Village or converting Villagers (from Renaissance).<n>This does not stop you from playing more cards via cards that tell you to play cards, such as Throne Room.<n>You can convert Villagers between drawing the card and reaching the last sentence which prevents further +Actions.",
+        "name": "Snowy Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+4&nbsp;Actions'''<br>'''+1&nbsp;Buy'''<p>Ignore any further '''+Actions''' you get this turn.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+4&nbsp;Actions</b><br><b>+1&nbsp;Buy</b><n>Ignore any further <b>+Actions</b> you get this turn."
+    },
+    "Soldier": {
+        "description": "+2 Coins<br>+1 Coin per other Attack you have in play. Each other player with 4 or more cards in hand discards a card.<line>When you discard this from play, you may exchange it for a Fugitive.<n><i>(This is not in the Supply.)</i>",
+        "extra": "This gives +2 Coins, and then an additional +1 Coin per other Attack card you have in play. Then each other player with 4 or more cards in hand discards a card. So for example if you play Soldier, then another Soldier, and have an opponent with 5 cards in hand, you will get +2 Coins and that opponent will discard a card, then you will get +2 Coins and an extra +1 Coin while that opponent discards again. Soldier only cares about Attack cards in play, not Attack cards played that turn; for example using Disciple on Soldier will not produce an extra +1 Coin, because there is no other Attack card in play. Duration Attacks played on the previous turn are Attack cards in play and so do count for Soldier.",
+        "name": "Soldier",
+        "raw_wikitext": "{{Costplus|2}}<p>{{Costplus|1}} per other Attack you have in play. Each other player with 4 or more cards in hand discards a card.</p>{{Divline}}<p>When you discard this from play, you may exchange it for a Fugitive. </p>''(This is not in the Supply.)''",
+        "wikitext": "+2 Coins<n>+1 Coin per other Attack you have in play. Each other player with 4 or more cards in hand discards a card.<n><line><n>When you discard this from play, you may exchange it for a Fugitive. <n><i>(This is not in the Supply.)</i>"
+    },
+    "Soothsayer": {
+        "description": "Gain a Gold. Each other player gains a Curse. Each player who did draws a card.",
+        "extra": "The Gold and Curses come from the Supply and go into discard piles. If there is no Gold left, you do not gain one. If there are not enough Curses left to go around, deal them out in turn order, starting with the player to your left. Each player who gained a Curse draws a card. This is not optional. A player who did not gain a Curse, whether due to the Curses running out or due to some other reason, does not draw a card. A player who uses Watchtower (from Prosperity) to trash the Curse did gain a Curse and so draws a card; a player who uses Trader (from Hinterlands) to gain a Silver instead did not gain a Curse and so does not draw a card.",
+        "name": "Soothsayer",
+        "raw_wikitext": "Gain a Gold. Each other player gains a Curse, and if they did, draws a card.",
+        "wikitext": "Gain a Gold. Each other player gains a Curse, and if they did, draws a card."
+    },
+    "Sorcerer": {
+        "description": "+1 Card<br>+1 Action<n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.",
+        "extra": "Each other player names a card, and reveals the top card of their deck.<n>If it doesn't have that name, they gain a Curse.<n>Whether or not it does, they return the card to the top of their deck.<n>So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.",
+        "name": "Sorcerer",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Each other player names a card, then reveals the top card of their deck. If wrong, they gain a Curse."
+    },
+    "Sorceress": {
+        "description": "+1 Action<n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.",
+        "extra": "Name a card; if the top card of your deck has that name, each other player gains a Curse.<n>You put the card into your hand whether or not it had the name you chose.",
+        "name": "Sorceress",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Name a card. Reveal the top card of your deck and put it into your hand. If it's the named card, each other player gains a Curse."
+    },
+    "Souk": {
+        "description": "+1 Buy<br>+7 Coin<br>–1 Coin per card in your hand (you can't go below 0 Coin).<line>When you gain this, trash up to 2 cards from your hand.",
+        "extra": "For example, if you play Souk and have 3 other cards left in your hand, you'd get +7 Coin (and +1 Buy), and then lose 3 Coin for a net gain of +4 Coin. You can't go below 0 Coin but might end up with less _ Coin than you started with. When you gain Souk, trash up to 2 cards from your hand; you don't have to trash any.",
+        "name": "Souk",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|7}}<p>{{nowrap|–{{Cost|1}}}} per card in your hand (you can't go below {{nowrap|{{Cost|0}}).}}</p>{{Divline}}When you gain this, trash up to 2&nbsp;cards from your hand.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+7 Coins<n>–1 Coin per card in your hand (you can't go below 0 Coins).<n><line>When you gain this, trash up to 2&nbsp;cards from your hand."
+    },
+    "Specialist": {
+        "description": "You may play an Action or Treasure from your hand. Choose one: play it again; or gain a copy of it.",
+        "extra": "First you may play an Action or Treasure card from your hand. If you did, then after completely resolving playing that card, you choose to either play it again or gain a copy of it.<n>You can play the card again even if it left play.<n>You can choose to gain a copy even if there are no copies left; you won't gain anything though.<n>This can only gain cards from the Supply.",
+        "name": "Specialist",
+        "raw_wikitext": "You may play an Action or Treasure from your hand. Choose one: Play it again; or gain a copy of it.",
+        "wikitext": "You may play an Action or Treasure from your hand. Choose one: Play it again; or gain a copy of it."
+    },
+    "Spell Scroll": {
+        "description": "Trash this to gain a cheaper card. If it's an Action or Treasure, you may play it.",
+        "extra": "You can play this in your Action phase or Buy phase; if played in your Action phase, it uses up an Action play for the turn. However playing the card you gain from Spell Scroll does not use up an Action play.",
+        "name": "Spell Scroll",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "Trash this to gain a cheaper card. If it's an Action or Treasure, you may play it.",
+        "wikitext": "Trash this to gain a cheaper card. If it's an Action or Treasure, you may play it."
+    },
+    "Spice Merchant": {
+        "description": "You may trash a Treasure from your hand. If you do, choose one:<n>+2 Cards and +1 Action;<br>or +2 Coins and +1 Buy.",
+        "extra": "You may trash a Treasure card from your hand. This is optional. If you did trash a Treasure card, you choose either to get +2 Cards and +1 Action, or +2 coins and +1 Buy.",
+        "name": "Spice Merchant",
+        "raw_wikitext": "You may trash a Treasure from your hand to choose one: '''+2&nbsp;Cards''' and '''+1&nbsp;Action'''; or '''+1&nbsp;Buy''' and {{Costplus|2}}.",
+        "wikitext": "You may trash a Treasure from your hand to choose one: <b>+2&nbsp;Cards</b> and <b>+1&nbsp;Action</b>; or <b>+1&nbsp;Buy</b> and +2 Coins."
+    },
+    "Spices": {
+        "description": "2 <*COIN*><br><br>+1 Buy<line>When you gain this, +2 Coffers.",
+        "extra": "This is a Treasure that makes 2 Coin and +1 Buy when played; when gaining it, you get +2 Coffers.",
+        "name": "Spices",
+        "raw_wikitext": "{{Cost|2|l}}<br>'''+1&nbsp;Buy'''{{Divline}}When you gain this, '''+2&nbsp;Coffers'''.",
+        "wikitext": "2 <*COIN*><br><b>+1&nbsp;Buy</b><line>When you gain this, <b>+2&nbsp;Coffers</b>."
+    },
+    "Spoils": {
+        "description": "3 <*COIN*><n>When you play this, return it to the Spoils pile.<n><i>(This is not in the Supply.)</i>",
+        "extra": "This is never in the Supply; it can only be obtained via Bandit Camp, Marauder, and Pillage. When you play Spoils, you get +3 Coins to spend this turn, and return that copy of Spoils to its pile. You are not forced to play Treasures in your hand.",
+        "name": "Spoils",
+        "raw_wikitext": "{{Cost|3|l}}<p>When you play this, return it to the Spoils pile.</p>''(This is not in the Supply.)''",
+        "wikitext": "3 <*COIN*><n>When you play this, return it to the Spoils pile.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Sprawling Castle": {
+        "description": "4 <*VP*><line>When you gain this, gain a Duchy or 3&nbsp;Estates.",
+        "name": "Sprawling Castle",
+        "raw_wikitext": "{{VP|4|l}}{{Divline}}When you gain this, gain a Duchy or 3&nbsp;Estates."
+    },
+    "Spy": {
+        "description": "+1 Card<br>+1 Action<n>Each player (including you) reveals the top card of his deck and either discards it or puts it back, your choice.",
+        "extra": "Spy causes all players, including the one who played it, to reveal the top card of their Deck. Note that you draw your card for playing Spy before any cards are revealed. Anyone who does not have any cards left in their Deck shuffles in order to have something to reveal. Anyone who still has no cards to reveal doesn't reveal one. If players care about the order in which things happen for this, you do yourself first, then each other player in turn order. Revealed cards that aren't discarded are returned to the top of their players' Decks.",
+        "name": "Spy",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Each player (including you) reveals the top card of their deck and either discards it or puts it back, your choice.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Each player (including you) reveals the top card of their deck and either discards it or puts it back, your choice."
+    },
+    "Squire": {
+        "description": "+1 Coin<n>Choose one: +2 Actions; or +2 Buys; or gain a Silver.<line>When you trash this, gain an Action card.",
+        "extra": "When you play this, you get +1 Coins, and your choice of either +2 Actions, +2 Buys, or gaining a Silver. The Silver comes from the Supply and is put into your discard pile. If Squire is trashed somehow, you gain an Attack card; the Attack card comes from the Supply and is put into your discard pile. You can gain any Attack card available in the Supply, but if no Attack card is available, you do not gain one.",
+        "name": "Squire",
+        "raw_wikitext": "{{Costplus|1}}<p>Choose one: '''+2&nbsp;Actions'''; or '''+2&nbsp;Buys'''; or gain a Silver.</p>{{Divline}}When you trash this, gain an Attack card.",
+        "wikitext": "+1 Coin<n>Choose one: <b>+2&nbsp;Actions</b>; or <b>+2&nbsp;Buys</b>; or gain a Silver.<n><line>When you trash this, gain an Attack card."
+    },
+    "Stables": {
+        "description": "You may discard a Treasure.<br>If you do, +3 Cards and +1 Action.",
+        "extra": "You may discard a Treasure card from your hand. This is optional. If you did discard one, you get +3 Cards and +1 Action. You draw after discarding, so if you have to shuffle to get the 3 cards, you will end up shuffling in the card you discarded.",
+        "name": "Stables",
+        "raw_wikitext": "You may discard a Treasure, for '''+3&nbsp;Cards''' and '''+1&nbsp;Action'''.",
+        "wikitext": "You may discard a Treasure, for <b>+3&nbsp;Cards</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Staff": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>You may play an Action from your hand.",
+        "extra": "Playing an Action card from your hand is optional.",
+        "name": "Staff",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>You may play an Action from your hand.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>You may play an Action from your hand."
+    },
+    "Stampede": {
+        "description": "If you have 5 or fewer cards in play, gain 5 Horses onto your deck.",
+        "extra": "It does not matter how many cards you played that turn, only how many you have in play when buying Stampede. If there are fewer than 5 Horses left in the pile, just gain as many as you can.",
+        "name": "Stampede",
+        "raw_wikitext": "If you have 5&nbsp;or fewer cards in play, gain 5 Horses onto your deck.",
+        "wikitext": "If you have 5&nbsp;or fewer cards in play, gain 5 Horses onto your deck."
+    },
+    "Star Chart": {
+        "description": "When you shuffle, you may pick one of the cards to go on top.",
+        "extra": "Each time you shuffle, you can look through the cards and pick one to go on top. Shuffle the other cards.<n><n>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.\n\nProjects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Star Chart",
+        "raw_wikitext": "When shuffling, you may pick one of the cards to go on top.",
+        "wikitext": "When shuffling, you may pick one of the cards to go on top."
+    },
+    "Start Deck": {
+        "description": "Player's starting deck of cards:<n>7 Copper cards<n>3 Estate cards",
+        "extra": "",
+        "name": "Player Start Deck"
+    },
+    "Stash": {
+        "description": "2 <*COIN*><line>When you shuffle, you may put this anywhere in your deck.",
+        "extra": "Stash is a Treasure that produces 2 coins when played, like Silver. Whenever you shuffle your deck, you can choose where in your deck each copy of Stash that you have goes. You can't look at the fronts of the other cards in your deck to see where to put it; Stash itself has a different card back, so that's how you'll know where it is. If you have multiple copies of Stash, you can clump them together or spread them out or whatever you want. Since Stash has a different card back, you will also know if it's in a player's hand, or set aside for someone's Haven (from Seaside), and so on.",
+        "name": "Stash",
+        "raw_wikitext": "{{Cost|2|l}}<br>When shuffling this, you may look through your remaining deck, and may put this anywhere in the shuffled cards.",
+        "wikitext": "2 <*COIN*><br>When shuffling this, you may look through your remaining deck, and may put this anywhere in the shuffled cards."
+    },
+    "Steward": {
+        "description": "Choose one: +2 Cards; or +2 Coins; or trash 2 cards from your hand.",
+        "extra": "If you choose to trash 2 cards and have 2 or more cards in your hand after playing the Steward, then you must trash exactly 2 cards. You may choose to trash 2 cards, even if you only have 1 card left in your hand after playing the Steward; just trash the remaining card in your hand. You cannot mix and match - you either draw 2 cards, get 2 coins, or trash 2 cards.",
+        "name": "Steward",
+        "raw_wikitext": "Choose one: '''+2&nbsp;Cards'''; or {{Costplus|2}}; or trash 2&nbsp;cards from your hand.",
+        "wikitext": "Choose one: <b>+2&nbsp;Cards</b>; or +2 Coins; or trash 2&nbsp;cards from your hand."
+    },
+    "Stockpile": {
+        "description": "3 <*COIN*><br><br>+1 Buy<n>When you play this, Exile it.",
+        "extra": "This is a Treasure worth 3 coin, like Gold; you play it in your Buy phase.<n>When you play this, you also get +1 Buy, and put this on your Exile mat.<n>If you play this twice with a card like Crown (from Empires), you will get +6 coin and +2 Buys total, even though you could only Exile it once.",
+        "name": "Stockpile",
+        "raw_wikitext": "{{Cost|3|l}}<p>'''+1&nbsp;Buy'''</p>Exile this.",
+        "wikitext": "3 <*COIN*><n><b>+1&nbsp;Buy</b><n>Exile this."
+    },
+    "Stonemason": {
+        "description": "Trash a card from your hand. Gain 2 cards each costing less than it.<line>When you buy this, you may overpay for it. If you do, gain 2 Action cards each costing the amount you overpaid.",
+        "extra": "When you play this, trash a card from your hand, and gain two cards, each costing less than the card you trashed. Trashing a card is not optional. If you do not have any cards left in your hand to trash, you do not gain any cards. The two cards you gain can be different or the same. For example you could trash a Gold to gain a Duchy and a Silver. Gaining cards is not optional if you trashed a card. The gained cards come from the Supply and are put into your discard pile; if there are no cheaper cards in the Supply (for example if you trash a Copper), you do not gain any. If there is only one card in the Supply cheaper than the trashed card, you gain that one. The cards you gain are gained one at a time; this may matter with cards that do something when gained, such as Inn from Hinterlands. When you buy this, you may choose to overpay for it. If you do, you gain two Action cards each costing exactly the amount you overpaid. The Action cards can be different or the same. For example, if you buy Stonemason for 6 Coins, you could gain two Heralds. The Action cards come from the Supply and are put into your discard pile. If there are no cards with the appropriate cost in the Supply, you do not gain one. Overpaying with a Potion (from Alchemy) will let you gain cards with Potion in the cost. Cards with multiple types, one of which is Action (such as Great Hall from Intrigue), are Action cards. If you choose not to overpay, you will not gain any cards from that ability; it is not possible to use it to gain Action cards costing 0 Coins.",
+        "name": "Stonemason",
+        "raw_wikitext": "Trash a card from your hand. Gain 2&nbsp;cards each costing less than it.{{Divline}}'''Overpay:''' Gain 2&nbsp;Action cards each costing the amount overpaid.",
+        "wikitext": "Trash a card from your hand. Gain 2&nbsp;cards each costing less than it.<line><b>Overpay:</b> Gain 2&nbsp;Action cards each costing the amount overpaid."
+    },
+    "Storeroom": {
+        "description": "+1 Buy<n>Discard any number of cards.<n>+1 Card per card discarded.<n>Discard any number of cards.<n>+1 Coins per card discarded the second time.",
+        "extra": "Discard any number of cards from your hand, and draw as many cards as you discarded. Then, discard any number of cards - which could include cards you just drew - and you get +1 Coins per card you discarded that time.",
+        "name": "Storeroom",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>Discard any number of cards, then draw that many. Then discard any number of cards for {{Costplus|1}} each.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>Discard any number of cards, then draw that many. Then discard any number of cards for +1 Coin each."
+    },
+    "Storyteller": {
+        "description": "+1 Action<br>+1 Coin<n>Play up to 3 Treasures from your hand. Pay all of your _ Coins. +1 Card per Coin paid.",
+        "extra": "This lets you play Treasures in your Action phase. They go into play and produce Coins, just like Treasures played in the Buy phase. Then Storyteller turns all of your Coins into +Cards; for each Coin you have you lose the Coin and get +1 Card. For example if you had 4 Coins, you lose the 4 Coins and draw 4 cards. This makes you lose all Coins you have so far that turn, including the Coins you get from playing the Treasures, the +1 Coin Storyteller gives you directly, and any you made earlier in the turn. You can track that the Treasures have been \"spent\" by putting them under the Storyteller. Potions, produced by Potions from Alchemy, is not Coin and so is not lost and does not get you any cards.",
+        "name": "Storyteller",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Play up to 3&nbsp;Treasures from your hand. Then '''+1&nbsp;Card''', and pay all of your {{Cost}} for '''+1&nbsp;Card''' per {{Cost|1}} you paid.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Play up to 3&nbsp;Treasures from your hand. Then <b>+1&nbsp;Card</b>, and pay all of your {{Cost}} for <b>+1&nbsp;Card</b> per 1 Coin you paid."
+    },
+    "Stowaway": {
+        "description": "At the start of your next turn, +2 Cards.<line>When anyone gains a Duration card, you may play this from your hand.",
+        "extra": "You may play this from your hand when you personally gain a Duration card, or when another player does.",
+        "name": "Stowaway",
+        "raw_wikitext": "At the start of your next turn, '''+2&nbsp;Cards.'''{{divline}}When anyone gains a Duration card, you may play this from your hand.",
+        "wikitext": "At the start of your next turn, <b>+2&nbsp;Cards.</b><line>When anyone gains a Duration card, you may play this from your hand."
+    },
+    "Stronghold": {
+        "description": "Choose one: +3 Coins; or at the start of your next turn, +3 Cards.<line>2 <*VP*>",
+        "extra": "If you choose +3 Coins, Stronghold will be discarded that turn; if you choose the +3 Cards next turn, Stronghold will stay out until that turn's Clean-up (and if you choose both via Elder, it will stay out).",
+        "name": "Stronghold",
+        "raw_wikitext": "Choose one: {{Costplus|3}}; or at the start of your next turn, '''+3&nbsp;Cards'''.{{Divline}}{{VP|2|l}}",
+        "wikitext": "Choose one: +3 Coins; or at the start of your next turn, <b>+3&nbsp;Cards</b>.<line>2 <*VP*>"
+    },
+    "Student": {
+        "description": "+1 Action<n>You may rotate the Wizards.<br>Trash a card from your hand. If it's a Treasure, +1 Favor and put this onto your deck.",
+        "extra": "Rotating the Wizards is optional, but trashing a card is mandatory.<n>If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again.<n>If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.",
+        "name": "Student",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>You may rotate the Wizards.</p>Trash a card from your hand. If it's a Treasure, '''+1&nbsp;Favor''' and put this onto your deck.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>You may rotate the Wizards.<n>Trash a card from your hand. If it's a Treasure, <b>+1&nbsp;Favor</b> and put this onto your deck."
+    },
+    "Summon": {
+        "description": "Gain an Action card costing up to 4 coins. Set it aside. If you do, then at the start of your next turn, play it.",
+        "extra": "When you buy this, you gain an Action card costing up to 4 coins from the Supply and set it aside face up.<n>If you did set it aside, then at the start of your next turn, play that Action card. This doesn't use up your default Action for the turn.<n>In order to remember to play the card on your next turn, you may want to turn it sideways or diagonally, turning it right side up when you play it.<n>If you move the Action card after you gain it but before you set it aside (e.g. by putting it on top of your deck with Watchtower, from Prosperity), then Summon will ''lose track'' of it and be unable to set it aside; in that case you will not play it at the start of your next turn.<n>If you use Summon to gain a Nomad Camp (from Hinterlands), Summon will know to find the Nomad Camp on your deck, so you will set it aside in that case (unless you have moved it elsewhere via another ability).",
+        "name": "Summon",
+        "raw_wikitext": "Gain an Action card costing up to {{Cost|4}}. Set it aside. If you did, then at the start of your next turn, play it.",
+        "wikitext": "Gain an Action card costing up to 4 Coins. Set it aside. If you did, then at the start of your next turn, play it."
+    },
+    "Sunken Treasure": {
+        "description": "Gain an Action card you don't have a copy of in play.",
+        "extra": "If there's no such Action in the Supply, you don't gain one.",
+        "name": "Sunken Treasure",
+        "raw_wikitext": "Gain an Action card you don't have a copy of in play.",
+        "wikitext": "Gain an Action card you don't have a copy of in play."
+    },
+    "Supplies": {
+        "description": "1 <*COIN*><br><br>When you play this, gain a Horse onto your deck.",
+        "extra": "This is a Treasure worth 1 Coin, like Copper; you play it in your Buy phase.<n>When you play this, gain a Horse, putting it directly onto your deck.",
+        "name": "Supplies",
+        "raw_wikitext": "{{Cost|1|l}}<p>Gain a Horse onto your deck.</p>",
+        "wikitext": "1 <*COIN*><n>Gain a Horse onto your deck."
+    },
+    "Survivors": {
+        "description": "Look at the top 2 cards of your deck. Discard them or put them back in any order.",
+        "extra": "If any Kingdom card has the type Looter (e.g. Cultist, Death Cart, and Marauder), add the all the Ruins cards (Abandoned Mine, Ruined Library, Ruined Market, Ruined Village, Survivors), shuffle, then count 10 per player after the first: 10 for two players, 20 for three players, 30 for four players, and so on. Put the pile face down with the top card face up. Return any remaining Ruins cards to the box.<n>Players can buy Ruins. Ruins cards are Actions; they may be played in the Action phase, and count as Actions for things that refer to Action cards, such as Procession. The Ruins pile, when used, is in the Supply, and if it is empty that counts towards the normal end condition.",
+        "name": "Survivors",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "Look at the top 2&nbsp;cards of your deck. Discard them or put them back in any order.",
+        "wikitext": "Look at the top 2&nbsp;cards of your deck. Discard them or put them back in any order."
+    },
+    "Swamp Hag": {
+        "description": "Until your next turn, when any other player buys a card, he gains a Curse.<n>At the start of your next turn:<n>+3 Coins",
+        "extra": "You will get +3 Coins at the start of your next turn; and until then, other players will gain a Curse whenever they buy a Card. Players who buy multiple cards will gain a Curse per card bought; players who do not buy any cards will not get any Curses. This is cumulative; if you play two Swamp Hags, and the player after you plays one, then the player after that will get three Curses with any card bought. This does not affect cards gained other ways, only bought cards. Buying Events is not buying cards and so does not trigger this. If you play Swamp Hag and then take an extra turn immediately, such as with Mission or Outpost (from Seaside), you will get +3 Coins at the start of that turn and discard Swamp Hag that turn, and other players will never be affected by it. If you want to use a Reaction card like Moat against Swamp Hag, you have to use it right when Swamp Hag is played.",
+        "name": "Swamp Hag",
+        "raw_wikitext": "<p>At the start of your next turn: {{Costplus|3}}.</p>Until then, when any other player gains a card they bought, they gain a Curse.",
+        "wikitext": "At the start of your next turn: +3 Coins.<n>Until then, when any other player gains a card they bought, they gain a Curse."
+    },
+    "Swamp Shacks": {
+        "description": "+2 Actions<br>+1 Card per 3 cards you have in play (round down).",
+        "extra": "This counts the Swamp Shacks itself, and Duration cards played on previous turns that are still in play.<br>It counts Treasures if you have some in play, such as Treasure Duration cards, or due to Storyteller.<br>It does not count set aside cards, such as cards on a Quartermaster.<br>Round down the number of cards you draw; if you have 8 cards in play, you draw 2.",
+        "name": "Swamp Shacks",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>'''+1&nbsp;Card''' per 3&nbsp;cards you have in play (round down).</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n><b>+1&nbsp;Card</b> per 3&nbsp;cards you have in play (round down)."
+    },
+    "Swap": {
+        "description": "+1 Card<br>+1 Action<n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins.",
+        "extra": "First you get +1 Card and +1 Action. Then you may return an Action card from your hand to its pile; this is optional. If you do, then gain an Action card from the Supply costing up to 5 Coins and put it into your hand.<n>The card you gain can't have the same name as the one you returned.<n>Returning the card isn't trashing it and won't trigger \"when you trash this\" abilities; gaining the card is gaining it and will trigger \"when you gain this\" abilities.",
+        "name": "Swap",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to {{Cost|5}}.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may return an Action from your hand to its pile, to gain to your hand a different Action costing up to 5 Coins."
+    },
+    "Swashbuckler": {
+        "description": "+3 Cards<n>If your discard pile has any cards in it:<n>+1 Coffer, then if you have at least 4 Coffers tokens, take the Treasure Chest",
+        "extra": "First you draw 3 cards, then you check to see if your discard pile has any cards in it; if drawing those cards caused you to shuffle, your discard pile would be empty. If your discard pile has at least one card, you get +1 Coffers, and if you then have 4 or more tokens on your Coffers, you take the Treasure Chest. You cannot get the Treasure Chest unless your discard pile had at least one card. Treasure Chest simply causes you to gain a Gold at the start of your Buy phase each turn, including the turn you take it; this is not optional.",
+        "name": "Swashbuckler",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>If your discard pile has any cards in it: '''+1&nbsp;Coffers''', then if you have at least 4&nbsp;Coffers tokens, take the Treasure Chest.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>If your discard pile has any cards in it: <b>+1&nbsp;Coffers</b>, then if you have at least 4&nbsp;Coffers tokens, take the Treasure Chest."
+    },
+    "Swashbuckler - Treasure Chest": {
+        "description": "<left><u>Swashbuckler</u>:</left><n>+3 Cards<n>If your discard pile has any cards in it:<n>+1 Coffer, then if you have at least 4 Coffers tokens, take the Treasure Chest<n><left><u>Treasure Chest</u>:</left><n>At the start of your Buy phase, gain a Gold.",
+        "extra": "First you draw 3 cards, then you check to see if your discard pile has any cards in it; if drawing those cards caused you to shuffle, your discard pile would be empty. If your discard pile has at least one card, you get +1 Coffers, and if you then have 4 or more tokens on your Coffers, you take the Treasure Chest. You cannot get the Treasure Chest unless your discard pile had at least one card. Treasure Chest simply causes you to gain a Gold at the start of your Buy phase each turn, including the turn you take it; this is not optional.<n><n>Treasure Chest is an Artifact. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Swashbuckler / Treasure Chest"
+    },
+    "Swindler": {
+        "description": "+2 Coins<n>Each other player trashes the top card of his deck and gains a card with the same cost that you choose.",
+        "extra": "A player with no cards left in his Deck shuffles first; a player who still has no cards does not trash a card or gain a card. If the order matters (such as when piles are running low), resolve Swindler in turn order starting with the player to your left. Gained cards go to discard piles. If a player trashed a 0 Coins card such as Copper, you may choose to give him Curse (if there are any left). You can give a player another copy of the same card he trashed. The gained cards have to be ones from the Supply, and you have to pick a card that's left if you can (you cannot pick an empty pile). If there are no cards in the Supply with the same cost as a given player's trashed card, no card is gained by that player. A player who Moats this does not reveal a card from his deck, and so neither trashes a card nor gains a card.",
+        "name": "Swindler",
+        "raw_wikitext": "{{Costplus|2}}<p>Each other player trashes the top card of their deck and gains a card with the same cost that you choose.</p>",
+        "wikitext": "+2 Coins<n>Each other player trashes the top card of their deck and gains a card with the same cost that you choose."
+    },
+    "Sword": {
+        "description": "3 <*COIN*><br><br>+1 Buy<br>Each other player discards down to 4 cards in hand.",
+        "extra": "This is an Attack, and so cards like Moat and Shield protect from it.",
+        "name": "Sword",
+        "notes": [
+            "This card is currently not used."
+        ],
+        "raw_wikitext": "{{Cost|3|l}}<br>'''+1&nbsp;Buy'''<p>Each other player discards down to 4&nbsp;cards in hand.</p>",
+        "wikitext": "3 <*COIN*><br><b>+1&nbsp;Buy</b><n>Each other player discards down to 4&nbsp;cards in hand."
+    },
+    "Sycophant": {
+        "description": "+1 Action<n>Discard 3 cards. If you discarded at least one, +3 Coins.<line>When you gain or trash this, +2 Favors.",
+        "extra": "You can play this regardless of how many cards are left in your hand.<n>When you play this, if you have at least three cards left in hand, you discard three and get +3 Coins. If you have one or two cards, you discard them and get +3 Coins. If you have no cards, you don't get the +3 Coins.<n>When you gain or trash this, you get +2 Favors; you can immediately spend them, for example, on the ability of City-state.",
+        "name": "Sycophant",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Discard 3&nbsp;cards. If you discarded at least one, {{Costplus|3}}.</p>{{Divline}}When you gain or trash this, '''+2&nbsp;Favors'''.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Discard 3&nbsp;cards. If you discarded at least one, +3 Coins.<n><line>When you gain or trash this, <b>+2&nbsp;Favors</b>."
+    },
+    "Tactician": {
+        "description": "Discard your hand. If you discarded any cards this way, then at the start of your next turn, +5 Cards, +1 Buy, and +1 Action.",
+        "extra": "You wait until the start of your next turn to draw the 5 extra cards; you don't draw them at the end of the turn you played Tactician. Tactician stays out in front of you until the Clean-up phase of your next turn. Because you must discard at least one card in order to gain the bonuses from tactician, it is not possible to Throne Room a Tactician to get +10 cards, +2 Buys, and +2 Actions. You will have to discard all of your cards with the first Tactician and you will not have cards left in your hand to trigger the card drawing or the extra Buy or the extra Action when you play Tactician for the second time.",
+        "name": "Tactician",
+        "raw_wikitext": "If you have at least one card in hand: Discard your hand, and at the start of your next turn, '''+5&nbsp;Cards''', '''+1&nbsp;Action''', and '''+1&nbsp;Buy'''.",
+        "wikitext": "If you have at least one card in hand: Discard your hand, and at the start of your next turn, <b>+5&nbsp;Cards</b>, <b>+1&nbsp;Action</b>, and <b>+1&nbsp;Buy</b>."
+    },
+    "Talisman": {
+        "description": "1 <*COIN*><line>While you have this in play, when you buy a non-Victory card costing 4 Coins or less, gain a copy of it.",
+        "extra": "This is a Treasure worth 1 coin, like Copper. Each time you buy a non-Victory card costing 4 coins or less with this in play, you gain another copy of the bought card. If there are no copies left, you do not gain one. The gained card comes from the Supply and goes into your discard pile. If you have multiple Talismans, you gain an additional copy for each one; if you buy multiple cards for 4 coins or less, Talisman applies to each one. For example if you have two Talismans, four Coppers, and two Buys, you could Buy Silver and Trade Route, gaining two more Silvers and two more Trade Routes. Talisman only affects buying cards; it does not work on cards gained other ways, such as with Expand. A card if a Victory card if Victory is any of its types; for example Great Hall from Intrigue is an Action - Victory card, so it is a Victory card. Talisman only cares about the cost of the card when you buy it, not its normal cost; so for example it can get you a Peddler if you have played two Actions this turn, thus lowering Peddler's cost to 4 coins, or can get you a Grand Market if you played Quarry. You may not choose to not gain the additional card from Talisman; you must gain an additional one for each Talisman in play if possible.",
+        "name": "Talisman",
+        "raw_wikitext": "{{Cost|1|l}}{{divline}}While you have this in play, when you buy a non-Victory card costing {{Cost|4}} or less, gain a copy of it.",
+        "wikitext": "1 <*COIN*><line>While you have this in play, when you buy a non-Victory card costing 4 Coins or less, gain a copy of it."
+    },
+    "Tanuki": {
+        "description": "Trash a card from your hand. Gain a card costing up to 2 Coins more than it.<line>You can play this from your deck as if it is in your hand.",
+        "extra": "See the Shadows section. When you play this, you trash a card from your hand, and gain a card costing up to two Coins more than it, like when playing Remodel.",
+        "name": "Tanuki",
+        "raw_wikitext": "Trash a card from your hand. Gain a card costing up to {{Cost|2}} more than it.{{Divline}}You can play this from your deck as if in your hand.",
+        "wikitext": "Trash a card from your hand. Gain a card costing up to 2 Coins more than it.<line>You can play this from your deck as if in your hand."
+    },
+    "Taskmaster": {
+        "description": "+1 Action, +1 Coin, and if you gain a card costing exactly 5 Coin this turn, then at the start of your next turn, repeat this ability.",
+        "extra": "Taskmaster can end up making +1 Action and +1 Coin turn after turn, as long as you keep gaining at least one card costing 5 Coin.",
+        "name": "Taskmaster",
+        "raw_wikitext": "'''+1&nbsp;Action''', {{Costplus|1}}, and if you gain a card costing exactly {{Cost|5}} this turn, then at the start of your next turn, repeat this ability.",
+        "wikitext": "<b>+1&nbsp;Action</b>, +1 Coin, and if you gain a card costing exactly 5 Coins this turn, then at the start of your next turn, repeat this ability."
+    },
+    "Tax": {
+        "description": "Add 2 Debt to a Supply pile.<line>Setup: Add 1 Debt to each Supply pile. When a player buys a card, they take the Debt from its pile.",
+        "extra": "Every Supply pile starts with 1 Debt, including Kingdom cards and basic cards like Silver.<n>The Event itself, when bought, adds 2 Debt to a single pile, whether or not that pile has any Debt on it already.<n>The Debt is taken by the next player to buy a card from that pile; gaining a card without buying it leaves the Debt on the pile.",
+        "name": "Tax",
+        "raw_wikitext": "Add {{Debt|2}} to a Supply pile.{{Divline}}Setup: Add {{Debt|1}} to each Supply pile. When a player gains a card in their Buy phase, they take the {{Debt}} from its pile.",
+        "wikitext": "Add {{Debt|2}} to a Supply pile.<line>Setup: Add {{Debt|1}} to each Supply pile. When a player gains a card in their Buy phase, they take the {{Debt}} from its pile."
+    },
+    "Taxman": {
+        "description": "You may trash a Treasure from your hand. Each other player with 5 or more cards in hand discards a copy of it (or reveals a hand without it). Gain a Treasure card costing up to 3 Coins more than the trashed card, putting it on top of your deck.",
+        "extra": "You may trash a Treasure card from your hand. This is optional. Cards with multiple types, one of which is Treasure (like Harem from Intrigue), are Treasures. If you do trash a Treasure, each other player with at least five cards in hand discards a copy of it from her hand if she can, or reveals a hand with no copies of it, and you gain a Treasure costing up to 3 Coins more than the trashed Treasure, putting it on top of your deck. If there are no cards in your deck, it becomes the only card in your deck. You do not have to gain a more expensive Treasure; you may gain a Treasure with the same cost, or a cheaper Treasure. You have to gain a card if you trashed one though, if possible. The gained Treasure comes from the Supply.",
+        "name": "Taxman",
+        "raw_wikitext": "You may trash a Treasure from your hand. Each other player with 5&nbsp;or more cards in hand discards a copy of it (or reveals they can't). Gain a Treasure onto your deck costing up to {{Cost|3}} more than it.",
+        "wikitext": "You may trash a Treasure from your hand. Each other player with 5&nbsp;or more cards in hand discards a copy of it (or reveals they can't). Gain a Treasure onto your deck costing up to 3 Coins more than it."
+    },
+    "Tea House": {
+        "description": "+1 SunToken<br>+1 Card<br>+1 Action<br>+2 Coins",
+        "extra": "First the +1 SunToken happens, which may trigger a Prophecy; then you get +1 Card, +1 Action, and +2 Coins.",
+        "name": "Tea House",
+        "raw_wikitext": "{{Sunplus}}<br>'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|2}}",
+        "wikitext": "{{Sunplus}}<br><b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+2 Coins"
+    },
+    "Teacher": {
+        "description": "Put this on your Tavern mat.<line>At the start of your turn, you may call this, to move your +1 Card token, +1 Action token, +1 Buy token, or +1 Coin token to an Action Supply pile you have no tokens on (when you play a card from that pile, you first get that bonus).<n><i>(This is not in the Supply.)</i>",
+        "extra": "When you play this, put it on your Tavern mat. It stays on your mat until you call it at the start of one of your turns. If multiple things can happen at the start of your turn, you can do them in any order. When you call Teacher, it moves from the mat into play, and you choose your +1 Action, +1 Card, +1 Buy, or +1 Coin token, and move it to an Action Supply pile that you have no tokens on. The token on the pile means that every time you play a card from that pile, you will get the corresponding bonus - if you put your +1 Action token on a pile, you will get an extra +1 Action when playing a card from that pile. See the Tokens section. This cannot put a token on a pile you have tokens on, including the tokens Teacher places as well as your - 2 Coin cost token and Trashing token. This can put a token on a pile that other players have tokens on. Other things can put tokens on a pile you put a token on with Teacher; it is just Teacher itself that cannot put a token on a pile you have a token on. It is okay if the pile has a token that does not belong to you or anyone, such as an Embargo token (from Seaside) or coin token for Trade Route (from Prosperity). It is okay if you have an Estate token on a card set aside from that pile.",
+        "name": "Teacher",
+        "raw_wikitext": "Put this on your Tavern mat.{{Divline}}<p>At the start of your turn, you may call this, to move your +1&nbsp;Card, +1&nbsp;Action, +1&nbsp;Buy, or {{Costplus|1}} token to an Action Supply pile you have no tokens on. (When you play a card from that pile, you first get that bonus.)</p>''(This is not in the Supply.)''",
+        "wikitext": "Put this on your Tavern mat.<line><n>At the start of your turn, you may call this, to move your +1&nbsp;Card, +1&nbsp;Action, +1&nbsp;Buy, or +1 Coin token to an Action Supply pile you have no tokens on. (When you play a card from that pile, you first get that bonus.)<n><i>(This is not in the Supply.)</i>"
+    },
+    "Temple": {
+        "description": "+1 <VP><n>Trash from 1 to 3 differently named cards from your hand. Add 1 <VP> to the Temple Supply pile.<line>When you gain this, take the <VP> from the Temple Supply pile.",
+        "extra": "You get +1 <VP>, trash 1, 2, or 3 cards with different names from your hand (for example a Copper and an Estate, but not two Coppers), then add 1 <VP> (from the supply) to the Temple pile. Gaining a Temple (whether buying it or otherwise) gives you all the <VP> that has accumulated on the pile. The pile gets <VP> even if it is empty; this only matters if there is a way to return a Temple to the pile (like Ambassador from Seaside) or a way to gain one from the trash (like Graverobber from Dark Ages).",
+        "name": "Temple",
+        "raw_wikitext": "{{VP|'''+1'''}}<p>Trash from 1 to 3 differently named cards from your hand. Add {{VP|'''1'''}} to the Temple pile.</p>{{Divline}}When you gain this, take the {{VP}} from the Temple pile.",
+        "wikitext": "{{VP|<b>+1</b>}}<n>Trash from 1 to 3 differently named cards from your hand. Add 1 <VP> to the Temple pile.<n><line>When you gain this, take the {{VP}} from the Temple pile."
+    },
+    "Tent": {
+        "description": "+2 Coins<n>You may rotate the Forts.<line>When you discard this from play, you may put it onto your deck.",
+        "extra": "If you have multiple Tents in play, you can choose how many you want to put on top of your deck.",
+        "name": "Tent",
+        "raw_wikitext": "{{Costplus|2}}<p>You may rotate the Forts.</p>{{Divline}}When you discard this from play, you may put it onto your deck.",
+        "wikitext": "+2 Coins<n>You may rotate the Forts.<n><line>When you discard this from play, you may put it onto your deck."
+    },
+    "Territory": {
+        "description": "Worth 1 <VP> per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile.",
+        "extra": "For example, if your deck has 3 Estates, a Province, and a Territory, Territory is worth 3 <VP>.<n>If gaining Territory causes the Clashes pile to be empty, that counts for how many Gold you get.",
+        "name": "Territory",
+        "raw_wikitext": "Worth {{VP|1}} per differently named Victory card you have.{{Divline}}When you gain this, gain a Gold per empty Supply pile.",
+        "wikitext": "Worth {{VP|1}} per differently named Victory card you have.<line>When you gain this, gain a Gold per empty Supply pile."
+    },
+    "The Earth's Gift": {
+        "description": "You may discard a Treasure to gain a card costing up to 4 Coin.",
+        "extra": "",
+        "name": "The Earth's Gift",
+        "raw_wikitext": "You may discard a Treasure to gain a card costing up to {{Cost|4}}.",
+        "wikitext": "You may discard a Treasure to gain a card costing up to 4 Coins."
+    },
+    "The Field's Gift": {
+        "description": "+1 Action<br>+1 Coin<br>(Keep this until Clean-up.)",
+        "extra": "",
+        "name": "The Field's Gift",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>''(Keep this until Clean-up.)''</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+1 Coin<n><i>(Keep this until Clean-up.)</i>"
+    },
+    "The Flame's Gift": {
+        "description": "You may trash a card from your hand.",
+        "extra": "",
+        "name": "The Flame's Gift",
+        "raw_wikitext": "You may trash a card from your hand.",
+        "wikitext": "You may trash a card from your hand."
+    },
+    "The Forest's Gift": {
+        "description": "+1 Buy<br>+1 Coin<br>(Keep this until Clean-up.)",
+        "extra": "",
+        "name": "The Forest's Gift",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}<p>''(Keep this until Clean-up.)''</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin<n><i>(Keep this until Clean-up.)</i>"
+    },
+    "The Moon's Gift": {
+        "description": "Look through your discard pile.<br>You may put a card from it onto your deck.",
+        "extra": "If your discard pile is empty, this will not do anything.",
+        "name": "The Moon's Gift",
+        "raw_wikitext": "Look through your discard pile. You may put a card from it onto your deck.",
+        "wikitext": "Look through your discard pile. You may put a card from it onto your deck."
+    },
+    "The Mountain's Gift": {
+        "description": "Gain a Silver.",
+        "extra": "",
+        "name": "The Mountain's Gift",
+        "raw_wikitext": "Gain a Silver.",
+        "wikitext": "Gain a Silver."
+    },
+    "The River's Gift": {
+        "description": "+1 Card at the end of this turn.<br>(Keep this until Clean-up.)",
+        "extra": "You draw the card after drawing your hand for your next turn.",
+        "name": "The River's Gift",
+        "raw_wikitext": "<p>'''+1&nbsp;Card''' at the end of this turn.</p>''(Keep this until Clean-up.)''",
+        "wikitext": "<b>+1&nbsp;Card</b> at the end of this turn.<n><i>(Keep this until Clean-up.)</i>"
+    },
+    "The Sea's Gift": {
+        "description": "+1 Card",
+        "extra": "",
+        "name": "The Sea's Gift",
+        "raw_wikitext": "'''+1&nbsp;Card'''",
+        "wikitext": "<b>+1&nbsp;Card</b>"
+    },
+    "The Sky's Gift": {
+        "description": "You may discard 3 cards to gain a Gold.",
+        "extra": "If you choose to do this with fewer than three cards in hand, you will discard the rest of your cards but not gain a Gold. Discarding three cards gets you one Gold, not three.",
+        "name": "The Sky's Gift",
+        "raw_wikitext": "You may discard 3&nbsp;cards to gain a Gold.",
+        "wikitext": "You may discard 3&nbsp;cards to gain a Gold."
+    },
+    "The Sun's Gift": {
+        "description": "Look at the top 4 cards of your deck.<br>Discard any number of them and put the rest back in any order.",
+        "extra": "",
+        "name": "The Sun's Gift",
+        "raw_wikitext": "Look at the top 4&nbsp;cards of your deck. Discard any number of them and put the rest back in any order.",
+        "wikitext": "Look at the top 4&nbsp;cards of your deck. Discard any number of them and put the rest back in any order."
+    },
+    "The Swamp's Gift": {
+        "description": "Gain a Will-o'-Wisp from its pile.",
+        "extra": "",
+        "name": "The Swamp's Gift",
+        "raw_wikitext": "Gain a Will-o'-Wisp.",
+        "wikitext": "Gain a Will-o'-Wisp."
+    },
+    "The Wind's Gift": {
+        "description": "+2 Cards<br>Discard 2 cards.",
+        "extra": "",
+        "name": "The Wind's Gift",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Discard 2&nbsp;cards.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Discard 2&nbsp;cards."
+    },
+    "Thief": {
+        "description": "Each other player reveals the top 2 cards of his deck. If they revealed any Treasure cards, they trash one of them that you choose. You may gain any or all of these trashed cards. They discard the other revealed cards.",
+        "extra": "A player with just one card left revealed that last card and then shuffles to get the other card to reveal (without including the revealed card); a player with no cards left shuffles to get both of them. A player who still doesn't have two cards to reveal after shuffling just reveals what he can. Each player trashes one Treasure card at most, of the attacker's choice from the two revealed cards, and then you gain any of the trashed cards that you want. You can only take Treasures just trashed - not ones trashed on previous turns. You can take none of them, all of them, or anything in between. Put the Treasures you decided to gain into your Discard pile. The ones you choose not to gain stay in the Trash pile.",
+        "name": "Thief",
+        "raw_wikitext": "Each other player reveals the top 2&nbsp;cards of their deck. If they revealed any Treasure cards, they trash one of them that you choose. You may gain any or all of these trashed cards. They discard the other revealed cards.",
+        "wikitext": "Each other player reveals the top 2&nbsp;cards of their deck. If they revealed any Treasure cards, they trash one of them that you choose. You may gain any or all of these trashed cards. They discard the other revealed cards."
+    },
+    "Throne Room": {
+        "description": "You may play an Action card from your hand twice.<n>[Choose an Action card in your hand. Play it twice.]",
+        "extra": "You pick another Action card in your hand, play it, and play it again. The second use of the Action card doesn't use up any extra Actions you have. You completely resolve playing the Action the first time before playing it the second time. If you Throne Room a Throne Room, you play an Action, doing it twice, and then play another Action and do it twice; you do not resolve an Action four times. If you Throne Room a card that gives you +1 Action, such as Market, you will end up with 2 Actions left afterwards, which is tricky, because if you'd just played Market twice you'd only have 1 Action left afterwards. Remember to count the number of Actions you have remaining out loud to keep from getting confused! You cannot play any other Actions in between playing the Throne Roomed Action twice.",
+        "name": "Throne Room",
+        "raw_wikitext": "You may play an Action card from your hand twice.",
+        "wikitext": "You may play an Action card from your hand twice."
+    },
+    "Tiara": {
+        "description": "+1 Buy<n><n>This turn, when you gain a card, you may put it onto your deck.<n><n>You may play a Treasure from your hand twice.",
+        "extra": "If you gain multiple cards later in the turn after playing Tiara, you may put any or all of them onto your deck. This applies both to cards gained due to being bought, and to cards gained other ways, such as with War Chest. If you play a Tiara with a Tiara, you will be able to play two Treasures from your hand twice each - you don't play one Treasure four times.",
+        "name": "Tiara",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>This turn, when you gain a card, you may put it onto your deck.</p>You may play a Treasure from your hand twice.",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>This turn, when you gain a card, you may put it onto your deck.<n>You may play a Treasure from your hand twice."
+    },
+    "Tide Pools": {
+        "description": "+3 Cards<br>+1 Action<br><br>At the start of your next turn, discard 2 cards.",
+        "extra": "When you play this, you get +3 Cards and +1 Action, but at the start of your next turn, you have to discard 2 cards.<br>If you have only one card left in hand you discard that one, and if you have no cards you don't discard any.<br>When you have multiple Duration cards doing things at the start of your turn, you can put them in an order to your advantage; for example if you have four <i>Tide Pools</i> and a <i>Wharf</i>, you could discard all of your cards to the <i>Tide Pools</i>, then draw the <i>Wharf</i> cards.",
+        "name": "Tide Pools",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>At the start of your next turn, discard 2&nbsp;cards.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>At the start of your next turn, discard 2&nbsp;cards."
+    },
+    "Tireless": {
+        "description": "When you discard a Tireless card from play, set it aside, and put it onto your deck at end of turn.",
+        "extra": "This is mandatory.<br>You draw your next hand before putting the card onto your deck.",
+        "name": "Tireless",
+        "raw_wikitext": "When you discard a Tireless card from play, set it aside, and put it onto your deck at end of turn.",
+        "wikitext": "When you discard a Tireless card from play, set it aside, and put it onto your deck at end of turn."
+    },
+    "Toil": {
+        "description": "+1 Buy<n>You may play an Action card from your hand.",
+        "extra": "Playing an Action card this way does not use up an Action.",
+        "name": "Toil",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<p>You may play an Action card from your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Buy</b><n>You may play an Action card from your hand."
+    },
+    "Tomb": {
+        "description": "When you trash a card, +1 <VP>.",
+        "extra": "This works even when it is not your turn, such as when you trash a card to Swindler (from Intrigue), and works when told to trash a card that is not yours, such as with Salt the Earth.",
+        "name": "Tomb",
+        "raw_wikitext": "When you trash a card, {{VP|'''+1'''}}.",
+        "wikitext": "When you trash a card, {{VP|<b>+1</b>}}."
+    },
+    "Tools": {
+        "description": "Gain a copy of a card anyone has in play.",
+        "extra": "This can gain a copy of a card any player has in play; other players may for example have Duration cards in play.<br>Tools itself is in play, so you can gain a copy of that.",
+        "name": "Tools",
+        "raw_wikitext": "Gain a copy of a card anyone has in play.",
+        "wikitext": "Gain a copy of a card anyone has in play."
+    },
+    "Tormentor": {
+        "description": "+2 Coins<n>If you have no other cards in play, gain an Imp from its pile. Otherwise, each other player receives the next Hex.",
+        "extra": "Setup: Put the Imp pile near the Supply.<br><br>Cards in play from previous turns are still cards in play; cards you played this turn but which are no longer in play (such as a Pixie you trashed) are not in play.",
+        "name": "Tormentor",
+        "raw_wikitext": "{{Costplus|2}}<p>If you have no other cards in play, gain an Imp. Otherwise, each other player receives the next Hex.</p>",
+        "wikitext": "+2 Coins<n>If you have no other cards in play, gain an Imp. Otherwise, each other player receives the next Hex."
+    },
+    "Torturer": {
+        "description": "+3 Card<n>Each other player chooses one: he discards 2 cards; or he gains a Curse card, putting it in his hand.",
+        "extra": "Each other player chooses which option to suffer and then suffers it. A player can choose to gain a Curse even when there are no Curses left, in which case he doesn't gain one; and a player can choose to discard 2 cards even if he has no cards in hand or one card in hand (if he has one card, he discards that single card). Gained Curses go to the players' hands rather than their discard piles. If there aren't enough Curses left for everybody, deal them around in turn order starting with the player to your left. When the order matters (such as with very few Curses left), each player makes his decision of which fate to suffer in turn order.",
+        "name": "Torturer",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>Each other player either discards 2&nbsp;cards or gains a Curse to their hand, their choice. (They may pick an option they can't do.)</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>Each other player either discards 2&nbsp;cards or gains a Curse to their hand, their choice. (They may pick an option they can't do.)"
+    },
+    "Tournament": {
+        "description": "+1 Action<n>Each player may reveal a Province from his hand. If you do, discard it and gain a Prize (from the Prize pile) or a Duchy, putting it on top of your deck. If no-one else does, +1 Card, +1 Coin.<n>Prizes: <u>Bag of Gold</u>, <u>Diadem</u>, <u>Followers</u>, <u>Princess</u>, <u>Trusty Steed</u>",
+        "extra": "First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin.",
+        "name": "Tournament",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Each player may reveal a Province from their hand. If you do, discard it and gain any Prize (from the Prize pile) or a Duchy, onto your deck. If no-one else does, '''+1&nbsp;Card''' and {{Costplus|1}}.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Each player may reveal a Province from their hand. If you do, discard it and gain any Prize (from the Prize pile) or a Duchy, onto your deck. If no-one else does, <b>+1&nbsp;Card</b> and +1 Coin."
+    },
+    "Tournament and Prizes": {
+        "description": "+1 Action<n>Each player may reveal a Province from his hand. If you do, discard it and gain a Prize (from the Prize pile) or a Duchy, putting it on top of your deck. If no-one else does, +1 Card +1 Coin.<n><justify>Prizes: <u>Bag of Gold</u>, <u>Diadem</u>, <u>Followers</u>, <u>Princess</u>, <u>Trusty Steed</u></justify>",
+        "extra": " First you get +1 Action. Then each player, including you, may reveal a Province card from his hand. Then, if you revealed a Province, discard that card, and you gain a Prize of your choice, or a Duchy, putting whatever card you took on top of your deck. If there were no cards in your deck, it becomes the only card in your deck. There are five Prizes, set out at the start of the game; see Preparation. You can only take a Prize from the Prize pile. You can take any Prize from the Prize pile; you do not have to take the top one. You can take a Duchy instead, whether or not the Prizes have run out. You can opt to take a Duchy even if the Duchy pile is empty, or a Prize even if no Prizes are left; in these cases you gain nothing. After gaining your card or not, if no other player revealed a Province, you draw a card and get +1 coin. ",
+        "name": "Tournament and Prizes"
+    },
+    "Tower": {
+        "description": "When scoring, 1 <VP> per non-Victory card you have from an empty Supply pile.",
+        "extra": "A Supply pile is only empty if it has no cards in it; a split pile with half of the cards gone is not empty.<n>Victory cards do not count, but Curses do.",
+        "name": "Tower",
+        "raw_wikitext": "When scoring, {{VP|'''1'''}} per non-Victory card you have from an empty Supply pile.",
+        "wikitext": "When scoring, 1 <VP> per non-Victory card you have from an empty Supply pile."
+    },
+    "Town": {
+        "description": "Choose one:<br>+1 Card and +2 Actions;<br>or +1 Buy and +2 Coins.",
+        "extra": "You simply choose to either get +1 Card and +2 Actions, or +1 Buy and +2 Coins. ",
+        "name": "Town",
+        "raw_wikitext": "Choose one: '''+1&nbsp;Card''' and '''+2&nbsp;Actions'''; or '''+1&nbsp;Buy''' and {{Costplus|2}}.",
+        "wikitext": "Choose one: <b>+1&nbsp;Card</b> and <b>+2&nbsp;Actions</b>; or <b>+1&nbsp;Buy</b> and +2 Coins."
+    },
+    "Town Crier": {
+        "description": "Choose one: +2 Coin; or gain a Silver; or +1 Card and +1 Action. You may rotate the Townsfolk.",
+        "extra": "First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.",
+        "name": "Town Crier",
+        "raw_wikitext": "<p>Choose one: {{Costplus|2}}; or gain a Silver; or '''+1&nbsp;Card''' and '''+1&nbsp;Action'''.</p>You may rotate the Townsfolk.",
+        "wikitext": "Choose one: +2 Coins; or gain a Silver; or <b>+1&nbsp;Card</b> and <b>+1&nbsp;Action</b>.<n>You may rotate the Townsfolk."
+    },
+    "Townsfolk": {
+        "description": "This pile starts the game with 4 copies each of Town Crier, Blacksmith, Miller, and Elder, in that order. Only the top card can be gained or bought.",
+        "extra": "Town Crier: First choose either to get +2 Coins, or to gain a Silver, or to get +1 Card and +1 Action. Then, no matter what you picked, choose whether or not to rotate the Townsfolk pile.<n>Blacksmith: You either draw until you have 6 cards in hand, or draw 2 cards, or draw one card and get +1 Action.<n>Miller: If you have fewer than four cards (after shuffling), you just look at what's left.<n>Elder: You can play an Action card with no \"choose\" ability; it will simply do what it normally does. If you play one with a \"choose\" ability, you may take an extra choice, but don't have to. If you choose multiple things, you do those things in the order listed on the card. If you use Elder on Courtier, you get one extra choice, not one extra choice per type. Elder doesn't affect all choices, just ones that say \"choose\" and have a list of options.",
+        "name": "Townsfolk"
+    },
+    "Tracker": {
+        "description": "+1 Coin<br>Receive a Boon.<line>While this is in play, when you gain a card, you may put that card onto your deck.<br><br><i>Heirloom: Pouch</i>",
+        "extra": "If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck. In games using Tracker, replace one of your starting Coppers with a Pouch.",
+        "name": "Tracker",
+        "raw_wikitext": "{{Costplus|1}}<p>This turn, when you gain a card, you may put it onto your deck. Receive a Boon.</p>''Heirloom: Pouch''",
+        "wikitext": "+1 Coin<n>This turn, when you gain a card, you may put it onto your deck. Receive a Boon.<n><i>Heirloom: Pouch</i>"
+    },
+    "Tracker - Pouch": {
+        "description": "<left><u>Tracker</u>:</left><center>+1 Coin</center><center>Receive a Boon.</center><line><center>While this is in play, when you gain a card, you may put that card onto your deck.</center><left><i>Heirloom: Pouch</i></left><left><u>Pouch</u>:</left><center>1 <*COIN*></center><n><n>+1 Buy",
+        "extra": "<u>Tracker</u>: If you gain multiple cards with this in play, this applies to each of them - you could put any or all of them on top of your deck. This applies both to cards gained due to being bought, and to cards gained other ways with Tracker in play. Tracker is in play when you resolve its Boon, so if the Boon causes you to gain a card, for example a Silver from The Mountain's Gift, you can put that card onto your deck.\nIn games using Tracker, replace one of your starting Coppers with a Pouch.\n<u>Pouch</u>: This simply gives you 1 Coin and +1 Buy when you play it.",
+        "name": "Tracker / Pouch"
+    },
+    "Trade": {
+        "description": "Trash up to 2 cards from your hand.<n>Gain a Silver per card you trashed.",
+        "extra": "You may trash zero, one, or two cards from your hand. For each card you actually trashed, you gain a Silver, putting it into your discard pile.",
+        "name": "Trade",
+        "raw_wikitext": "Trash up to 2&nbsp;cards from your hand. Gain a Silver per card you trashed.",
+        "wikitext": "Trash up to 2&nbsp;cards from your hand. Gain a Silver per card you trashed."
+    },
+    "Trade Route": {
+        "description": "+1 Buy<br>+1 Coin per token on the Trade Route mat.<br>Trash a card from your hand.<line>Setup: Put a token on each Victory card Supply pile. When a card is gained from that pile, move the token to the Trade Route mat.",
+        "extra": "You get an additional Buy to use in your Buy phase. You get +1 coin per token on the Trade Route mat. Then you trash a card from your hand. If you have no cards left in hand, you do not trash one. The amount you get from Trade Route is the same as +1 coin per Victory card pile that a card has been gained from this game. If Victory cards have been gained from outside the Supply piles, for example using the promotional card Black Market, then this does not count those. Put a coin token on each Victory card pile at the start of the game. When a card is gained from a Victory card pile, move its token onto the Trade Route mat. So for example if this game includes the Intrigue card Harem, and so far Harem and Duchy have been bought, but no one has bought (or otherwise gained) Estate or Province or Colony, then Trade Route makes 2 coins. It does not matter who gained the cards or how they gained them. You do not get any extra money if a pile has had multiple cards gained from it or is empty; all that matters is if at least one card has been gained from it. It does not matter if cards have been returned to a pile, such as with Ambassador from Seaside; Trade Route only cares if a card was ever gained from the pile this game. If you are using Black Market and Trade Route is in the Black Market deck, put tokens on Victory card piles at the start of the game.",
+        "name": "Trade Route",
+        "raw_wikitext": "'''+1 Buy'''<p>Trash a card from your hand. {{Costplus|1}} per Coin token on the Trade Route mat.</p>{{Divline}}Setup: Add a Coin token to each Victory Supply pile; move that token to the Trade Route mat when a card is gained from the pile.",
+        "wikitext": "<b>+1 Buy</b><n>Trash a card from your hand. +1 Coin per Coin token on the Trade Route mat.<n><line>Setup: Add a Coin token to each Victory Supply pile; move that token to the Trade Route mat when a card is gained from the pile."
+    },
+    "Trader": {
+        "description": "Trash a card from your hand. Gain a Silver per 1 coin it costs.<line>When you gain a card, you may reveal this from your hand, to exchange the card for a Silver.",
+        "extra": "When you play this, trash a card from your hand, and if you did, gain a number of Silvers equal to the cost of that card in coins. The Silvers come from the Supply and are put into your discard pile. If there are not enough Silvers left, just gain all of the Silvers that you can. You only gain Silvers if you trashed a card. If you trash a card costing 0 coins, such as Copper, you will gain zero Silvers. You can trash Silver if you want; you will gain three Silvers for it normally. If costs are different, such as due to playing Highway, then Trader will give you a different number of Silvers, based on the current costs. For example if you play Highway and then Trader, trashing an Estate you will only gain one Silver. If you trash a card with Potion in its cost from Alchemy, you do not get anything for the Potion, just for the coins that the card cost. Trader is also a Reaction. When you gain a card, whether due to buying it or due to gaining it some other way, you may reveal Trader from your hand to instead gain a Silver from the Supply. If you do this, you gain a Silver, not the card you would have gained; if something would have happened due to gaining the other card, it does not happen, because you did not gain it. For example if you buy Ill-Gotten Gains but use Trader to gain Silver instead, no-one will gain a Curse. However if something happens when you buy a card, that will still happen if you replace gaining the card with gaining Silver. For example you can buy Farmland, trash a card from your hand and gain one costing 2 more, then use Trader to gain Silver rather than Farmland. If the card you were going to gain was not going to your discard pile, the Silver still goes to your discard pile; if the card you were going to gain did not come from the Supply, the Silver still comes from the Supply. If there are no Silvers left in the Supply, you can still reveal Trader when you gain a card; you gain nothing instead of the card you would have gained.",
+        "name": "Trader",
+        "raw_wikitext": "Trash a card from your hand. Gain a Silver per {{Cost|1}} it costs.{{Divline}}When you gain a card, you may reveal this from your hand, to exchange the card for a Silver.",
+        "wikitext": "Trash a card from your hand. Gain a Silver per 1 Coin it costs.<line>When you gain a card, you may reveal this from your hand, to exchange the card for a Silver."
+    },
+    "Trading Post": {
+        "description": "Trash 2 cards from your hand. If you do, gain a silver card; put it into your hand.",
+        "extra": "If you have 2 or more cards, you must trash exactly 2 cards and gain a Silver card. The gained Silver card goes into your hand and can be spent the same turn. If the Silver pile is empty, you do not gain a Silver card (but still trash cards if possible). If you only have one card left in your hand and you play Trading Post, you trash the one remaining card but you do not gain a Silver. If you have no cards left when you play this, nothing happens.",
+        "name": "Trading Post",
+        "raw_wikitext": "Trash 2&nbsp;cards from your hand. If you did, gain a Silver to your hand.",
+        "wikitext": "Trash 2&nbsp;cards from your hand. If you did, gain a Silver to your hand."
+    },
+    "Tragic Hero": {
+        "description": "+3 Cards<br>+1 Buy<br>If you have 8 or more cards in hand (after drawing), trash this and gain a Treasure.",
+        "extra": "First draw three cards; then, if you have eight or more cards in hand, you trash Tragic Hero and gain a Treasure. If you cannot trash Tragic Hero (for example if you play it twice with Throne Room and trashed it the first time), you still gain the Treasure.",
+        "name": "Tragic Hero",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Buy'''<p>If you have 8&nbsp;or more cards in hand (after drawing), trash this and gain a Treasure.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Buy</b><n>If you have 8&nbsp;or more cards in hand (after drawing), trash this and gain a Treasure."
+    },
+    "Trail": {
+        "description": "+1 Card<br>+1 Action<line>When you gain, trash, or discard this, other than in Clean-up, you may play it.",
+        "extra": "When you play this, you simply get +1 Card and +1 Action. When you gain, trash, or discard this, other than in Clean-up, you may play it. As usual playing it means putting it into play and following its instructions. If you play Trail on another player's turn, the +1 Action won't be useful, and you discard Trail from play in that turn's Clean-up. If you trash Trail, playing it means you get the Trail back; it will go into play, and be discarded into your discard pile in that turn's Clean-up. This still counts as trashing it; if you Remodel a Trail you can play it and then gain a Gold from Remodel, and so on. If you gain or trash a Trail during Clean-up (with e.g. Improve), you can't use its Reaction.",
+        "name": "Trail",
+        "raw_wikitext": "'''+1&nbsp;Card<br>+1&nbsp;Action'''{{Divline}}When you gain, trash, or discard this, other than in Clean-up, you may play it.",
+        "wikitext": "<b>+1&nbsp;Card<br>+1&nbsp;Action</b><line>When you gain, trash, or discard this, other than in Clean-up, you may play it."
+    },
+    "Training": {
+        "description": "Move your +1 Coin token to an Action Supply pile (when you play a card from that pile, you first get +1 Coin).",
+        "extra": "When you buy this, you move your +1 Coin token to any Action Supply pile. This token gives you +1 Coin whenever you play a card from that pile; see the Tokens section.",
+        "name": "Training",
+        "raw_wikitext": "Move your {{Costplus|1}} token to an Action Supply pile. (When you play a card from that pile, you first get {{Costplus|1}}.)",
+        "wikitext": "Move your +1 Coin token to an Action Supply pile. (When you play a card from that pile, you first get +1 Coin.)"
+    },
+    "Transmogrify": {
+        "description": "+1 Action<n>Put this on your Tavern mat.<line>At the start of your turn, you may call this, to trash a card from your hand, gain a card costing up to 1 Coin more than it, and put that card into your hand.",
+        "extra": "When you play this, you get +1 Action and put it on your Tavern mat. It stays on your mat until you call it, at the start of one of your turns. If multiple things can happen at the start of your turn, you can do them in any order. When you call Transmogrify, it moves from the mat into play, and you trash a card from your hand, then gain a card costing up to 1 Coin more than the trashed card. The gained card comes from the Supply and is put into your hand; if you had no cards to trash, you do not gain one. Transmogrify is discarded that turn with your other cards in play. You may trash a card to gain a card costing 1 Coin more, or the same amount, or less; you may trash a card to gain a copy of the same card.",
+        "name": "Transmogrify",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Put this on your Tavern mat.</p>{{Divline}}At the start of your turn, you may call this, to trash a card from your hand, and gain a card to your hand costing up to {{Cost|1}} more than it.",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Put this on your Tavern mat.<n><line>At the start of your turn, you may call this, to trash a card from your hand, and gain a card to your hand costing up to 1 Coin more than it."
+    },
+    "Transmute": {
+        "description": "Trash a card from your hand. If it is an...<n>Action card, gain a Duchy<n>Treasure card, gain a Transmute<n>Victory card, gain a Gold",
+        "extra": "If you have no cards left in hand to trash, you do not get anything. If you trash a Curse to this, you do not get anything - Curse is not an Action card or Victory card or Treasure card. If you trash a card with more than one type, you get each applicable thing. For example, if you trash an Action-Victory card (such as Nobles, from Intrigue), you gain both a Duchy and a Gold. Gained cards come from the Supply and go to your discard pile. If there are no appropriate cards left to gain, you don't gain those cards.",
+        "name": "Transmute",
+        "raw_wikitext": "<p>Trash a card from your hand. If it is an&hellip;</p>Action card, gain a Duchy<br>Treasure card, gain a Transmute<br>Victory card, gain a Gold",
+        "wikitext": "Trash a card from your hand. If it is an&hellip;<n>Action card, gain a Duchy<br>Treasure card, gain a Transmute<br>Victory card, gain a Gold"
+    },
+    "Transport": {
+        "description": "Choose one: Exile an Action card from the Supply; or put an Action card you have in Exile onto your deck.",
+        "extra": "It only matters if the card is an Action, not if the whole pile is.<n>This can take Action cards from your Exile mat that were put there by other cards.",
+        "name": "Transport",
+        "raw_wikitext": "Choose one: Exile an Action card from the Supply; or put an Action card you have in Exile onto your deck.",
+        "wikitext": "Choose one: Exile an Action card from the Supply; or put an Action card you have in Exile onto your deck."
+    },
+    "Trappers' Lodge": {
+        "description": "When you gain a card, you may spend a Favor to put it onto your deck.",
+        "extra": "",
+        "name": "Trappers' Lodge",
+        "raw_wikitext": "When you gain a card, you may spend a '''Favor''' to put it onto your deck.",
+        "wikitext": "When you gain a card, you may spend a <b>Favor</b> to put it onto your deck."
+    },
+    "Trash": {
+        "description": "Pile of trash.",
+        "extra": "",
+        "name": "Trash"
+    },
+    "Travelling Fair": {
+        "description": "+2 Buys<n>When you gain a card this turn, you may put it on top of your deck.",
+        "extra": "When you buy this, you get +2 Buys (letting you buy more Events or cards afterwards). Then for the rest of the turn, whenever you gain a card, you may put it on your deck. This works on cards you buy, as well as cards gained other ways, such as gaining cards with Ball. It does not work on Travellers exchanged for other cards; exchanging is not gaining. Putting the card on your deck is optional each time you gain a card that turn; you could put some on top and let the others go to your discard pile.",
+        "name": "Travelling Fair",
+        "raw_wikitext": "'''+2&nbsp;Buys'''<p>When you gain a card this turn, you may put it onto your deck.</p>",
+        "wikitext": "<b>+2&nbsp;Buys</b><n>When you gain a card this turn, you may put it onto your deck."
+    },
+    "Treasure Chest": {
+        "description": "At the start of your Buy phase, gain a Gold.",
+        "extra": "Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Treasure Chest",
+        "raw_wikitext": "At the start of your Buy phase, gain a Gold.",
+        "wikitext": "At the start of your Buy phase, gain a Gold."
+    },
+    "Treasure Hunter": {
+        "description": "+1 Action<br>+1 Coin<n>Gain a Silver per card the player to your right gained in his last turn.<line>When you discard this from play, you may exchange it for a Warrior.<n><i>(This is not in the Supply.)</i>",
+        "extra": "This counts all cards gained, not just bought cards. For example if the player to your right played Amulet, gaining a Silver, then bought a Duchy, you would gain two Silvers. The gained Silvers are put into your discard pile.",
+        "name": "Treasure Hunter",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>Gain a Silver per card the player to your right gained in their last turn.</p>{{Divline}}<p>When you discard this from play, you may exchange it for a Warrior.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+1 Coin<n>Gain a Silver per card the player to your right gained in their last turn.<n><line><n>When you discard this from play, you may exchange it for a Warrior.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Treasure Map": {
+        "description": "Trash this and another copy of Treasure Map from your hand. If you do trash two Treasure Maps, gain 4 Gold cards, putting them on top of your deck.",
+        "extra": "You can play this without another Treasure Map in your hand; if you do, you trash this and gain nothing. You have to actually trash two copies of Treasure Map to gain the Golds; so for example if you Throne Room a Treasure Map, with two more Treasure Maps in hand, then the first time Treasure Map resolves you trash it and another one and gain 4 Golds, and the second time it resolves you trash your other Treasure Map but gain nothing (since you didn't actually trash the played Treasure Map that time). If there aren't enough Gold cards left, just gain what you can. The gained Golds go on top of your Deck. If your deck was empty they become the only cards in it.",
+        "name": "Treasure Map",
+        "raw_wikitext": "Trash this and a Treasure Map from your hand. If you trashed two Treasure Maps, gain 4&nbsp;Golds onto your deck.",
+        "wikitext": "Trash this and a Treasure Map from your hand. If you trashed two Treasure Maps, gain 4&nbsp;Golds onto your deck."
+    },
+    "Treasure Trove": {
+        "description": "2 <*COIN*><n>When you play this, gain a Gold and a Copper.",
+        "extra": "This is a Treasure worth 2 Coins. You play it in your Buy phase, like other Treasures. When you play it, you gain a Copper and a Gold from the Supply, putting them into your discard pile. If one of those piles is empty, you still gain the other card.",
+        "name": "Treasure Trove",
+        "raw_wikitext": "{{Cost|2|l}}<p>Gain a Gold and a Copper.</p>",
+        "wikitext": "2 <*COIN*><n>Gain a Gold and a Copper."
+    },
+    "Treasurer": {
+        "description": "+3 Coin<br><n>Choose one: Trash a Treasure from your hand; or gain a Treasure from the trash to your hand; or take the Key.",
+        "extra": "The Key does not help you the turn you take it; it gives +1 Coin at the start of your turn, which has already happened. When you use a Treasurer to gain a Treasure from the trash, that can trigger abilities like the ones on Ducat and Spices. You can choose to take the Key even if you already have it.",
+        "name": "Treasurer",
+        "raw_wikitext": "{{Costplus|3}}<p>Choose one: Trash a Treasure from your hand; or gain a Treasure from the trash to your hand; or take the Key.</p>",
+        "wikitext": "+3 Coins<n>Choose one: Trash a Treasure from your hand; or gain a Treasure from the trash to your hand; or take the Key."
+    },
+    "Treasurer - Key": {
+        "description": "<left><u>Treasurer</u>:</left><n>+3 Coin<br><n>Choose one: Trash a Treasure from your hand; or gain a Treasure from the trash to your hand; or take the Key.<n><left><u>Key</u>:</left><n>At the start of your turn, +1 Coin.",
+        "extra": "The Key does not help you the turn you take it; it gives +1 Coin at the start of your turn, which has already happened. When you use a Treasurer to gain a Treasure from the trash, that can trigger abilities like the ones on Ducat and Spices. You can choose to take the Key even if you already have it.<n><n>Key is an Artifact. Artifacts are effects that apply to one player, that are not tracked by normal cards or Events. They function similarly to States (from Nocturne). Artifacts are not \"cards\"; any text referring to a \"card\" does not apply to Artifacts. There is only one copy of each Artifact; when a player takes an Artifact, the Artifact card is placed in front of them until another player takes it.",
+        "name": "Treasurer / Key"
+    },
+    "Treasury": {
+        "description": "+1 Card<br>+1 Action<br>+1 Coin<line>When you discard this from play, if you didn't buy a Victory card this turn, you may put this on top of your deck.",
+        "extra": "If you buy multiple cards and at least one of them is a Victory card, then none of your Treasuries can be put on top of your deck. If you played multiple Treasuries and did not buy a Victory card this turn, then you can put any or all of the played Treasuries on top of your deck. If you forget and discard a Treasury to your discard pile, then essentially you have chosen not to use the optional ability. You may not dig through your discard pile to retrieve it later. Gaining a Victory card without buying it, such as with Smugglers, does not stop you from putting Treasury on top of your deck.",
+        "name": "Treasury",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>{{Costplus|1}}<p>At the end of your Buy phase this turn, if you didn't gain a Victory card in it, you may put this onto your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br>+1 Coin<n>At the end of your Buy phase this turn, if you didn't gain a Victory card in it, you may put this onto your deck."
+    },
+    "Tribute": {
+        "description": "The player to your left reveals then discards the top 2 cards of his deck. For each differently named card revealed, if it is an...<n>Action Card, +2 Actions;<br>Treasure Card, +2 Coins;<br>Victory Card, +2 Cards.",
+        "extra": "If the player after you has fewer than 2 cards left in his deck, he reveals all the cards in his deck, shuffles his discard pile (which does not include currently revealed cards), and then reveals the remainder needed. The player then discards the revealed cards. If the player after you does not have enough cards to reveal 2, he reveals what he can. You get bonuses for the types of cards revealed, counting only the different cards. A card with 2 types gives you both bonuses. So if the player to your left reveals Copper and Harem, you get +4 Coins and +2 cards; if he reveals 2 Silvers, you just get +2 coins. Curse produces no bonus.",
+        "name": "Tribute",
+        "raw_wikitext": "<p>The player to your left reveals then discards the top 2&nbsp;cards of their deck. For each differently named card revealed, if it is an&hellip;</p>Action Card, '''+2&nbsp;Actions'''<br>Treasure Card, {{Costplus|2}}<br>Victory Card, '''+2&nbsp;Cards'''",
+        "wikitext": "The player to your left reveals then discards the top 2&nbsp;cards of their deck. For each differently named card revealed, if it is an&hellip;<n>Action Card, <b>+2&nbsp;Actions</b><br>Treasure Card, +2 Coins<br>Victory Card, <b>+2&nbsp;Cards</b>"
+    },
+    "Trickster": {
+        "description": "Each other player gains a Curse.<br>Once this turn, when you discard a Treasure from play, you may set it aside. Put it in your hand at end of turn.",
+        "extra": "This is cumulative; if you play two Tricksters, then you can set aside up to two Treasures you discard from play and put them into your hand at end of turn, after drawing.",
+        "name": "Trickster",
+        "raw_wikitext": "Each other player gains a Curse.<br>Once this turn, when you discard a Treasure from play, you may set it aside. Put it in your hand at end of turn.",
+        "wikitext": "Each other player gains a Curse.<br>Once this turn, when you discard a Treasure from play, you may set it aside. Put it in your hand at end of turn."
+    },
+    "Triumph": {
+        "description": "Gain an Estate.<n>If you did, +1 <VP> per card you've gained this turn.",
+        "extra": "You get +1 <VP> per card you have gained, including the Estate, and any other cards bought or gained other ways; you do not get <VP> for Events bought.<n>Once the Estate pile is empty, this does nothing.",
+        "name": "Triumph",
+        "raw_wikitext": "Gain an Estate. If you did, {{VP|'''+1'''}} per card you've gained this turn.",
+        "wikitext": "Gain an Estate. If you did, {{VP|<b>+1</b>}} per card you've gained this turn."
+    },
+    "Triumphal Arch": {
+        "description": "When scoring, 3 <VP> per copy you have of the 2nd most common Action card among your cards (if it's a tie, count either).",
+        "extra": "For example, if you had 7 copies of Villa and 4 copies of Wild Hunt, you would score 12 <VP>.",
+        "name": "Triumphal Arch",
+        "raw_wikitext": "When scoring, {{VP|'''3'''}} per copy you have of the 2nd most common Action card among your cards (if it's a tie, count either).",
+        "wikitext": "When scoring, 3 <VP> per copy you have of the 2nd most common Action card among your cards (if it's a tie, count either)."
+    },
+    "Trusty Steed": {
+        "description": "Choose two: +2 Cards; or +2 Actions; or +2 Coins; or gain 4 Silvers and put your deck into your discard pile.<n>(The choices must be different.)<n><i>(This is not in the Supply.)</i>",
+        "extra": "First choose any two of the four options; then do those options in the order listed. So if you choose both +2 Cards, and the last option, you will draw cards before you gain the Silvers and put your deck into your discard pile. The last option both gains you Silvers and puts your deck into your discard pile. The Silvers come from the Supply; if there are fewer than four left, just gain as many as you can. You do not get to look through your deck as you put it into your discard pile. This is a Prize; see the Additional Rules.",
+        "name": "Trusty Steed",
+        "raw_wikitext": "<p>Choose two: '''+2&nbsp;Cards'''; or '''+2&nbsp;Actions'''; or {{Costplus|2}}; or gain 4&nbsp;Silvers and put your deck into your discard pile. The choices must be different.</p>''(This is not in the Supply.)''",
+        "wikitext": "Choose two: <b>+2&nbsp;Cards</b>; or <b>+2&nbsp;Actions</b>; or +2 Coins; or gain 4&nbsp;Silvers and put your deck into your discard pile. The choices must be different.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Tunnel": {
+        "description": "2 <*VP*><line>When you discard this other than during a Clean-up phase, you may reveal it. If you do, gain a Gold.",
+        "extra": "This is both a Victory card and a Reaction. At the end of the game, Tunnel is worth 2 <VP>. Tunnel's Reaction ability functions when you discard it. You cannot simply choose to discard it; something has to let you or make you discard it. This ability functions whether you discard Tunnel on your own turn (such as due to Oasis) or on someone else's (such as due to Margrave). It functions if Tunnel is discarded from your hand (such as due to Oasis) or from your deck, or when set aside (such as due to Cartographer). If Tunnel would normally not necessarily be revealed (such as when discarding multiple cards to Cartographer), you have to reveal it to get the Gold. Revealing it is optional, even if Tunnel was already revealed for some other reason; you are not forced to gain a Gold. This ability does not function if cards are put into your discard pile without being discarded, such as when you buy a card, when you gain a card directly (such as with Border Village), when your deck is put into your discard pile, such as with Chancellor from Dominion, or with Possession from Alchemy, when trashed cards are returned to you at end of turn. It also does not function during Clean-up, when you normally discard all of your played and unplayed cards. The key thing to look for is a card actually telling you to \"discard\" cards. The Gold you gain comes from the Supply and is put into your discard pile; if there is no Gold left in the Supply, you do not gain one.",
+        "name": "Tunnel",
+        "raw_wikitext": "{{VP|2|l}}{{Divline}}When you discard this other than during Clean-up, you may reveal it to gain a Gold.",
+        "wikitext": "2 <*VP*><line>When you discard this other than during Clean-up, you may reveal it to gain a Gold."
+    },
+    "Twice Miserable": {
+        "description": "-4 <*VP*>",
+        "name": "Twice Miserable",
+        "raw_wikitext": "{{VP|-4|l}}"
+    },
+    "Underling": {
+        "description": "+1 Card<br>+1Action<br>+1 Favor",
+        "extra": "Playing this simply gives you +1 Card, +1 Action, and +1 Favor.",
+        "name": "Underling",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<br>'''+1&nbsp;Favor'''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><br><b>+1&nbsp;Favor</b>"
+    },
+    "University": {
+        "description": "+2 Actions<n>You may gain an Action card costing up to 5 Coins.",
+        "extra": "Gaining an Action card is optional. If you choose to gain one, it comes from the Supply, must cost no more than 5 coins, and goes to your discard pile. Cards with multiple types, one of which is Action, are Actions and can be gained this way. Cards with Potion in their cost can't be gained by this.",
+        "name": "University",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<p>You may gain an Action card costing up to {{Cost|5}}.</p>",
+        "wikitext": "<b>+2&nbsp;Actions</b><n>You may gain an Action card costing up to 5 Coins."
+    },
+    "Upgrade": {
+        "description": "+1 Card<br>+1 Action<n>Trash a card from your hand. Gain a card costing exactly 1 Coin more than it.",
+        "extra": "Draw a card first. Then, you must trash a card from your hand and gain a card costing exactly 1 coin more than the trashed card. The gained card has to be a card in the Supply, and it goes into your discard pile. If there are no cards available for that cost, you do not get one (you still trashed a card though). If you do not have a card in your hand to trash, you neither trash nor gain a card. Card costs are affected by Bridge. Since Bridge affects the costs of the card you trash and then card you gain, in most cases the Bridge will have no net effect. But since cards cannot go below zero in cost, a Bridge played before an Upgrade would allow you to trash a Copper and gain an Estate.",
+        "name": "Upgrade",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Trash a card from your hand. Gain a card costing exactly {{Cost|1}} more than it.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Trash a card from your hand. Gain a card costing exactly 1 Coin more than it."
+    },
+    "Urchin": {
+        "description": "+1 Card<br>+1 Action<n>Each other player discards down to 4 cards in hand.<line>When you play another Attack card with this in play, you may trash this.<n>If you do, gain a Mercenary from the Mercenary pile.",
+        "extra": "When you play this, you draw a card and get +1 Action, then each other player discards down to 4 cards in hand. Players who already have 4 or fewer cards in hand do not do anything. While Urchin is in play, when you play another Attack card, before resolving it, you may trash the Urchin. If you do, you gain a Mercenary. The Mercenary comes from the Mercenary pile, which is not in the Supply, and is put into your discard pile. If there are no Mercenaries left you do not gain one. If you play the same Urchin twice in one turn, such as via Procession, that does not let you trash it for a Mercenary. If you play two different Urchins however, playing the second one will let you trash the first one.",
+        "name": "Urchin",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Each other player discards down to 4&nbsp;cards in hand.</p>{{Divline}}When you play another Attack card with this in play, you may first trash this, to gain a Mercenary.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Each other player discards down to 4&nbsp;cards in hand.<n><line>When you play another Attack card with this in play, you may first trash this, to gain a Mercenary."
+    },
+    "Urchin - Mercenary": {
+        "description": "<left><u>Urchin</u>:</left><center>+1 Card<br>+1 Action</center><center>Each other player discards down to 4 cards in hand.</center><line><center>When you play another Attack card with this in play, you may trash this.</center><center>If you do, gain a Mercenary from the Mercenary pile.</center><left><u>Mercenary</u>:</left><center>You may trash 2 cards from your hand.</center><center>If you do, +2 Cards, +2 Coins, and each other player discards down to 3 cards in hand.</center><center><i>(This is not in the Supply.)</i></center>",
+        "extra": "<u>Urchin</u>: When you play this, you draw a card and get +1 Action, then each other player discards down to 4 cards in hand. Players who already have 4 or fewer cards in hand do not do anything. While Urchin is in play, when you play another Attack card, before resolving it, you may trash the Urchin. If you do, you gain a Mercenary. If there are no Mercenaries left you do not gain one. If you play the same Urchin twice in one turn, such as via Procession, that does not let you trash it for a Mercenary. If you play two different Urchins however, playing the second one will let you trash the first one.<n><u>Mercenary</u>: This card is not in the Supply; it can only be obtained via Urchin. When you play it, you may trash 2 cards from your hand. If you do, you draw two cards, get +2 Coins, and each other player discards down to 3 cards in hand. Players who already have 3 or fewer cards in hand do nothing. Players responding to this Attack with cards like Beggar must choose to do so before you decide whether or not to trash 2 cards from your hand. If you play this with only one card in hand, you may choose to trash that card, but then will fail the \"if you do\" and will not draw cards and so on. If the cards you trash do things when trashed, first trash them both, then choose what order to resolve the things they do when trashed.",
+        "name": "Urchin / Mercenary"
+    },
+    "Vagrant": {
+        "description": "+1 Card<br>+1 Action<n>Reveal the top card of your deck. If it's a Curse, Ruins, Shelter, or Victory card, put it into your hand.",
+        "extra": "You draw a card before revealing your top card. If the top card of your deck is a Curse, Ruins, Shelter, or Victory card, it goes into your hand; otherwise it goes back on top. A card with multiple types goes into your hand if at least one of the types is Curse, Ruins, Shelter, or Victory.",
+        "name": "Vagrant",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If it's a Curse, Ruins, Shelter, or Victory card, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If it's a Curse, Ruins, Shelter, or Victory card, put it into your hand."
+    },
+    "Vampire": {
+        "description": "Each other player receives the next Hex.<br>Gain a card costing up to 5 Coin other than a Vampire.<br>Exchange this for a Bat.",
+        "extra": "Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.",
+        "name": "Vampire",
+        "raw_wikitext": "Each other player receives the next Hex.<p> Gain a card costing up to {{Cost|5}} other than a Vampire.</p>Exchange this for a Bat.",
+        "wikitext": "Each other player receives the next Hex.<n> Gain a card costing up to 5 Coins other than a Vampire.<n>Exchange this for a Bat."
+    },
+    "Vampire - Bat": {
+        "description": "<left><u>Vampire</u>:</left><center>Each other player receives the next Hex.</center><center>Gain a card costing up to 5 Coin other than a Vampire.</center><center>Exchange this for a Bat.</center><left><u>Bat</u>:</left><center>Trash up to 2 cards from your hand. If you trashed at least one, exchange this for a Vampire.</center><left><i>(This is not in the Supply.)</i></left>",
+        "extra": "For Vampire: Follow the instructions in order. If the Bat pile is empty, you will be unable to exchange Vampire for a Bat, but will do the rest. The Bat is put into your discard pile.\nFor Bat: The Vampire is put into your discard pile. If there are no Vampires in their pile, you cannot exchange Bat for one, but can still trash cards.",
+        "name": "Vampire / Bat"
+    },
+    "Vassal": {
+        "description": "+2 Coin<n>Discard the top card of your deck. If it's an Action card, you may play it",
+        "extra": "If the card is an Action card, you can play it, but do not have to.<n>If you do play it, you move it into your play area and follow its instructions; this does not use up one of your Action plays for the turn.",
+        "name": "Vassal",
+        "raw_wikitext": "{{Costplus|2}}<p>Discard the top card of your deck. If it's an Action card, you may play it.</p>",
+        "wikitext": "+2 Coins<n>Discard the top card of your deck. If it's an Action card, you may play it."
+    },
+    "Vault": {
+        "description": "+2 Cards<n>Discard any number of cards. +1 Coin per card discarded.<n>Each other player may discard 2 cards. If he does, he draws a card.",
+        "extra": "\"Any number\" includes zero. You draw cards first; you can discard the cards you just drew. Each other player chooses whether or not to discard 2 cards, then discards 2 cards if he chose to, then draws a card if he did discard 2 cards. If one of the other players has just one card, he can choose to discard it, but will not draw a card. Another player who discards but then has no cards left to draw shuffles in the discards before drawing.",
+        "name": "Vault",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Discard any number of cards for {{Costplus|1}} each.</p>Each other player may discard 2 cards, to draw a card.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Discard any number of cards for +1 Coin each.<n>Each other player may discard 2 cards, to draw a card."
+    },
+    "Venture": {
+        "description": "1 <*COIN*><n>Reveal cards from your deck until you reveal a Treasure. Discard the other cards. Play that Treasure.",
+        "extra": "This is a Treasure card worth 1 coin, like Copper. When you play it, you reveal cards from your deck until revealing a Treasure card. If you run out of cards before revealing a Treasure, shuffle your discard pile (but not the revealed cards) to get more; if you still do not find a Treasure, just discard all of the revealed cards. If you do find a Treasure, discard the other cards and play the Treasure. If that Treasure does something when played, do that something. For example if Venture finds you another Venture, you reveal cards again. Remember that you choose what order to play Treasure cards; for example if you have both Venture and Loan in hand, you can play either one first.",
+        "name": "Venture",
+        "raw_wikitext": "{{Cost|1|l}}<p>Reveal cards from your deck until you reveal a Treasure. Discard the other cards. Play that Treasure.</p>",
+        "wikitext": "1 <*COIN*><n>Reveal cards from your deck until you reveal a Treasure. Discard the other cards. Play that Treasure."
+    },
+    "Villa": {
+        "description": "+2 Actions<br>+1 Buy<br>+1 Coin<line>When you gain this, put it into your hand, +1 Action, and if it's your Buy phase return to your Action phase.",
+        "extra": "If you gain this during your Action phase, such as with Engineer, you will put the Villa into your hand and get +1 Action (letting you, for example, play the Villa). If you gain this during your Buy phase (such as by buying it), you will put the Villa into your hand, get +1 Action, and return to your Action phase. This will let you play more Action cards (such as the Villa); when you are done with that you will return to your Buy phase, from the beginning - you can play more Treasures (and Arena will trigger again). If you buy Villa, that uses up your default Buy for the turn, however playing Villa will give you +1 Buy and so let you buy another card in your second Buy phase. If you gain this during another player's turn, you will put the Villa into your hand and get +1 Action, but will have no way to use that Action, since it is not your turn. It is possible to return to your Action phase multiple times in a turn via buying multiple Villas. Returning to your Action phase does not cause \"start of turn\" abilities to repeat; they only happen at the start of your turn.",
+        "name": "Villa",
+        "raw_wikitext": "'''+2&nbsp;Actions'''<br>'''+1&nbsp;Buy'''<br>{{Costplus|1}}{{Divline}}When you gain this, put it into your hand, '''+1&nbsp;Action''', and if it's your Buy phase return to your Action phase.",
+        "wikitext": "<b>+2&nbsp;Actions</b><br><b>+1&nbsp;Buy</b><br>+1 Coin<line>When you gain this, put it into your hand, <b>+1&nbsp;Action</b>, and if it's your Buy phase return to your Action phase."
+    },
+    "Village": {
+        "description": "+1 Card<br>+2 Actions",
+        "extra": "If you're playing multiple Villages, keep a careful count of your Actions. Say how many you have left out loud; this trick works every time.",
+        "name": "Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b>"
+    },
+    "Village Green": {
+        "description": "Either now or at the start of your next turn, +1 Card and +2 Actions.<line>When you discard this other than during Clean-up, you may reveal it to play it.",
+        "extra": "When playing Village Green, choose whether to take +1 Card and +2 Actions immediately, or at the start of your next turn.<n>If you choose \"immediately,\" Village Green will be discarded in the same turn's Clean-up; if you choose \"next turn,\" Village Green will be discarded that turn.<n>If you play a Village Green multiple times, such as with Mastermind, you choose each time whether to take +1 Card and +2 Actions immediately or next turn, and the Village Green only stays in play until next turn if at least one of the plays was for next turn (in which case the Mastermind also stays in play).<n>Village Green also lets you play it when you discard it, other than in Clean-up.<n>You can only discard Village Green if something causes you to or lets you, and discarding it only lets you play it once (each time you discard it). This works whether it is your turn or another player's, and whether you discard it from your hand, or deck (such as with Cardinal), or from being set aside, or from Exile. This ability does not function if Village Green is put into your discard pile without being discarded, such as when bought, or due to Scavenger (from Dark Ages). The key thing to look for is a card telling you to \"discard\" cards.<n>If you play Village Green when it is not your turn, and choose to take the +1 Card and +2 Actions immediately, the +2 Actions will not be useful.<n>If you play Vassal and discard Village Green, you can react with Village Green to play it, and then Vassal lets you play it too. Vassal is discarded during from play that turn, regardless of whether Village Green stays out.",
+        "name": "Village Green",
+        "raw_wikitext": "Either now or at the start of your next turn, '''+1&nbsp;Card''' and '''+2&nbsp;Actions'''.{{Divline}}When you discard this other than during Clean-up, you may reveal it to play it.",
+        "wikitext": "Either now or at the start of your next turn, <b>+1&nbsp;Card</b> and <b>+2&nbsp;Actions</b>.<line>When you discard this other than during Clean-up, you may reveal it to play it."
+    },
+    "Villain": {
+        "description": "+2 Coffers<br><n>Each other player with 5 or more cards in hand discards one costing 2 Coin or more (or reveals they can't).",
+        "extra": "For example a player could discard an Estate, which costs 2 Coin.",
+        "name": "Villain",
+        "raw_wikitext": "'''+2&nbsp;Coffers'''<p>Each other player with 5&nbsp;or more cards in hand discards one costing {{Cost|2}} or more (or reveals they can't).</p>",
+        "wikitext": "<b>+2&nbsp;Coffers</b><n>Each other player with 5&nbsp;or more cards in hand discards one costing 2 Coins or more (or reveals they can't)."
+    },
+    "Vineyard": {
+        "description": "Worth 1 <VP> for every 3 Action cards in your deck (rounded down).",
+        "extra": "This Kingdom card is a Victory card, not an Action card. It does nothing until the end of the game, when it is worth 1 victory point per 3 Action cards in your Deck (counting all of your cards - your Discard pile and hand are part of your Deck at that point). Round down; if you have 11 Action cards, Vineyard is worth 3 victory points. During set-up, put all 12 Vineyards in the Supply for a game with 3 or more players, but only 8 in the Supply for a 2-player game. Cards with multiple types, one of which is Action, are Actions and so are counted by Vineyard.",
+        "name": "Vineyard",
+        "raw_wikitext": "Worth {{VP|'''1'''}} per 3&nbsp;Action cards you have (rounded down).",
+        "wikitext": "Worth 1 <VP> per 3&nbsp;Action cards you have (rounded down)."
+    },
+    "Voyage": {
+        "description": "+1 Action<n>If the previous turn wasn't yours, take an extra turn after this one, during which you can only play 3 cards from your hand.",
+        "extra": "This doesn't stop you from playing cards that aren't in your hand; for example, if the third card you play is Golem, it can still play its two cards, which are set aside.<n>On a Voyage turn, if you Throne Room a card, both Throne Room and that card count as plays from your hand, but Throne Room replaying the card does not.<n>This limits plays of all types of cards, including Treasures like Copper.",
+        "name": "Voyage",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Take an extra turn after this one (but not a 3rd turn in a row), during which you can only play 3&nbsp;cards from your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Take an extra turn after this one (but not a 3rd turn in a row), during which you can only play 3&nbsp;cards from your hand."
+    },
+    "Wall": {
+        "description": "When scoring, -1 <VP> per card you have after the first 15.",
+        "extra": "For example, if you had 27 cards in your deck, you would score -12 <VP> for Wall.<n>Scores can go negative.",
+        "name": "Wall",
+        "raw_wikitext": "When scoring, {{VP|'''-1'''}} per card you have after the first 15.",
+        "wikitext": "When scoring, -1 <VP> per card you have after the first 15."
+    },
+    "Walled Village": {
+        "description": "+1 Card<br>+2 Actions<line>At the start of Clean-up, if you have this and no more than one other Action card in play, you may put this on top of your deck.",
+        "extra": "When you play this, you draw a card and can play two more Actions this turn. At the start of your Clean-up phase, before discarding anything and before drawing for next turn, if you have a Walled Village in play and no more than two Action cards in play (counting the Walled Village), you may put the Walled Village on top of your deck. If the only cards you have in play are two Walled Villages, you may put either or both of them on top of your deck. Walled Village has to be in play to be put on top of your deck. Walled Village only checks how many Action cards are in play when its ability resolves; Action cards you played earlier this turn but which are no longer in play (such as Feast from Dominion) are not counted, while Action cards still in play from previous turns (duration cards from Seaside) are counted, as are Action cards that are in play now but may leave play after resolving Walled Village (such as Treasury from Seaside).",
+        "name": "Walled Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}At the start of Clean-up, if you have this and no more than one other Action card in play, you may put this onto your deck.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>At the start of Clean-up, if you have this and no more than one other Action card in play, you may put this onto your deck."
+    },
+    "Wandering Minstrel": {
+        "description": "+1 Card<br>+2 Actions<n>Reveal the top 3 cards of your deck.<n>Put the Actions back on top in any order and discard the rest.",
+        "extra": "First draw a card, then reveal the top 3 cards of your deck, shuffling your discard pile if there are not enough cards in your deck. If there still are not enough after shuffling, just reveal what you can. Put the revealed Action cards on top of your deck in any order, and discard the other cards. A card with multiple types, one of which is Action, is an Action card. If you didn't reveal any Action cards, no cards will be put on top.",
+        "name": "Wandering Minstrel",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''<p>Reveal the top 3&nbsp;cards of your deck. Put the Action cards back in any order and discard the rest.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><n>Reveal the top 3&nbsp;cards of your deck. Put the Action cards back in any order and discard the rest."
+    },
+    "War": {
+        "description": "Reveal cards from your deck until revealing one costing 3 Coin or 4 Coin. Trash it and discard the rest.",
+        "extra": "If you do not find a card costing 3 Coins or 4 Coins, your entire deck will end up in your discard pile, with nothing trashed.",
+        "name": "War",
+        "raw_wikitext": "Reveal cards from your deck until revealing one costing {{Cost|3}} or {{Cost|4}}. Trash it and discard the rest.",
+        "wikitext": "Reveal cards from your deck until revealing one costing 3 Coins or 4 Coins. Trash it and discard the rest."
+    },
+    "War Chest": {
+        "description": "The player to your left names a card. Gain a card costing up to 5 Coin that hasn't been named for War Chest this turn.",
+        "extra": "The first War Chest you play in a turn can't gain whatever card they name; the second can't gain the card they name, or the card they previously named, and so on. The gained card comes from the Supply and is put into your discard pile. You can still gain the named cards other ways, just not via War Chests. They do not have to name a card in the Supply; however War Chest gains a card from the Supply, and puts it into your discard pile.",
+        "name": "War Chest",
+        "raw_wikitext": "The player to your left names a card. Gain a card costing up to {{Cost|5}} that hasn't been named for War Chests this turn.",
+        "wikitext": "The player to your left names a card. Gain a card costing up to 5 Coins that hasn't been named for War Chests this turn."
+    },
+    "Warehouse": {
+        "description": "+3 Card<br>+1 Action<br>Discard 3 cards.",
+        "extra": "If you do not have 3 cards to draw in your deck, draw as many as you can, shuffle your discard pile, and draw the remaining cards. If you are still not able to draw 3 cards, draw as many as you can. You will still need to discard 3 cards if you can, even if you couldn't draw 3. You may discard any combination of cards that you just drew with the Warehouse or cards that were previously in your hand.",
+        "name": "Warehouse",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Discard 3&nbsp;cards.</p>",
+        "wikitext": "<b>+3&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Discard 3&nbsp;cards."
+    },
+    "Warlord": {
+        "description": "+1 Action<n>At the start of your next turn, +2 Cards. Until then, other players can't play an Action from their hand that they have 2 or more copies of in play.",
+        "extra": "This doesn't stop players from playing cards that aren't in their hands; for example, Golem can still play its two cards, which are set aside, no matter how many copies of them are in play.<n>With Warlord affecting you, Throne Room can't play a card from your hand that you have two copies of in play; but Throne can play a card you have one copy of in play and then can replay that card, even though now you have two copies of it in play.<n>This only affects Action cards; it doesn't affect Copper, for example.",
+        "name": "Warlord",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>At the start of your next turn, '''+2&nbsp;Cards'''. Until then, other players can't play an Action from their hand that they have 2&nbsp;or more copies of in play.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>At the start of your next turn, <b>+2&nbsp;Cards</b>. Until then, other players can't play an Action from their hand that they have 2&nbsp;or more copies of in play."
+    },
+    "Warrior": {
+        "description": "+2 Cards<n>For each Traveller you have in play (including this), each other player discards the top card of his deck and trashes it if it costs 3 Coins or 4 Coins.<line>When you discard this from play, you may exchange it for a Hero.<n><i>(This is not in the Supply.)</i>",
+        "extra": "Each player, in turn order, discards the appropriate number of cards from the top of his deck, trashing the ones costing 3 or 4 Coins. If Warrior is your only Traveller in play, each other player will only discard and potentially trash one card. If you, for example, have a Peasant, a Fugitive, and the Warrior in play, each other player would discard and potentially trash three cards. Cards are only trashed if they cost exactly 3 Coins or exactly 4 Coins. Cards with Potion in the cost (from Alchemy) do not cost exactly 3 Coins or 4 Coins. Cards with an asterisk in the cost (such as Warrior) or + in the cost (such as Masterpiece from Guilds) may be trashed by Warrior (if costing 3 Coin or 4 Coin). Champion and Teacher are not Travellers.",
+        "name": "Warrior",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>For each Traveller you have in play (including this), each other player discards the top card of their deck and trashes it if it costs {{Cost|3}} or {{Cost|4}}.</p>{{Divline}}<p>When you discard this from play, you may exchange it for a Hero.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>For each Traveller you have in play (including this), each other player discards the top card of their deck and trashes it if it costs 3 Coins or 4 Coins.<n><line><n>When you discard this from play, you may exchange it for a Hero.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Watchtower": {
+        "description": "Draw until you have 6 cards in hand.<line>When you gain a card, you may reveal this from your hand. If you do, either trash that card, or put it on top of your deck.",
+        "extra": "When you play this, you draw cards one at a time until you have 6 cards in hand. If you have 6 or more cards in hand already, you do not draw any cards. When you gain a card, even on someone else's turn, you may reveal Watchtower from your hand, to either trash the gained card or put it on top of your deck. You may reveal Watchtower each time you gain a card; for example if another player plays Mountebank, you may use Watchtower to trash both the Curse and Copper, or to trash the Curse and put the Copper on top of your deck, or just to trash the Curse, and so on. You still did gain whatever card you gained; you just immediately trash it. So if Mountebank gives you a Curse and you trash it, the Curse pile will go down by one as the Curse gets moved to the trash pile. You may reveal Watchtower on your own turn as well, for example when buying a card, or gaining a card via something like Expand. If you use Watchtower to put a card on your deck but have no cards left in your deck, you do not shuffle; the gained card becomes the only card in your deck. Revealing Watchtower does not take it out of your hand; you could reveal Watchtower on multiple opponents' turns and still have it on your turn to draw up to 6 with. When cards are gained during a Possession turn (from Alchemy), the player who played Possession is the one who can use Watchtower, not the player who is being possessed. If a gained card is going somewhere other than to your discard pile, such as a card gained with Mine (from Dominion), you can still use Watchtower to trash it or put it on your deck.",
+        "name": "Watchtower",
+        "raw_wikitext": "Draw until you have 6&nbsp;cards in hand.{{Divline}}When you gain a card, you may reveal this from your hand, to either trash that card or put it onto your deck.",
+        "wikitext": "Draw until you have 6&nbsp;cards in hand.<line>When you gain a card, you may reveal this from your hand, to either trash that card or put it onto your deck."
+    },
+    "Way of the Butterfly": {
+        "description": "You may return this to its pile to gain a card costing exactly 1 coin more than it.",
+        "extra": "You only gain a card if you manage to return the card to its pile. A non-Supply card (like Horse) can return to its pile; a card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile. The card you gain comes from the Supply, and can be any type; if there is no card in the Supply costing exactly more than the returned card, you do not gain one.",
+        "name": "Way of the Butterfly",
+        "raw_wikitext": "You may return this to its pile to gain a card costing exactly {{Cost|1}} more than it.",
+        "wikitext": "You may return this to its pile to gain a card costing exactly 1 Coin more than it."
+    },
+    "Way of the Camel": {
+        "description": "Exile a Gold from the Supply.",
+        "extra": "",
+        "name": "Way of the Camel",
+        "raw_wikitext": "Exile a Gold from the Supply.",
+        "wikitext": "Exile a Gold from the Supply."
+    },
+    "Way of the Chameleon": {
+        "description": "Follow this card's instructions; each time that would give you +Cards this turn, you get +_ Coin instead, and vice-versa.",
+        "extra": "For example, if you play Sheepdog and use Way of the Chameleon, you will get +2 Coin instead of +2 Cards.<n>If you play a Duration card using Way of the Chameleon, only the +_ Coin and +Cards you get that turn are affected; for example, if you play Merchant Ship (from Seaside) and use Way of the Chameleon, you will get +2 Cards this turn, but the normal +2 Coin next turn.<n>This turns \"+Cards\" into \"+Coin\" and vice-versa, but does not change other ways to draw cards, for example, \"draw until you have 6 cards in hand.\"<n>If the card that uses Way of the Chameleon plays another card, that card just does what it normally does (unless you use Way of the Chameleon on it as well).",
+        "name": "Way of the Chameleon",
+        "raw_wikitext": "Follow this card's instructions; each time that would give you '''+Cards''' this turn, you get {{Costplus}} instead, and vice-versa.",
+        "wikitext": "Follow this card's instructions; each time that would give you <b>+Cards</b> this turn, you get {{Costplus}} instead, and vice-versa."
+    },
+    "Way of the Frog": {
+        "description": "+1 Action<n>When you discard this from play this turn, put it onto your deck.",
+        "extra": "",
+        "name": "Way of the Frog",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>When you discard this from play this turn, put it onto your deck.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>When you discard this from play this turn, put it onto your deck."
+    },
+    "Way of the Goat": {
+        "description": "Trash a card from your hand.",
+        "extra": "",
+        "name": "Way of the Goat",
+        "raw_wikitext": "Trash a card from your hand.",
+        "wikitext": "Trash a card from your hand."
+    },
+    "Way of the Horse": {
+        "description": "+2 Cards<br>+1 Action<n>Return this to its pile.",
+        "extra": "The card returns to its pile, even if that is a non-Supply pile. A card with no pile, such as Necropolis (from Dark Ages), fails to return to its pile.<n>If you use a card like Necromancer to play another card without moving it into play, and use Way of the Horse, that card does not move to its pile.<n>Failing to return a card to a pile does not stop you from getting +2 Cards and +1 Action.",
+        "name": "Way of the Horse",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<br>'''+1&nbsp;Action'''<p>Return this to its pile.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><br><b>+1&nbsp;Action</b><n>Return this to its pile."
+    },
+    "Way of the Mole": {
+        "description": "+1 Action<br>Discard your hand. +3 Cards.",
+        "extra": "You draw 3 cards even if you did not have any cards left to discard.",
+        "name": "Way of the Mole",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Discard your hand. '''+3&nbsp;Cards'''.</p>",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Discard your hand. <b>+3&nbsp;Cards</b>."
+    },
+    "Way of the Monkey": {
+        "description": "+1 Buy<br>+1 Coin",
+        "extra": "",
+        "name": "Way of the Monkey",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|1}}",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+1 Coin"
+    },
+    "Way of the Mouse": {
+        "description": "Play the set-aside card, leaving it there.<line>Setup: Set aside an unused Action costing 2 Coin or 3 Coin.",
+        "extra": "Set aside any unused Action kingdom card costing 2 Coin or 3 Coin at the start of the game. Do any setup that that card requires.<n>When using Way of the Mouse, you play the set-aside card, leaving it set-aside. For example, if you set aside Sleigh, then any Action card could be used to gain 2 Horses.<n>The set-aside card cannot move itself when played, since it is not in play; for example, if the card is Embargo (from Seaside), it cannot be trashed.<n>Text below a dividing line (other than setup) will not do anything.",
+        "name": "Way of the Mouse",
+        "raw_wikitext": "Play the set-aside card, leaving it there.{{Divline}}'''Setup:''' Set aside an unused non-Duration Action costing {{Cost|2}} or {{Cost|3}}.",
+        "wikitext": "Play the set-aside card, leaving it there.<line><b>Setup:</b> Set aside an unused non-Duration Action costing 2 Coins or 3 Coins."
+    },
+    "Way of the Mule": {
+        "description": "+1 Action<br>+1 Coin",
+        "extra": "",
+        "name": "Way of the Mule",
+        "raw_wikitext": "'''+1&nbsp;Action'''<br>{{Costplus|1}}",
+        "wikitext": "<b>+1&nbsp;Action</b><br>+1 Coin"
+    },
+    "Way of the Otter": {
+        "description": "+2 Cards",
+        "extra": "",
+        "name": "Way of the Otter",
+        "raw_wikitext": "'''+2&nbsp;Cards'''",
+        "wikitext": "<b>+2&nbsp;Cards</b>"
+    },
+    "Way of the Owl": {
+        "description": "Draw until you have 6 cards in hand.",
+        "extra": "If you already have 6 or more cards in hand, you do not draw any cards.",
+        "name": "Way of the Owl",
+        "raw_wikitext": "Draw until you have 6&nbsp;cards in hand.",
+        "wikitext": "Draw until you have 6&nbsp;cards in hand."
+    },
+    "Way of the Ox": {
+        "description": "+2 Actions",
+        "extra": "",
+        "name": "Way of the Ox",
+        "raw_wikitext": "'''+2&nbsp;Actions'''",
+        "wikitext": "<b>+2&nbsp;Actions</b>"
+    },
+    "Way of the Pig": {
+        "description": "+1 Card<br>+1 Action",
+        "extra": "",
+        "name": "Way of the Pig",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b>"
+    },
+    "Way of the Rat": {
+        "description": "You may discard a Treasure to gain a copy of this.",
+        "extra": "This can only gain cards from the Supply.",
+        "name": "Way of the Rat",
+        "raw_wikitext": "You may discard a Treasure to gain a copy of this.",
+        "wikitext": "You may discard a Treasure to gain a copy of this."
+    },
+    "Way of the Seal": {
+        "description": "+1 Coin<br>This turn, when you gain a card, you may put it onto your deck.",
+        "extra": "This applies to all gained cards, whether bought or otherwise gained.<n>The card first is gained to wherever it normally would be, then you can move it onto your deck. If it moves somewhere else in-between (for example, trashing it using Watchtower from Prosperity), you cannot move it.",
+        "name": "Way of the Seal",
+        "raw_wikitext": "{{Costplus|1}}<p>This turn, when you gain a card, you may put it onto your deck.</p>",
+        "wikitext": "+1 Coin<n>This turn, when you gain a card, you may put it onto your deck."
+    },
+    "Way of the Sheep": {
+        "description": "+2 Coin",
+        "extra": "",
+        "name": "Way of the Sheep",
+        "raw_wikitext": "{{Costplus|2}}",
+        "wikitext": "+2 Coins"
+    },
+    "Way of the Squirrel": {
+        "description": "+2 Cards at the end of this turn.",
+        "extra": "Normally you get the two cards after drawing your hand in Clean-up. If you use this when it is not your turn (such as via Black Cat), you still draw two cards at the end of the turn.",
+        "name": "Way of the Squirrel",
+        "raw_wikitext": "'''+2&nbsp;Cards''' at the end of this turn.",
+        "wikitext": "<b>+2&nbsp;Cards</b> at the end of this turn."
+    },
+    "Way of the Turtle": {
+        "description": "Set this aside. If you did, play it at the start of your next turn.",
+        "extra": "When you play the card at the start of your next turn, you can again use Way of the Turtle, delaying it another turn. You can keep doing this.<n>Playing the card next turn does not use up an Action then. If you use a card like Throne Room to play a card twice, and then use Way of the Turtle, this does not cause the Throne Room to be set aside, or to stay in play as with Duration cards.<n>If you use a card like Throne Room to play a card twice, and choose Way of the Turtle both times, you still only get one play at the start of your next turn, as you were not able to set it aside the second time.",
+        "name": "Way of the Turtle",
+        "raw_wikitext": "Set this aside. If you did, play it at the start of your next turn.",
+        "wikitext": "Set this aside. If you did, play it at the start of your next turn."
+    },
+    "Way of the Worm": {
+        "description": "Exile an Estate from the Supply.",
+        "extra": "",
+        "name": "Way of the Worm",
+        "raw_wikitext": "Exile an Estate from the Supply.",
+        "wikitext": "Exile an Estate from the Supply."
+    },
+    "Wayfarer": {
+        "description": "+3 Cards<br>You may gain a Silver.<line>This has the same cost as the last other card gained this turn, if any.",
+        "extra": "Cards that lower costs, like Bridge from Intrigue, only apply to the other card, not to Wayfarer too (though they apply to Wayfarer if no other cards have been gained yet). For example, if you play Bridge, Wayfarer costs 5 Coin; if you then buy a Silver, at that point Wayfarer costs 2 Coin, the same as Silver.<n>Wayfarer can have a cost with Potion (from Alchemy) or Debt (from Empires) in it.<n>Buying Animal Fair via trashing an Action card changes the cost of Wayfarer to 7 Coin, Animal Fair's cost, not to trashing an Action card.<n>If the cost of the last card gained changes after it was gained, the cost of Wayfarer changes too. For example, if you gain a Peddler when it costs 8 Coin, and then play 2 Action cards, Peddler and therefore Wayfarer both now cost 4 Coin in the Buy phase.<n>The cost of Wayfarer can change while resolving other cards. For example, if you play Stonemason and trash a Wayfarer which costs 6 Coin, you then gain a cheaper card such as Duchy which costs 5 Coin; then you gain a second card costing less than Wayfarer which now costs 5 Coin.",
+        "name": "Wayfarer",
+        "raw_wikitext": "'''+3&nbsp;Cards'''<p>You may gain a Silver.</p>{{Divline}}This has the same cost as the last other card gained this turn, if any.",
+        "wikitext": "<b>+3&nbsp;Cards</b><n>You may gain a Silver.<n><line>This has the same cost as the last other card gained this turn, if any."
+    },
+    "Wealthy Village": {
+        "description": "+1 Card<br>+2 Actions<line>When you gain this, if you have at least 3 differently named Treasures in play, gain a Loot.",
+        "extra": "The 3 differently named Treasures can include Duration Treasures you played on a previous turn, and Loots themselves.",
+        "name": "Wealthy Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2&nbsp;Actions'''{{Divline}}When you gain this, if you have at least 3&nbsp;differently named Treasures in play, gain a Loot.",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2&nbsp;Actions</b><line>When you gain this, if you have at least 3&nbsp;differently named Treasures in play, gain a Loot."
+    },
+    "Weaver": {
+        "description": "Gain two Silvers or a card costing up to 4 Coin.<line>When you discard this other than in Clean-up, you may play it.",
+        "extra": "You either gain 2 Silvers, or a card costing up to 4 Coin (which might be a Silver). You can play this when you discard it. As usual playing it means putting it into play and following its instructions. If you play it on another player's turn, it's discarded in that turn's Clean-up. This doesn't say \"choose one,\" so if you play this with Elder, you can't choose to gain 2 Silvers and a 4 Coin. If a Vassal discards Weaver, you can react with Weaver to play it. Doing this causes Vassal to lose track, so you will only play Weaver once. If you need to discard down to a certain number of cards (due to Militia), you discard all the cards at once. So if you discard multiple Weavers, you resolve their reactions one at a time. When discarding multiple Weavers, if playing one of them triggers a reshuffle (e.g. it gains a Cavalry, then you can't play any of the other Weavers.",
+        "name": "Weaver",
+        "raw_wikitext": "Gain two Silvers or a card costing up to {{Cost|4}}.{{Divline}}When you discard this other than in Clean-up, you may play it.",
+        "wikitext": "Gain two Silvers or a card costing up to 4 Coins.<line>When you discard this other than in Clean-up, you may play it."
+    },
+    "Wedding": {
+        "description": "+1 <VP><br>Gain a Gold.",
+        "extra": "You get the <VP> even if there are no Golds left.",
+        "name": "Wedding",
+        "raw_wikitext": "{{VP|'''+1'''}}<p>Gain a Gold.</p>",
+        "wikitext": "{{VP|<b>+1</b>}}<n>Gain a Gold."
+    },
+    "Werewolf": {
+        "description": "If it’s your Night phase, each other player receives the next Hex.<br>Otherwise, +3 Cards.",
+        "extra": "Werewolf can be played in either your Action phase or Night phase. If played in your Action phase, you draw three cards; if played at Night, each other player receives the next Hex.",
+        "name": "Werewolf",
+        "raw_wikitext": "If it's your Night phase, each other player receives the next Hex. Otherwise, '''+3&nbsp;Cards'''.",
+        "wikitext": "If it's your Night phase, each other player receives the next Hex. Otherwise, <b>+3&nbsp;Cards</b>."
+    },
+    "Wharf": {
+        "description": "Now and at the start of your next turn: +2 Cards, +1 Buy.",
+        "extra": "You draw 2 cards and get an extra Buy this turn, and then draw 2 more cards and get another extra Buy at the start of your next turn. You don't draw your extra 2 cards for the next turn until that turn actually starts. Leave this in front of you until the Clean-up phase of your next turn.",
+        "name": "Wharf",
+        "raw_wikitext": "Now and at the start of your next turn: '''+2&nbsp;Cards''' and '''+1&nbsp;Buy'''.",
+        "wikitext": "Now and at the start of your next turn: <b>+2&nbsp;Cards</b> and <b>+1&nbsp;Buy</b>."
+    },
+    "Wheelwright": {
+        "description": "+1 Card<br>+1 Action<br><br>You may discard a card to gain an Action card costing as much as it or less.",
+        "extra": "You may discard any type of card, but can only gain an Action card. If you discard an Action card, you can gain a copy of it. If you do discard, you have to gain an Action card if there is one to gain.",
+        "name": "Wheelwright",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>You may discard a card to gain an Action card costing as much as it or less.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>You may discard a card to gain an Action card costing as much as it or less."
+    },
+    "Wild Hunt": {
+        "description": "Choose one: +3 Cards and add 1 <VP> to the Wild Hunt Supply pile; or gain an Estate, and if you do, take the <VP> from the pile.",
+        "extra": "If the Estate pile is empty, you can choose that option but will not get the <VP> tokens. Wild Hunt still functions normally if the Wild Hunt pile is empty.",
+        "name": "Wild Hunt",
+        "raw_wikitext": "Choose one: '''+3&nbsp;Cards''' and add {{VP|'''1'''}} to the Wild Hunt pile; or gain an Estate, and if you do, take the {{VP}} from the pile.",
+        "wikitext": "Choose one: <b>+3&nbsp;Cards</b> and add 1 <VP> to the Wild Hunt pile; or gain an Estate, and if you do, take the {{VP}} from the pile."
+    },
+    "Will-o'-Wisp": {
+        "description": "+1 Card<br>+1 Action<br>Reveal the top card of your deck. If it costs 2 Coin or less, put it into your hand.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": " If the revealed card does not cost 2 Coins or less, leave it on your deck. Cards with Potion or Debt  in the cost (from Alchemy and Empires) do not cost 2 Coins or less.",
+        "name": "Will-o'-Wisp",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Reveal the top card of your deck. If it costs {{Cost|2}} or less, put it into your hand.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Reveal the top card of your deck. If it costs 2 Coins or less, put it into your hand.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Windfall": {
+        "description": "If your deck and discard pile are empty, gain 3 Golds.",
+        "extra": "If there are fewer than 3 Golds in the pile, just gain the remaining Golds.",
+        "name": "Windfall",
+        "raw_wikitext": "If your deck and discard pile are empty, gain 3&nbsp;Golds.",
+        "wikitext": "If your deck and discard pile are empty, gain 3&nbsp;Golds."
+    },
+    "Wine Merchant": {
+        "description": "+1 Buy<br>+4 Coins<n>Put this on your Tavern mat.<line>At the end of your Buy phase, if you have at least 2 Coins unspent, you may discard this from your Tavern mat.",
+        "extra": "When you play this, you get +1 Buy and +4 Coins, and put it on your Tavern mat. It stays on your mat until the end of one of your Buy phases in which you have 2 Coins or more that you didn't spend. At that point you can discard Wine Merchant from your mat. If you have multiple Wine Merchants on your mat, you don't need 2 Coins per Wine Merchant, just 2 Coins total.",
+        "name": "Wine Merchant",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|4}}<p>Put this on your Tavern mat.</p>{{Divline}}At the end of your Buy phase, if you have at least {{Cost|2}} unspent, you may discard this from your Tavern mat.",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+4 Coins<n>Put this on your Tavern mat.<n><line>At the end of your Buy phase, if you have at least 2 Coins unspent, you may discard this from your Tavern mat."
+    },
+    "Wish": {
+        "description": "+1 Action<br>Return this to its pile. If you did, gain a card to your hand costing up to 6 coin.<br><br><i>(This is not in the Supply.)</i>",
+        "extra": " You only gain a card if you actually returned Wish to its pile. A card you gain that would normally go somewhere else, like Nomad Camp (from Hinterlands), goes to your hand.",
+        "name": "Wish",
+        "raw_wikitext": "'''+1&nbsp;Action'''<p>Return this to its pile. If you did, gain a card to your hand costing up to {{Cost|6}}.</p>''(This is not in the Supply.)''",
+        "wikitext": "<b>+1&nbsp;Action</b><n>Return this to its pile. If you did, gain a card to your hand costing up to 6 Coins.<n><i>(This is not in the Supply.)</i>"
+    },
+    "Wishing Well": {
+        "description": "+1 Card<br>+1 Action<n>Name a card, then reveal the top card of your deck. If it is the named card, put it in your hand.",
+        "extra": "First you draw your card. Then name a card (\"Copper,\" for example - not \"Treasure\") and reveal the top card of your deck; if you named the same card you revealed, put the revealed card in your hand. If you do not name the right card, you put the revealed card back on top.",
+        "name": "Wishing Well",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Name a card, then reveal the top card of your deck. If you named it, put it into your hand.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Name a card, then reveal the top card of your deck. If you named it, put it into your hand."
+    },
+    "Witch": {
+        "description": "+2 Cards<n>Each other player gains a Curse card.",
+        "extra": "If there aren't enough Curses left to go around when you play the Witch, you deal them out in turn order - starting with the player after you. If you play Witch with no Curses remaining, you will still draw 2 cards. A player gaining a Curse puts it face-up into his Discard pile.",
+        "name": "Witch",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Each other player gains a Curse.</p>",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Each other player gains a Curse."
+    },
+    "Witch's Hut": {
+        "description": "+4 Cards<br><br>Discard 2 cards, revealed. If they're both Actions, each other player gains a Curse.",
+        "extra": "You reveal the discarded cards even if they aren't both Actions. If they're both Actions - even if they also have other types - each other player gains a Curse.",
+        "name": "Witch's Hut",
+        "raw_wikitext": "'''+4&nbsp;Cards'''<p>Discard 2&nbsp;cards, revealed. If they're both Actions, each other player gains a Curse.</p>",
+        "wikitext": "<b>+4&nbsp;Cards</b><n>Discard 2&nbsp;cards, revealed. If they're both Actions, each other player gains a Curse."
+    },
+    "Wizards": {
+        "description": "This pile starts the game with 4 copies each of Student, Conjurer, Sorcerer, and Lich, in that order. Only the top card can be gained or bought.",
+        "extra": "Student: Rotating the Wizards is optional, but trashing a card is mandatory. If you trash a Treasure, you get +1 Favor and put Student onto your deck: that's mandatory. This means you might draw that same Student again that turn and play it again. If you trash a non-Treasure, Student stays in play and is discarded in Clean-up like other cards.<n>Conjurer: This will keep returning to your hand each turn as long as you keep playing it.<n>Sorcerer: Each other player names a card, and reveals the top card of their deck. If it doesn't have that name, they gain a Curse. Whether or not it does, they return the card to the top of their deck. So if you play Sorcerer twice in a turn, they will probably know the card for the 2nd play.<n>Lich: Skipping a turn means that the next time you would take a turn, you don't; nothing happens for that turn: no \"start of turn\" abilities, no phases. Play continues with the player to your left as usual. You can skip an extra turn, like one from Voyage. Skipped turns still count for the tiebreaker however they would have if taken. If you play multiple Liches you will skip multiple turns. When you trash Lich, you put it from the trash into your discard pile, which does not trigger abilities that care about gaining cards; then you gain a card costing less than Lich from the trash, which does trigger such abilities. Gaining a cheaper card is mandatory if possible.",
+        "name": "Wizards"
+    },
+    "Wolf Den": {
+        "description": "When scoring, -3 <VP> per card you have exactly one copy of.",
+        "extra": "Having no copies of a card, or two or more copies of a card, confers no penalty.<n>Scores can go negative.",
+        "name": "Wolf Den",
+        "raw_wikitext": "When scoring, {{VP|'''-3'''}} per card you have exactly one copy of.",
+        "wikitext": "When scoring, -3 <VP> per card you have exactly one copy of."
+    },
+    "Woodcutter": {
+        "description": "+1 Buy<br>+2 Coins",
+        "extra": "During your Buy phase, you may add 2 Coins to the total value of the Treasure cards played, and you may buy an additional card from the Supply.",
+        "name": "Woodcutter",
+        "raw_wikitext": "'''+1&nbsp;Buy'''<br>{{Costplus|2}}",
+        "wikitext": "<b>+1&nbsp;Buy</b><br>+2 Coins"
+    },
+    "Woodworkers' Guild": {
+        "description": "At the start of your Buy phase, you may spend a Favor to trash an Action card from your hand. If you did, gain an Action card.",
+        "extra": "",
+        "name": "Woodworkers' Guild",
+        "raw_wikitext": "At the start of your Buy phase, you may spend a '''Favor''' to trash an Action card from your hand. If you did, gain an Action card.",
+        "wikitext": "At the start of your Buy phase, you may spend a <b>Favor</b> to trash an Action card from your hand. If you did, gain an Action card."
+    },
+    "Worker's Village": {
+        "description": "+1 Card<br>+2 Actions<br>+1 Buy",
+        "extra": "You draw a card, can play two more Actions this turn, and can buy one more card in your Buy phase this turn.",
+        "name": "Worker's Village",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+2 Actions'''<br>'''+1&nbsp;Buy'''",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+2 Actions</b><br><b>+1&nbsp;Buy</b>"
+    },
+    "Workshop": {
+        "description": "Gain a card costing up to 4 Coins.",
+        "extra": "The card you gain is put into your Discard pile. It has to be a card from the Supply. You cannot use coins from Treasures or previous Actions (like the Market) to increase the cost of the card you may gain. [You cannot gain cards with Potion in the cost with Workshop.]",
+        "name": "Workshop",
+        "raw_wikitext": "Gain a card costing up to {{Cost|4}}.",
+        "wikitext": "Gain a card costing up to 4 Coins."
+    },
+    "Yard Dog": {
+        "description": "+1 Card<n>+1 Action<br>Defends the section in which he dwells (hand, discard pile or deck) against any attack which aims at this section (only if he is or becomes visible or can be shown)",
+        "extra": "",
+        "name": "Yard Dog",
+        "notes": [
+            "Fan expansion: Animals"
+        ]
+    },
+    "Young Witch": {
+        "description": "+2 Cards<n>Discard 2 cards. Each other player may reveal a Bane card from his hand.<n>If he doesn't, he gains a Curse.<line>Setup: Add an extra Kingdom card pile costing 2 or 3 to the Supply. Cards from that pile are Bane cards.",
+        "extra": "This card causes there to be an extra pile in the Supply, called the Bane pile; see Preparation. The extra pile is just like other Kingdom card piles - it can be bought, it can be gained via cards like Horn of Plenty, it counts for the end game condition. When you play Young Witch, after you draw 2 cards and discard 2 cards, each other player may reveal a Bane card from his hand; if he does not, he gains a Curse. This attack hits other players in turn order, which matters when the Curse pile is low. Players may still respond to a Young Witch with Reaction cards like Horse Traders or Moat (from Dominion); those happen before Bane cards are revealed. If Secret Chamber (from Intrigue) is the Bane card, first you can reveal it for its Reaction ability, and then, if it's still in your hand, you can reveal it to avoid getting a Curse.",
+        "name": "Young Witch",
+        "raw_wikitext": "'''+2&nbsp;Cards'''<p>Discard 2&nbsp;cards. Each other player gains a Curse unless they reveal a Bane from their hand.</p>{{Divline}}'''Setup:''' Add an extra Kingdom card pile costing {{Cost|2}} or {{Cost|3}} to the Supply. Its cards are Banes.",
+        "wikitext": "<b>+2&nbsp;Cards</b><n>Discard 2&nbsp;cards. Each other player gains a Curse unless they reveal a Bane from their hand.<n><line><b>Setup:</b> Add an extra Kingdom card pile costing 2 Coins or 3 Coins to the Supply. Its cards are Banes."
+    },
+    "Zombie Apprentice": {
+        "description": "You may trash an Action card from your hand for +3 Cards and +1 Action.",
+        "extra": "If you trash an Action card from your hand, you draw three cards and get +1 Action.",
+        "name": "Zombie Apprentice",
+        "raw_wikitext": "You may trash an Action card from your hand for '''+3&nbsp;Cards''' and '''+1&nbsp;Action'''.",
+        "wikitext": "You may trash an Action card from your hand for <b>+3&nbsp;Cards</b> and <b>+1&nbsp;Action</b>."
+    },
+    "Zombie Mason": {
+        "description": "Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it.",
+        "extra": "Gaining a card is optional. You can gain a card costing more than the trashed card, or any amount less; for example you can gain a copy of the trashed card.",
+        "name": "Zombie Mason",
+        "raw_wikitext": "Trash the top card of your deck. You may gain a card costing up to {{Cost|1}} more than it.",
+        "wikitext": "Trash the top card of your deck. You may gain a card costing up to 1 Coin more than it."
+    },
+    "Zombie Spy": {
+        "description": "+1 Card<br>+1 Action<br>Look at the top card of your deck. Discard it or put it back.",
+        "extra": "You draw a card before looking at the top card. The Zombie Spy is like a regular Spy except it can only discard the top card of your own deck.",
+        "name": "Zombie Spy",
+        "raw_wikitext": "'''+1&nbsp;Card'''<br>'''+1&nbsp;Action'''<p>Look at the top card of your deck. Discard it or put it back.</p>",
+        "wikitext": "<b>+1&nbsp;Card</b><br><b>+1&nbsp;Action</b><n>Look at the top card of your deck. Discard it or put it back."
+    },
+    "adventures events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are special on-buy effects not attached to cards. Players can buy Events during their Buy phase to trigger whatever the effect of the Event is, as an alternative to (or in addition to) buying cards from the supply.<n>Events are not Kingdom cards; including one or more Events in a game does not count toward the 10 Kingdom card piles the supply includes. In fact, Events are not considered \"cards\" at all. Any text referring to a \"card\" (such as instructions to \"name a card\", or cost reducers changing the cost of cards) does not apply to Events. However, for reference, the Event effects and costs are printed on cards in a landscape orientation with silver frames.<n>Any number of Events may be used in a game, but the recommendation is to not use more than two total Events and Landmarks. When choosing a random Kingdom, the Events may be shuffled into the randomizer deck; any Events that are dealt once 10 Kingdom cards have also been dealt will be included in the game.",
+        "name": "Events: Adventures"
+    },
+    "allies": {
+        "description": "<justify>Allies are not Kingdom cards, but are added to the game whenever one or more Kingdom cards have the Liaison type. In any game using Liaisons, exactly one Ally is chosen, and it determines what effect Favor tokens have in that game. Since Allies are not considered cards, they cannot be bought or gained; the way to take advantage of their abilities is to accumulate Favor tokens and then use them as instructed by the Ally.</justify>",
+        "extra": "In games using one or more Liaison cards, give each player a Favors mat and deal out a single Ally card. The Ally cards are a separate deck, not combined with Events and so on.<n>Each player gets a single Favor token to start with (or five tokens in games with Importer).<n>Allies are landscape cards that give Favor tokens a use; Liaisons are kingdom cards that provide a way to get Favor tokens.<n>In games with a Liaison, deal out a random Ally to use that game. Only use one Ally per game, even with multiple Liaisons. You can still have as many other landscape cards (Events, Landmarks, Projects, Ways) as you otherwise would have.<n>Coin tokens are used for Favors; they go on a Favors mat to distinguish them from Coffers and Villagers (from other expansions), which have their own mats. When a card gives you +1 Favor, add a token to your mat; when spending a Favor, remove the token from your mat.<n>Favors may be used starting with the first turn of the game; they may not be used prior to that turn. Spending Favors is always optional. Spending Favors can only be done once per time an Ally ability triggers, unless it says, \"Repeat as desired.\"",
+        "name": "Allies"
+    },
+    "allies allies": {
+        "description": "<justify>Allies are not Kingdom cards, but are added to the game whenever one or more Kingdom cards have the Liaison type. In any game using Liaisons, exactly one Ally is chosen, and it determines what effect Favor tokens have in that game. Since Allies are not considered cards, they cannot be bought or gained; the way to take advantage of their abilities is to accumulate Favor tokens and then use them as instructed by the Ally.</justify>",
+        "extra": "In games using one or more Liaison cards, give each player a Favors mat and deal out a single Ally card. The Ally cards are a separate deck, not combined with Events and so on.<n>Each player gets a single Favor token to start with (or five tokens in games with Importer).<n>Allies are landscape cards that give Favor tokens a use; Liaisons are kingdom cards that provide a way to get Favor tokens.<n>In games with a Liaison, deal out a random Ally to use that game. Only use one Ally per game, even with multiple Liaisons. You can still have as many other landscape cards (Events, Landmarks, Projects, Ways) as you otherwise would have.<n>Coin tokens are used for Favors; they go on a Favors mat to distinguish them from Coffers and Villagers (from other expansions), which have their own mats. When a card gives you +1 Favor, add a token to your mat; when spending a Favor, remove the token from your mat.<n>Favors may be used starting with the first turn of the game; they may not be used prior to that turn. Spending Favors is always optional. Spending Favors can only be done once per time an Ally ability triggers, unless it says, \"Repeat as desired.\"",
+        "name": "Allies: Allies"
+    },
+    "boons": {
+        "description": "Boons are a face-down deck of landscape-style instruction cards that are revealed as needed. Generally these have effects that are good for a player.<n>Setup: If any Kingdom cards being used have the Fate type, shuffle the Boons and put them near the Supply, and put the Will-o'-Wisp (Spirit) pile near the Supply also.<br>Fate cards can somehow give players Boons; all the Fate type means is that the Boons are shuffled at the start of the game.",
+        "extra": "The phrase 'receive a Boon' means, turn over the top Boon, and follow the instructions on it. If the Boons deck is empty, first shuffle the discarded Boons to reform the deck; you may also do this any time all Boons are in their discard pile. Received Boons normally go to the Boons discard pile, but three (The Field's Gift, The Forest's Gift, and The River's Gift) go in front of a player until that turn's Clean-up.\nBoons are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' receiving Boons is not 'gaining a card,' and so on.\nWith the exception of the following, most Boons are so simple that they do not need additional explanation.\n<u>The Moon's Gift</u>: If your discard pile is empty, this will not do anything.\n<u>The River's Gift</u>: You draw the card after drawing your hand for your next turn.\n<u>The Sky's Gift</u>: If you choose to do this with fewer than three cards in hand, you will discard the rest of your cards but not gain a Gold. Discarding three cards gets you one Gold, not three.",
+        "name": "Boons"
+    },
+    "empires events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are special on-buy effects not attached to cards. Players can buy Events during their Buy phase to trigger whatever the effect of the Event is, as an alternative to (or in addition to) buying cards from the supply.<n>Events are not Kingdom cards; including one or more Events in a game does not count toward the 10 Kingdom card piles the supply includes. In fact, Events are not considered \"cards\" at all. Any text referring to a \"card\" (such as instructions to \"name a card\", or cost reducers changing the cost of cards) does not apply to Events. However, for reference, the Event effects and costs are printed on cards in a landscape orientation with silver frames.<n>Any number of Events may be used in a game, but the recommendation is to not use more than two total Events and Landmarks. When choosing a random Kingdom, the Events may be shuffled into the randomizer deck; any Events that are dealt once 10 Kingdom cards have also been dealt will be included in the game.",
+        "name": "Events: Empires"
+    },
+    "empires landmarks": {
+        "description": "<justify>Landmarks are not Kingdom cards. Landmarks provide new ways for players to score. Players may choose how to determine what Landmarks to play with. Landmarks in use are visible to all from the start of the game. Many Landmarks only apply when scoring at the end of the game.</justify>",
+        "extra": "Landmarks are not Kingdom cards. It is recommended that no more than two Landmarks be used per game. Players may choose how to determine what Landmarks to play with. They may shuffle them with Events and deal out 2 cards from that pile every game; they may shuffle them into the Randomizer deck and use 0-2 depending on how many come up before finding 10 Kingdom cards; or they may use any method they like.",
+        "name": "Landmarks: Empires"
+    },
+    "events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are special on-buy effects not attached to cards. Players can buy Events during their Buy phase to trigger whatever the effect of the Event is, as an alternative to (or in addition to) buying cards from the supply.<n>Events are not Kingdom cards; including one or more Events in a game does not count toward the 10 Kingdom card piles the supply includes. In fact, Events are not considered \"cards\" at all. Any text referring to a \"card\" (such as instructions to \"name a card\", or cost reducers changing the cost of cards) does not apply to Events. However, for reference, the Event effects and costs are printed on cards in a landscape orientation with silver frames.<n>Any number of Events may be used in a game, but the recommendation is to not use more than two total Events and Landmarks. When choosing a random Kingdom, the Events may be shuffled into the randomizer deck; any Events that are dealt once 10 Kingdom cards have also been dealt will be included in the game.",
+        "name": "Events"
+    },
+    "hexes": {
+        "description": "Hexes are a face-down deck of landscape-style instruction cards that are revealed as needed. Generally these have effects that are not good for a player.<br>Setup: If any Kingdom cards being used have the Doom type, shuffle the Hexes and put them near the Supply, and put Deluded/Envious (States) and Miserable/Twice Miserable (States) near the Supply also.<br>Doom cards can somehow give players Hexes; all the Doom type means is that the Hexes are shuffled at the start of the game.",
+        "extra": "The phrase 'receive a Hex' means, turn over the top Hex, and follow the instructions on it. 'Each other player receives the next Hex' means, turn over just one Hex, and the other players all follow the instructions on that same Hex. If all Hexes have been used, shuffle the discards to reform the deck; do this whenever the deck is empty. Received Hexes always go to the Hexes discard pile. Hexes are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' receiving Hexes is not 'gaining a card,' and so on. With the exception of the following, most Hexes are so simple that they do not need additional explanation.\n<u>Bad Omens</u>: Normally you will end up with a deck consisting of two Coppers, and a discard pile with the rest of your cards. Sometimes you will only have one or no Coppers; in those cases reveal your deck to demonstrate this.\n<u>Delusion</u>: Deluded / Envious is two-sided; take it with the Deluded side face up.\n<u>Envy</u>: Deluded / Envious is two-sided; take it with the Envious side face up.\n<u>Famine</u>: The revealed cards that are not Actions are shuffled back into your deck.\n<u>Fear</u>: You discard an Action or Treasure if you have either, and only reveal your hand if you have no Actions and no Treasures.\n<u>Locusts</u>: Types are the words on the bottom banner, like Action and Attack. If there is no cheaper card that shares a type - for example if the card trashed is Curse - the player does not gain anything.\n<u>Misery</u>: If this hits you for a third time in a game, nothing will happen; you stay at Twice Miserable.\n<u>War</u>: If you do not find a card costing 3 Coins or 4 Coins, your entire deck will end up in your discard pile, with nothing trashed.",
+        "name": "Hexes"
+    },
+    "landmarks": {
+        "description": "<justify>Landmarks are not Kingdom cards. Landmarks provide new ways for players to score. Players may choose how to determine what Landmarks to play with. Landmarks in use are visible to all from the start of the game. Many Landmarks only apply when scoring at the end of the game.</justify>",
+        "extra": "Landmarks are not Kingdom cards. It is recommended that no more than two Landmarks be used per game. Players may choose how to determine what Landmarks to play with. They may shuffle them with Events and deal out 2 cards from that pile every game; they may shuffle them into the Randomizer deck and use 0-2 depending on how many come up before finding 10 Kingdom cards; or they may use any method they like.",
+        "name": "Landmarks"
+    },
+    "menagerie events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are special on-buy effects not attached to cards. Players can buy Events during their Buy phase to trigger whatever the effect of the Event is, as an alternative to (or in addition to) buying cards from the supply.<n>Events are not Kingdom cards; including one or more Events in a game does not count toward the 10 Kingdom card piles the supply includes. In fact, Events are not considered \"cards\" at all. Any text referring to a \"card\" (such as instructions to \"name a card\", or cost reducers changing the cost of cards) does not apply to Events. However, for reference, the Event effects and costs are printed on cards in a landscape orientation with silver frames.<n>Any number of Events may be used in a game, but the recommendation is to not use more than two total Events and Landmarks. When choosing a random Kingdom, the Events may be shuffled into the randomizer deck; any Events that are dealt once 10 Kingdom cards have also been dealt will be included in the game.",
+        "name": "Events: Menagerie"
+    },
+    "menagerie ways": {
+        "description": "<justify>Ways are a landscape that provide alternate ways to play Action cards. When you play an Action card, instead of doing what is printed on the Action card, you may do what is printed on a Way being used in that game.</justify><n><justify>Ways are not Kingdom cards, and cannot be bought. Including one or more Ways in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Ways are not considered \"cards\" at all; any text referring to a \"card\" (such as instructions to \"name a card\") does not apply to Ways. However, for reference, Ways' effects are printed on cards in a landscape orientation with light blue frames.</justify>",
+        "extra": "Each Way gives Action cards an additional option: you can play the Action for what it normally does, or play it to do what the Way says to do. Playing an Action card for a Way ability means not doing anything the Action card said to do when played. For example, if you have Way of the Sheep in a game, which says \"+2 Coin,\" then you could play a Horse and choose to get +2 Coin; if you did so, you would not get +2 Cards and +1 Action, and would not return the Horse to its pile. Ways are not Kingdom cards, and cannot be bought; they sit on the table modifying the game rules. Text below a dividing line is unaffected, it will still happen whenever it says it does. For example, if you play a Highway (from Hinterlands) and use Way of the Sheep, you get +2 Coin, and then while Highway is in play, its ability makes cards cheaper. For tracking, it is helpful to tilt a card that was played using a Way, so that you remember that it did the Way instead of what it says. Some Ways refer to \"this.\" That is the card being used to do the Way ability. For example, Way of the Turtle says \"Set this aside...\" If you play a Market using Way of the Turtle, you will set the Market aside. Enchantress from Empires also changes what an Action card does when played. If you are affected by Enchantress, you can use a Way instead of getting the +1 Card and +1 Action that Enchantress's effect would give you. When an Action card can be played at an unusual time, like Sheepdog, it can still be used as a Way. If you play an Action card multiple times, with a card like Mastermind, you can choose for each play whether you want it to use a Way or not. If the card you are playing is a Duration card, it only stays in play if at least one of its plays was for its own abilities. If it does stay in play, you will have to remember for your next turn how many times you actually played the Duration card for its abilities. The choice to use a Way or not happens after \"first\" abilities on cards like Moat and Kiln. The Adventures tokens from Adventures still apply when playing a card using a Way. Any number of Ways may be used in a game of Dominion, though it is recommended to not use more than one Way, and not more than two total Ways, Events, Landmarks, and Projects.",
+        "name": "Ways: Menagerie"
+    },
+    "nocturne boons": {
+        "description": "Boons are a face-down deck of landscape-style instruction cards that are revealed as needed. Generally these have effects that are good for a player.<n>Setup: If any Kingdom cards being used have the Fate type, shuffle the Boons and put them near the Supply, and put the Will-o'-Wisp (Spirit) pile near the Supply also.<br>Fate cards can somehow give players Boons; all the Fate type means is that the Boons are shuffled at the start of the game.",
+        "extra": "The phrase 'receive a Boon' means, turn over the top Boon, and follow the instructions on it. If the Boons deck is empty, first shuffle the discarded Boons to reform the deck; you may also do this any time all Boons are in their discard pile. Received Boons normally go to the Boons discard pile, but three (The Field's Gift, The Forest's Gift, and The River's Gift) go in front of a player until that turn's Clean-up.\nBoons are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' receiving Boons is not 'gaining a card,' and so on.\nWith the exception of the following, most Boons are so simple that they do not need additional explanation.\n<u>The Moon's Gift</u>: If your discard pile is empty, this will not do anything.\n<u>The River's Gift</u>: You draw the card after drawing your hand for your next turn.\n<u>The Sky's Gift</u>: If you choose to do this with fewer than three cards in hand, you will discard the rest of your cards but not gain a Gold. Discarding three cards gets you one Gold, not three.",
+        "name": "Boons: Nocturne"
+    },
+    "nocturne hexes": {
+        "description": "Hexes are a face-down deck of landscape-style instruction cards that are revealed as needed. Generally these have effects that are not good for a player.<br>Setup: If any Kingdom cards being used have the Doom type, shuffle the Hexes and put them near the Supply, and put Deluded/Envious (States) and Miserable/Twice Miserable (States) near the Supply also.<br>Doom cards can somehow give players Hexes; all the Doom type means is that the Hexes are shuffled at the start of the game.",
+        "extra": "The phrase 'receive a Hex' means, turn over the top Hex, and follow the instructions on it. 'Each other player receives the next Hex' means, turn over just one Hex, and the other players all follow the instructions on that same Hex. If all Hexes have been used, shuffle the discards to reform the deck; do this whenever the deck is empty. Received Hexes always go to the Hexes discard pile. Hexes are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' receiving Hexes is not 'gaining a card,' and so on. With the exception of the following, most Hexes are so simple that they do not need additional explanation.\n<u>Bad Omens</u>: Normally you will end up with a deck consisting of two Coppers, and a discard pile with the rest of your cards. Sometimes you will only have one or no Coppers; in those cases reveal your deck to demonstrate this.\n<u>Delusion</u>: Deluded / Envious is two-sided; take it with the Deluded side face up.\n<u>Envy</u>: Deluded / Envious is two-sided; take it with the Envious side face up.\n<u>Famine</u>: The revealed cards that are not Actions are shuffled back into your deck.\n<u>Fear</u>: You discard an Action or Treasure if you have either, and only reveal your hand if you have no Actions and no Treasures.\n<u>Locusts</u>: Types are the words on the bottom banner, like Action and Attack. If there is no cheaper card that shares a type - for example if the card trashed is Curse - the player does not gain anything.\n<u>Misery</u>: If this hits you for a third time in a game, nothing will happen; you stay at Twice Miserable.\n<u>War</u>: If you do not find a card costing 3 Coins or 4 Coins, your entire deck will end up in your discard pile, with nothing trashed.",
+        "name": "Hexes: Nocturne"
+    },
+    "nocturne states": {
+        "description": "States are deck of landscape-style cards. State cards are a way of tracking special information about players. It sits in front of a player as a reminder until it goes away.",
+        "extra": "A State is a card that goes in front of a player and applies a rule. States are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' taking a State is not 'gaining a card,' and so on.\n<u>Deluded / Envious</u>: This card is two-sided. Deluded prevents you from buying Action cards during one turn, starting in the Buy phase. If you get Deluded during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally Deluded will apply to your next turn. Envious causes Silver and Gold to make 1 Coin when you played in your Buy phase for one turn, rather than their usual 2 Coins and 3 Coins, starting in the Buy phase. Envious does not affect other Treasures, just Silver and Gold. If you get Envious during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally Envious will apply to your next turn.\n<u>Lost in the Woods</u>: The two sides are the same; use either. Using the ability is optional. Lost in the Woods stays in front of you turn after turn, until another players takes it with a Fool.\n<u>Miserable / Twice Miserable</u>: This card is two-sided. This does nothing until the end of the game. The card just sits in front of you. When scoring at the end of the game, if Miserable is in front of you, lose 2 <VP>. If Twice Miserable is in front of you, lose 4 <VP>.",
+        "name": "States: Nocturne"
+    },
+    "plunder events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.",
+        "name": "Events: Plunder"
+    },
+    "plunder traits": {
+        "description": "<justify>Traits are not Kingdom cards. During Setup, Traits can be assigned to random Action or Treasure Kingdom card piles. Traits only go on Kingdom cards and are never bought or gained. No pile can have more than one Trait. Traits refer to the pile using the name of the Trait; for example, Pious refers to \"Pious cards.\" That just means any card from that pile. A Trait on a split pile affects all of those different cards. Traits continue to affect the cards from a pile even after the pile is empty.</justify>",
+        "extra": "Traits are not Kingdom cards. During Setup, Traits can be assigned to random Action or Treasure Kingdom card piles. Traits only go on Kingdom cards and are never bought or gained. No pile can have more than one Trait. Traits refer to the pile using the name of the Trait; for example, Pious refers to \"Pious cards.\" That just means any card from that pile. A Trait on a split pile affects all of those different cards. Traits continue to affect the cards from a pile even after the pile is empty.",
+        "name": "Traits: Plunder"
+    },
+    "projects": {
+        "description": "<justify>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.</justify>",
+        "extra": "Projects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Projects"
+    },
+    "promo events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.",
+        "name": "Events: Promos"
+    },
+    "prophecies": {
+        "description": "Prophecies are rules that will eventually apply to the game.",
+        "extra": "In every game with one or more Omen cards, deal out one Prophecy for it. Only use one Prophecy no matter how many Omens you have.<br> • Put 5 Sun tokens on the Prophecy for 2 players, 8 for 3 players, 10 for 4 players, 12 for 5 players, and 13 for 6 players.<br> • +1 SunToken means remove a token from the Prophecy. Then if it was the last token, the rules text on the Prophecy becomes active, right then and for the rest of the game.<br> • +1 SunToken always appears first on Omens, before anything else the card does.<br> • +1 SunToken does nothing else once all the tokens are removed.<br> • Prophecy text does nothing until the last Sun token is removed.",
+        "name": "Prophecies"
+    },
+    "renaissance projects": {
+        "description": "<justify>Projects are special, permanent, on-buy effects not attached to cards. Players can buy Projects during their Buy phase whenever they might instead buy a card or Event. When a player buys a Project, they put a wooden cube of their color on it, to track which Projects' effects they receive. Each player has only two cubes to put on Projects.</justify>",
+        "extra": "Projects are not Kingdom cards; including one or more Projects in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Projects are not considered \"cards\" at all; any text referring to a \"card\" does not apply to Projects.\n\nAny number of Projects may be used in a game, though it is recommended to not use  more than two total Events, Landmarks, and Projects.",
+        "name": "Projects: Renaissance"
+    },
+    "risingSun events": {
+        "description": "<justify>Events are not Kingdom cards. In a player's Buy phase, when the player can buy a card, the player can buy an Event instead. Buying an Event means paying the cost indicated on the Event and then doing the effect of the Event. The Event just stays on the table, the player does not take it; there is no way for a player to gain one or end up with one in his deck. Buying an Event uses up a Buy; normally a player can either buy a card, or buy an Event. A player with two Buys, such as after playing Ranger, could buy two cards, or buy two Events, or buy a card and an Event (in either order). The same Event can be bought multiple times in a turn if the player has the Buys and available to do it. Some Events give +Buys and so let the player buy further cards/Events afterwards. Players cannot play further Treasures that turn after buying an Event. Buying an Event is not buying a card and so does not trigger cards like Swamp Hag or Goons (from Prosperity). Costs of Events are not affected by cards like Bridge Troll.</justify>",
+        "extra": "Events are special on-buy effects not attached to cards. Players can buy Events during their Buy phase to trigger whatever the effect of the Event is, as an alternative to (or in addition to) buying cards from the supply.<n>Events are not Kingdom cards; including one or more Events in a game does not count toward the 10 Kingdom card piles the supply includes. In fact, Events are not considered \"cards\" at all. Any text referring to a \"card\" (such as instructions to \"name a card\", or cost reducers changing the cost of cards) does not apply to Events. However, for reference, the Event effects and costs are printed on cards in a landscape orientation with silver frames.<n>Any number of Events may be used in a game, but the recommendation is to not use more than two total Events and Landmarks. When choosing a random Kingdom, the Events may be shuffled into the randomizer deck; any Events that are dealt once 10 Kingdom cards have also been dealt will be included in the game.",
+        "name": "Events: Rising Sun"
+    },
+    "risingSun prophecies": {
+        "description": "Prophecies are rules that will eventually apply to the game.",
+        "extra": "In every game with one or more Omen cards, deal out one Prophecy for it. Only use one Prophecy no matter how many Omens you have.<br> • Put 5 Sun tokens on the Prophecy for 2 players, 8 for 3 players, 10 for 4 players, 12 for 5 players, and 13 for 6 players.<br> • +1 SunToken means remove a token from the Prophecy. Then if it was the last token, the rules text on the Prophecy becomes active, right then and for the rest of the game.<br> • +1 SunToken always appears first on Omens, before anything else the card does.<br> • +1 SunToken does nothing else once all the tokens are removed.<br> • Prophecy text does nothing until the last Sun token is removed.",
+        "name": "Prophecies: Rising Sun"
+    },
+    "states": {
+        "description": "States are a deck of landscape-style cards. State cards are a way of tracking special information about players. It sits in front of a player as a reminder until it goes away.",
+        "extra": "A State is a card that goes in front of a player and applies a rule. States are never in a player's deck; they are physically cards but are not 'cards' in game terms. They are thus never 'cards in play,' taking a State is not 'gaining a card,' and so on.\n<u>Deluded / Envious</u>: This card is two-sided. Deluded prevents you from buying Action cards during one turn, starting in the Buy phase. If you get Deluded during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally Deluded will apply to your next turn. Envious causes Silver and Gold to make 1 Coin when you played in your Buy phase for one turn, rather than their usual 2 Coins and 3 Coins, starting in the Buy phase. Envious does not affect other Treasures, just Silver and Gold. If you get Envious during your turn before the Buy phase (such as with Leprechaun), it will apply that turn; normally Envious will apply to your next turn.\n<u>Lost in the Woods</u>: The two sides are the same; use either. Using the ability is optional. Lost in the Woods stays in front of you turn after turn, until another players takes it with a Fool.\n<u>Miserable / Twice Miserable</u>: This card is two-sided. This does nothing until the end of the game. The card just sits in front of you. When scoring at the end of the game, if Miserable is in front of you, lose 2 <VP>. If Twice Miserable is in front of you, lose 4 <VP>.",
+        "name": "States"
+    },
+    "traits": {
+        "description": "<justify>Traits are not Kingdom cards. During Setup, Traits can be assigned to random Action or Treasure Kingdom card piles. Traits only go on Kingdom cards and are never bought or gained. No pile can have more than one Trait. Traits refer to the pile using the name of the Trait; for example, Pious refers to \"Pious cards.\" That just means any card from that pile. A Trait on a split pile affects all of those different cards. Traits continue to affect the cards from a pile even after the pile is empty.</justify>",
+        "extra": "Traits are not Kingdom cards. During Setup, Traits can be assigned to random Action or Treasure Kingdom card piles. Traits only go on Kingdom cards and are never bought or gained. No pile can have more than one Trait. Traits refer to the pile using the name of the Trait; for example, Pious refers to \"Pious cards.\" That just means any card from that pile. A Trait on a split pile affects all of those different cards. Traits continue to affect the cards from a pile even after the pile is empty.",
+        "name": "Traits",
+        "notes": [
+            "This card is currently not used."
+        ]
+    },
+    "ways": {
+        "description": "<justify>Ways are a landscape that provide alternate ways to play Action cards. When you play an Action card, instead of doing what is printed on the Action card, you may do what is printed on a Way being used in that game.</justify><n><justify>Ways are not Kingdom cards, and cannot be bought. Including one or more Ways in a game does not count toward the 10 Kingdom card piles the Supply includes. In fact, Ways are not considered \"cards\" at all; any text referring to a \"card\" (such as instructions to \"name a card\") does not apply to Ways. However, for reference, Ways' effects are printed on cards in a landscape orientation with light blue frames.</justify>",
+        "extra": "Each Way gives Action cards an additional option: you can play the Action for what it normally does, or play it to do what the Way says to do. Playing an Action card for a Way ability means not doing anything the Action card said to do when played. For example, if you have Way of the Sheep in a game, which says \"+2 Coin,\" then you could play a Horse and choose to get +2 Coin; if you did so, you would not get +2 Cards and +1 Action, and would not return the Horse to its pile. Ways are not Kingdom cards, and cannot be bought; they sit on the table modifying the game rules. Text below a dividing line is unaffected, it will still happen whenever it says it does. For example, if you play a Highway (from Hinterlands) and use Way of the Sheep, you get +2 Coin, and then while Highway is in play, its ability makes cards cheaper. For tracking, it is helpful to tilt a card that was played using a Way, so that you remember that it did the Way instead of what it says. Some Ways refer to \"this.\" That is the card being used to do the Way ability. For example, Way of the Turtle says \"Set this aside...\" If you play a Market using Way of the Turtle, you will set the Market aside. Enchantress from Empires also changes what an Action card does when played. If you are affected by Enchantress, you can use a Way instead of getting the +1 Card and +1 Action that Enchantress's effect would give you. When an Action card can be played at an unusual time, like Sheepdog, it can still be used as a Way. If you play an Action card multiple times, with a card like Mastermind, you can choose for each play whether you want it to use a Way or not. If the card you are playing is a Duration card, it only stays in play if at least one of its plays was for its own abilities. If it does stay in play, you will have to remember for your next turn how many times you actually played the Duration card for its abilities. The choice to use a Way or not happens after \"first\" abilities on cards like Moat and Kiln. The Adventures tokens from Adventures still apply when playing a card using a Way. Any number of Ways may be used in a game of Dominion, though it is recommended to not use more than one Way, and not more than two total Ways, Events, Landmarks, and Projects.",
+        "name": "Ways"
+    }
+}

--- a/src/domdiv/tools/update_from_wiki.py
+++ b/src/domdiv/tools/update_from_wiki.py
@@ -1,0 +1,213 @@
+import json
+import re
+from difflib import SequenceMatcher
+
+import mwparserfromhell
+import pyquery
+import requests
+from wikimarkup.parser import Parser
+
+# File paths
+CARDS_FILE = "../../../card_db_src/en_us/cards_en_us.json"
+MERGED_OUTPUT = "merged_cards_en_us.json"
+LOG_OUTPUT = "merge_log.json"
+
+# MediaWiki API
+WIKI_API = "https://wiki.dominionstrategy.com/api.php"
+WIKI_PAGE = "List_of_cards"
+
+
+def fetch_wikitext():
+    params = {
+        "action": "query",
+        "prop": "revisions",
+        "titles": WIKI_PAGE,
+        "rvslots": "main",
+        "rvprop": "content",
+        "format": "json",
+        "formatversion": 2,
+    }
+    response = requests.get(WIKI_API, params=params)
+    response.raise_for_status()
+    return response.json()["query"]["pages"][0]["revisions"][0]["slots"]["main"][
+        "content"
+    ]
+
+
+def convert_wiki_markup(text):
+    """This whole function is obsolete"""
+    if not text:
+        return ""
+
+    # The wiki separates paragraphs by enclosing them in <p>...</p> tags.
+    # domdiv separates them by <n> strings which are converted to newlines, and then split.
+    # Split on either opening or closing tags, remove empty strings, then join with <n>
+    lines = re.split(r"</?p>", text)
+    text = "<n>".join([l for l in lines if l])
+
+    # The wiki sometimes uses &nbsp; to indicate nonbreaking spaces, and sometimes it uses a {{nowrap|text}} template.
+    # &nbsp; is supported natively by reportlab, so we can leave it as is. I can't think of a good way at the moment
+    # to represent the {{nowrap}} templates when there's no space involved, to e.g. ensure that something like
+    # {{nowrap|-1 Coin token.}} keeps the minus sign, the 1 coin icon, the word token, and the period all on the same
+    # line.
+    # The best I can think of is to make all spaces inside nowrap tags into nonbreaking spaces.
+    def nbsp_replacer(match):
+        content = match.group(1)
+        content_with_nbsp = content.replace(" ", "&nbsp;")
+        return content_with_nbsp
+
+    # Match {{nowrap|...}} and replace inner spaces
+    text = re.sub(r"{{nowrap\|([^{}]+?)}}", nbsp_replacer, text)
+
+    # I think the <nobr> tags would work. Need to figure out a regex that can handle {{nowrap|-{{Cost|1}} token.}}
+
+    # Convert cost and other icons
+    text = re.sub(r"{{[Cc]ostplus?\|(1)}}", r"+\1 Coin", text)
+    text = re.sub(r"{{[Cc]ostplus?\|([-0-9]+)}}", r"+\1 Coins", text)
+    text = re.sub(r"{{[Cc]ost?\|(1)}}", r"\1 Coin", text)
+    text = re.sub(r"{{[Cc]ost?\|([-0-9]+)}}", r"\1 Coins", text)
+    text = re.sub(r"{{[Cc]ost?\|([-0-9]+)\|x?l}}", r"\1 <*COIN*>", text)
+    text = re.sub(r"{{[Cc]ost\|\|\|\|P}}", r"Potion", text)
+    text = re.sub(r"{{VP\|'''([-0-9]+)'''}}", r"\1 <VP>", text)
+    text = re.sub(r"{{VP\|([-0-9]+)\|x?l}}", r"\1 <*VP*>", text)
+
+    text = re.sub(r"'''([^']+)'''", r"<b>\1</b>", text)
+    text = re.sub(r"''([^']+)''", r"<i>\1</i>", text)
+    text = re.sub(r"{{[Dd]ivline}}", "<line>", text)
+
+    # Unwrap nowrap tags that had nested {{}} in them that were just substituted
+    text = re.sub(r"{{nowrap\|([^{}]+?)}}", r"\1", text)
+
+    # text = text.replace("'''", "")  # bold
+    # text = text.replace("''", "")   # italics
+    # text = text.replace("&nbsp;", " ")
+
+    # text = re.sub(r"\{!(\d+)\}", r"\1 <*VP*>", text)
+    # text = re.sub(r"\{(\d+)\}", r"\1 <VP>", text)
+
+    # text = re.sub(r"\[?(\d+)[ ]*[Cc]oin[s]?\]?", r"\1 <*COIN*>", text)
+    # text = re.sub(r"\[?([Xx\?]) [Cc]oin[s]?\]?", r"\1 <*COIN*>", text)
+    # text = text.replace("[P]", "Potion")
+
+    # Paragraph and line breaks
+    # text = text.replace("<p>", "<br>")
+    # text = re.sub(r"</?[^>]+>", "", text)
+    # text = text.replace("////", "<br>")
+    # text = re.sub(r"(?<!/)//(?!/)", " ", text)
+    # text = re.sub(r"\s+", " ", text)
+    text = text.strip()
+
+    return text
+
+
+def extract_cards_from_wikitext(wikitext):
+    cards = {}
+    lines = wikitext.split("\n")
+    for line in lines:
+        if line.startswith("|{"):
+            columns = line.split(" || ")
+            if len(columns) < 5:
+                continue
+            name_match = re.search(r"{{[^|]+\|([^}]+)}}", columns[0])
+            if not name_match:
+                continue
+            name = name_match.group(1).strip()
+            raw_text = columns[4].strip()
+            converted_text = convert_wiki_markup(raw_text)
+            cards[name] = {"converted": converted_text, "raw": raw_text}
+    return cards
+
+
+def load_existing_cards(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def merge_cards(existing_cards, wiki_cards):
+    updated = existing_cards.copy()
+    updated_count = 0
+    unchanged_count = 0
+    applied_changes = {}
+    skipped_changes = {}
+    cards_to_skip = {
+        # 'Astrolabe',    # Needs extra <br> for the large coin image
+    }
+
+    for name, wiki_entry in wiki_cards.items():
+        new_text = wiki_entry["converted"]
+        raw = wiki_entry["raw"]
+        if name in updated and "description" in updated[name]:
+            original = updated[name]["description"].strip()
+            similarity = SequenceMatcher(None, original, new_text).ratio()
+            if name not in cards_to_skip and similarity < 1.02:
+                applied_changes[name] = {
+                    "original": original,
+                    "updated": new_text,
+                    "raw_wikitext": raw,
+                    "similarity": round(similarity, 4),
+                }
+                updated[name]["raw_wikitext"] = raw
+                updated[name]["wikitext"] = new_text
+                updated_count += 1
+            else:
+                updated[name]["raw_wikitext"] = raw
+                updated[name]["wikitext"] = new_text
+                skipped_changes[name] = {
+                    "original": original,
+                    "converted": new_text,
+                    "raw_wikitext": raw,
+                    "similarity": round(similarity, 4),
+                }
+                unchanged_count += 1
+        else:
+            updated[name] = {
+                "name": name,
+                "description": new_text,
+                "raw_wikitext": raw,
+            }
+            applied_changes[name] = {
+                "original": None,
+                "updated": new_text,
+                "raw_wikitext": raw,
+                "similarity": 0,
+            }
+            updated_count += 1
+
+    return updated, updated_count, unchanged_count, applied_changes, skipped_changes
+
+
+def main():
+    print("Fetching wikitext...")
+    wikitext = fetch_wikitext()
+
+    print("Parsing card rows...")
+    wiki_cards = extract_cards_from_wikitext(wikitext)
+    print(f"Found {len(wiki_cards)} cards with descriptions.")
+
+    print("Loading existing cards...")
+    existing_cards = load_existing_cards(CARDS_FILE)
+
+    print("Merging data...")
+    merged, updated_count, unchanged_count, applied, skipped = merge_cards(
+        existing_cards, wiki_cards
+    )
+
+    print("Writing merged cards...")
+    with open(MERGED_OUTPUT, "w", encoding="utf-8") as f:
+        json.dump(merged, f, indent=4, ensure_ascii=False)
+
+    print("Writing change log...")
+    log = {
+        "updated_count": updated_count,
+        "unchanged_count": unchanged_count,
+        "applied_changes": applied,
+        "skipped_changes": skipped,
+    }
+    with open(LOG_OUTPUT, "w", encoding="utf-8") as f:
+        json.dump(log, f, indent=4, ensure_ascii=False)
+
+    print(f"Done. {updated_count} cards updated, {unchanged_count} unchanged.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is not ready to merge yet, but I wanted to show what I'm working on and get some feedback. 

There's a lot going on here. 

* I originally hacked together a script that would read the card text from the dominion strategy wiki list of cards, and convert it into the format expected by this project (e.g changing `{{Cost|3}}` to `3 Coins`). 
* After evaluating its results when rendering all the cards, I opted to instead keep the wiki formatting, and write new code for handling the inline images. The main reasons for this were:
  * The wiki formatting doesn't cause extra replacements to happen unintentionally. For example, the card text of Alchemist says "At the start of Clean-up this turn, if you have a Potion in play, you may put this onto your deck.". Currently when rendering that, this project substitutes the Potion symbol, even though it's not referring to the Potion resource, but the card named Potion. 
  * The wiki formatting has more options for indicating size
  * The wiki formatting allows better control over line breaks, although actually making that work with reportlab is a challenge.
* I wanted to keep the existing text for now, so I could render both side by side (with `--front rules --back wiki-text`) to compare them. 
* I added an option to render the actual card images (which I scraped from the wiki), so I could compare the way this code rendered the text to the way the actual cards do. It was very close; this is what led me to adjust the horizontal margin and font size to get the wrapping on certain cards like Mine to match what the card does when the orientation is vertical. I left that code out of this PR for now (except for adding it to text_coices), but I could include it if @sumpfork or @nickv2002 would find it helpful. 
* While I was re-implementing inline images, I learned more about various options in reportlab, and added more parameters relating to vertical scaling to get images to line up with the surrounding text. I also added the `leading` and `autoLeading` parameters to make some vertical room around the images as needed.
* I found the mixture of percentages and absolute points in the current size code confusing. I settled on consistently using a factor to multiply by the font size.
* I used a more object-oriented paradigm with type hints in `inline_images.py` because I found it easier to understand/use.

A few things that still aren't done:
* Handling cards that are grouped, like the Knights, or the Augurs, or Plunder/Encampment. The wiki has a page for each individual card, and I think it makes sense to have an entry in the card db for each individual card, along with one for the group, as we currently have in most (but not all) situations (we're missing Knights, Castles and Prophecies, among others). The question that remains is what text to put on the group divider. I can think of three options:
  * Generate it dynamically from the text of each card in the group. This could work well as a follow-up to the refactor work I did in https://github.com/sumpfork/dominiontabs/pull/567, but it seems like it would probably result in a lot of duplication, especially for the rules text.
  * Retain hand-written and manually-maintained text for the group cards.
  * Write some sort of script that merges the individual card text into the group card's text.
* Scraping card text in additional languages. This will require loading each individual card's page and parsing the wiki text. Downloading all the pages is straightforward; I've already got a script that does that with a reasonable rate limit. I'm not sure how challenging it will be to scrape the wiki text; it will depend on how consistently formatted they are. 
* I don't think this is the form that I want to merge this in. I'd rather actually update the description in the card db rather than relying on a random external file, this was just easier to manage git conflicts for now.
* I'd love to also pull down the FAQ section from the wiki for the "Rules", but that's going to be another whole big project. Definitely not in the same PR.


Note regarding the `<nobr>` tag: the reportlab docs say this will prevent line breaks, but it doesn't actually work. I patched the library code to fix it and plan on submitting a patch to them. In the meantime, the tag is simply parsed and harmlessly ignored using the published versions of the reportlab library. Take a look at how Sailor is rendered with vertical orientation if you want an example.