### PR TITLE
Add Rising Sun missing events and prophecies to English translations.

### DIFF
--- a/card_db_src/en_us/cards_en_us.json
+++ b/card_db_src/en_us/cards_en_us.json
@@ -819,7 +819,7 @@
         "description": "Gain an Action or Treasure costing up to 8 Coin. +Debt equal to its cost.",
         "extra": "",
         "name": "Credit"
-    },    
+    },
     "Crew": {
         "description": "+3 Cards<br>At the start of your next turn, put this onto your deck.",
         "extra": "Putting this onto your deck isn't optional.",
@@ -2957,7 +2957,7 @@
         "description": "If you've gained at least 3 cards this turn, gain up to 3 differently named Action cards you don't have copies of in play.",
         "extra": "",
         "name": "Receive Tribute"
-    },    
+    },
     "Reckless": {
         "description": "Follow the instructions of played Reckless cards twice. When discarding one from play, return it to its pile.",
         "extra": "Reckless does two things, at different times. When you play a Reckless card, you follow its instructions an extra time - follow them entirely, then follow them again - and when you discard one from play, you return it to its Supply pile.<br>With Duration cards those may not happen on the same turn.<br>If you skip following the instructions of the card - for example by using a Way (from Menagerie) instead - then you don't follow them an extra time, but still return the card when discarding it from play.",


### PR DESCRIPTION
Descriptions pulled from Dominion strategy wiki.
Extras not defined.