### PR TITLE
Move Card defaults to read time

### DIFF
--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -216,31 +216,31 @@ class Card(object):
     def get_GroupCost(self):
         return self.getType().getGroupCost()
 
-    def get_total_cost(self, c):
+    def get_total_cost(self):
         # Return a tuple that represents the total cost of card c
         # Hightest cost cards are in order:
         # - Types with group cost of "" sort at the very end
         # - cards with * since that can mean anything
         # - cards with numeric errors
         # convert cost (a string) into a number
-        if c.get_GroupCost() == "":
+        if self.get_GroupCost() == "":
             c_cost = 999
-        elif not c.cost:
+        elif not self.cost:
             c_cost = 0  # if no cost, treat as 0
-        elif "*" in c.cost:
+        elif "*" in self.cost:
             c_cost = 998  # make it a really big number
         else:
             try:
-                c_cost = int(c.cost)
+                c_cost = int(self.cost)
             except ValueError:
                 c_cost = 997  # can't, so make it a really big number
 
-        return c_cost, c.potcost, c.debtcost
+        return c_cost, self.potcost, self.debtcost
 
     def set_lowest_cost(self, other):
         # set self cost fields to the lower of the two's total cost
-        self_cost = self.get_total_cost(self)
-        other_cost = self.get_total_cost(other)
+        self_cost = self.get_total_cost()
+        other_cost = self.get_total_cost()
         if other_cost < self_cost:
             self.cost = other.cost
             self.potcost = other.potcost

--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -112,7 +112,6 @@ class Card(object):
         self.text_icon = text_icon
         self.cardset_tag = cardset_tag
         self.randomizer = randomizer
-        self.count = None
 
         if count is not None:
             if isinstance(count, int):
@@ -126,10 +125,10 @@ class Card(object):
         else:
             self._counts = None
 
-    def getCardCount(self):
+    def getCardCount(self) -> int:
         return sum(self.getCardCounts())
 
-    def getCardCounts(self):
+    def getCardCounts(self) -> list[int]:
         if self._counts is None:
             return [self.getType().getTypeDefaultCardCount()]
         return self._counts
@@ -233,13 +232,15 @@ class Card(object):
     def get_GroupCost(self):
         return self.getType().getGroupCost()
 
-    def get_total_cost(self):
-        # Return a tuple that represents the total cost of card c
-        # Hightest cost cards are in order:
-        # - Types with group cost of "" sort at the very end
-        # - cards with * since that can mean anything
-        # - cards with numeric errors
-        # convert cost (a string) into a number
+    def cost_sort_key(self):
+        """Return a tuple that represents the total cost of this card in (coins, potions, debt)
+        used for sorting cards by cost.
+        Highest cost cards are in order:
+        - Types with group cost of "" sort at the very end
+        - cards with * since that can mean anything
+        - cards with numeric errors
+        convert cost (a string) into a number
+        """
         if self.get_GroupCost() == "":
             c_cost = 999
         elif not self.cost:
@@ -253,15 +254,6 @@ class Card(object):
                 c_cost = 997  # can't, so make it a really big number
 
         return c_cost, self.potcost, self.debtcost
-
-    def set_lowest_cost(self, other):
-        # set self cost fields to the lower of the two's total cost
-        self_cost = self.get_total_cost()
-        other_cost = self.get_total_cost()
-        if other_cost < self_cost:
-            self.cost = other.cost
-            self.potcost = other.potcost
-            self.debtcost = other.debtcost
 
     def setImage(self, use_set_icon=False):
         setImage = None

--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -5,6 +5,53 @@ from loguru import logger
 from reportlab.lib.units import cm
 
 
+class CardType(object):
+    @staticmethod
+    def decode_json(obj):
+        return CardType(**obj)
+
+    def __init__(
+        self,
+        card_type,
+        card_type_image,
+        group_global_type=None,
+        group_cost=None,
+        defaultCardCount=10,
+        tabTextHeightOffset=0,
+        tabCostHeightOffset=-1,
+    ):
+        self.typeNames = tuple(card_type)
+        self.tabImageFile = card_type_image
+        self.group_global_type = group_global_type
+        self.group_cost = group_cost
+        self.defaultCardCount = defaultCardCount
+        self.tabTextHeightOffset = tabTextHeightOffset
+        self.tabCostHeightOffset = tabCostHeightOffset
+
+    def getTypeDefaultCardCount(self):
+        return self.defaultCardCount
+
+    def getTypeNames(self):
+        return self.typeNames
+
+    def getTabImageFile(self):
+        if not self.tabImageFile:
+            return None
+        return self.tabImageFile
+
+    def getGroupGlobalType(self):
+        return self.group_global_type
+
+    def getGroupCost(self):
+        return self.group_cost
+
+    def getTabTextHeightOffset(self):
+        return self.tabTextHeightOffset
+
+    def getTabCostHeightOffset(self):
+        return self.tabCostHeightOffset
+
+
 class Card(object):
     sets = None
     types = None
@@ -83,10 +130,10 @@ class Card(object):
         self.count.extend(value)
 
     def getStackHeight(self, thickness):
-        # return height of the stacked cards in cm.  Using hight in cm of a stack of 60 Copper cards as thickness.
+        # return height of the stacked cards in cm.  Using height in cm of a stack of 60 Copper cards as thickness.
         return self.getCardCount() * cm * (thickness / 60.0) + 2
 
-    def getType(self):
+    def getType(self) -> CardType:
         return Card.types[tuple(self.types)]
 
     def getBonusBoldText(self, text):
@@ -235,50 +282,3 @@ class BlankCard(Card):
 
     def isBlank(self):
         return True
-
-
-class CardType(object):
-    @staticmethod
-    def decode_json(obj):
-        return CardType(**obj)
-
-    def __init__(
-        self,
-        card_type,
-        card_type_image,
-        group_global_type=None,
-        group_cost=None,
-        defaultCardCount=10,
-        tabTextHeightOffset=0,
-        tabCostHeightOffset=-1,
-    ):
-        self.typeNames = tuple(card_type)
-        self.tabImageFile = card_type_image
-        self.group_global_type = group_global_type
-        self.group_cost = group_cost
-        self.defaultCardCount = defaultCardCount
-        self.tabTextHeightOffset = tabTextHeightOffset
-        self.tabCostHeightOffset = tabCostHeightOffset
-
-    def getTypeDefaultCardCount(self):
-        return self.defaultCardCount
-
-    def getTypeNames(self):
-        return self.typeNames
-
-    def getTabImageFile(self):
-        if not self.tabImageFile:
-            return None
-        return self.tabImageFile
-
-    def getGroupGlobalType(self):
-        return self.group_global_type
-
-    def getGroupCost(self):
-        return self.group_cost
-
-    def getTabTextHeightOffset(self):
-        return self.tabTextHeightOffset
-
-    def getTabCostHeightOffset(self):
-        return self.tabCostHeightOffset

--- a/src/domdiv/cards.py
+++ b/src/domdiv/cards.py
@@ -78,7 +78,7 @@ class Card(object):
         potcost=0,
         debtcost=0,
         extra="",
-        count=-1,
+        count=None,
         card_tag="missing card_tag",
         cardset_tags=None,
         group_tag="",
@@ -108,26 +108,43 @@ class Card(object):
         self.cardset_tags = cardset_tags
         self.group_tag = group_tag
         self.group_top = group_top
-        self.image = image
+        self.image = image  # used for promo cards with unique "set" images
         self.text_icon = text_icon
         self.cardset_tag = cardset_tag
-        self.setCardCount(count)
         self.randomizer = randomizer
+        self.count = None
+
+        if count is not None:
+            if isinstance(count, int):
+                self._counts = [count]
+            elif isinstance(count, str) and count.isdigit():
+                self._counts = [int(count)]
+            else:
+                raise TypeError(
+                    f"{name or card_tag}: Count must be int or str: {count} has type {type(count)}"
+                )
+        else:
+            self._counts = None
 
     def getCardCount(self):
-        return sum(i for i in self.count)
+        return sum(self.getCardCounts())
+
+    def getCardCounts(self):
+        if self._counts is None:
+            return [self.getType().getTypeDefaultCardCount()]
+        return self._counts
 
     def setCardCount(self, value):
-        value = int(value)
-        if value < 0:
-            self.count = [self.getType().getTypeDefaultCardCount()]
-        elif value == 0:
-            self.count = []
+        if value == 0:
+            self._counts = []
         else:
-            self.count = [value]
+            self._counts = [int(value)]
 
-    def addCardCount(self, value):
-        self.count.extend(value)
+    def mergeCardCount(self, value: list):
+        if self._counts is None:
+            self._counts = value
+        else:
+            self._counts.extend(value)
 
     def getStackHeight(self, thickness):
         # return height of the stacked cards in cm.  Using height in cm of a stack of 60 Copper cards as thickness.

--- a/src/domdiv/db.py
+++ b/src/domdiv/db.py
@@ -250,7 +250,7 @@ def read_card_data(options) -> list[Card]:
 
             # Add correct card counts to Start Deck prototype.  This will be used to make copies.
             cards[StartDeck_index].setCardCount(STARTDECK_COPPERS)
-            cards[StartDeck_index].addCardCount([int(STARTDECK_ESTATES)])
+            cards[StartDeck_index].mergeCardCount([int(STARTDECK_ESTATES)])
 
             # Make new Start Deck Dividers and adjust the corresponding card counts
             for x in range(0, STARTDECK_NUMBER):

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1245,18 +1245,26 @@ class DividerDrawer(object):
 
         return text.strip().strip("\n")
 
-    def drawCardCount(self, card, x, y, offset=-1):
-        # Note that this is right justified.
-        # x represents the right most for the image (image grows to the left)
-        if card.getCardCount() < 1:
+    def drawCardCount(self, card, x, y) -> int:
+        """Draw the card counts for this card. (x, y) is the bottom right corner of the images,
+        which are right aligned.
+
+        Returns the width used in points.
+        """
+
+        card_counts = card.getCardCounts()
+        if sum(card_counts) < 1:
             return 0
 
-        #  draw_list = [(card.getCardCount(), 1)]
+        # make a list of all the (num cards in pile, num piles with that size) pairs for each unique pile size
         draw_list = sorted(
-            [(i, card.getCardCounts().count(i)) for i in set(card.getCardCounts())]
+            [
+                (pile_size, card_counts.count(pile_size))
+                for pile_size in set(card_counts)
+            ]
         )
 
-        cardIconHeight = y + offset
+        cardIconHeight = y
         countHeight = cardIconHeight - 4
         width = 0
 

--- a/src/domdiv/draw.py
+++ b/src/domdiv/draw.py
@@ -1252,7 +1252,9 @@ class DividerDrawer(object):
             return 0
 
         #  draw_list = [(card.getCardCount(), 1)]
-        draw_list = sorted([(i, card.count.count(i)) for i in set(card.count)])
+        draw_list = sorted(
+            [(i, card.getCardCounts().count(i)) for i in set(card.getCardCounts())]
+        )
 
         cardIconHeight = y + offset
         countHeight = cardIconHeight - 4

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -131,7 +131,7 @@ class CardSorter(object):
         return (
             card.cardset,
             int(card.isExpansion()),
-            str(card.get_total_cost(card)),
+            str(card.get_total_cost()),
             self.get_card_name_sort_key(card.name),
         )
 

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -247,7 +247,9 @@ def combine_cards(cards, old_card_type, new_card_tag, new_cardset_tag, new_type)
     filteredCards = []
     for c in cards:
         if c.isType(old_card_type):
-            holder.addCardCount(c.count)  # keep track of count and skip card
+            holder.mergeCardCount(
+                c.getCardCounts()
+            )  # keep track of count and skip card
         else:
             filteredCards.append(c)  # Not the right type, keep card
 
@@ -354,8 +356,8 @@ def filter_sort_cards(cards: list[Card], options) -> list[Card]:
                 cards_in_group.setdefault(
                     (card.group_tag, card.cardset_tag), []
                 ).append(card)
-                group_holders[(card.group_tag, card.cardset_tag)].addCardCount(
-                    card.count
+                group_holders[(card.group_tag, card.cardset_tag)].mergeCardCount(
+                    card.getCardCounts()
                 )
                 if card.group_top:
                     # this is a designated card to represent the group, so update important data

--- a/src/domdiv/main.py
+++ b/src/domdiv/main.py
@@ -131,7 +131,7 @@ class CardSorter(object):
         return (
             card.cardset,
             int(card.isExpansion()),
-            str(card.get_total_cost()),
+            str(card.cost_sort_key()),
             self.get_card_name_sort_key(card.name),
         )
 

--- a/tests/selection_tests.py
+++ b/tests/selection_tests.py
@@ -13,7 +13,7 @@ def test_group_special():
     ]
     assert len(empires_event_cards) == 1
     empires_events = empires_event_cards[0]
-    assert empires_events.count == [1] * 13
+    assert empires_events.getCardCounts() == [1] * 13
     assert empires_events.name == "Events: Empires"
     assert empires_events.types == ["Event"]
 
@@ -23,7 +23,7 @@ def test_group_special():
     gladiator_fortune = gladiator_matches[0]
     gladiator_fortune.name.startswith("Gladiator")
     assert "Fortune" in gladiator_fortune.name
-    assert gladiator_fortune.count == [5, 5]
+    assert gladiator_fortune.getCardCounts() == [5, 5]
     assert gladiator_fortune.types == ["Action"]
     assert gladiator_fortune.cost == "3"
 
@@ -32,8 +32,9 @@ def test_group_special():
     joust_rewards = joust_matches[0]
     assert joust_rewards.name.startswith("Joust")
     assert "Rewards" in joust_rewards.name
-    joust_rewards.count.sort()
-    assert joust_rewards.count == 6 * [2] + [10]
+    counts = joust_rewards.getCardCounts()
+    counts.sort()
+    assert counts == 6 * [2] + [10]
     assert joust_rewards.types == ["Action"]
 
     allies_ally_cards = [
@@ -42,4 +43,4 @@ def test_group_special():
     assert len(allies_ally_cards) == 1
     allies_allies = allies_ally_cards[0]
     assert allies_allies.name == "Allies: Allies"
-    assert allies_allies.count == [1] * 23
+    assert allies_allies.getCardCounts() == [1] * 23


### PR DESCRIPTION
These are a few minor improvements I made while working on other things that would be nice to merge separately. 

I now understand more about the way the card count was working previously (and I don't particularly like it). Now it's more explicit about what's a list and what's an int, and I have more confidence that the refactor I did to the card grouping code is correct, although the unit test for it is probably enough to show that the previous version was correct too.